### PR TITLE
chore: add Google Analytics snippet

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,19 @@
-import type { Metadata, Viewport } from "next";
-import { Inter } from "next/font/google";
-import "./globals.css";
-import Providers from "./providers";
+import type { Metadata, Viewport } from 'next';
+import Script from 'next/script';
+import { Inter } from 'next/font/google';
+import './globals.css';
+import Providers from './providers';
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: "ZeroTime - 전북대 알리미",
-  description: "ZeroTime - 전북대 공지사항 통합 알림 서비스",
-  manifest: "/manifest.json",
+  title: 'ZeroTime - 전북대 알리미',
+  description: 'ZeroTime - 전북대 공지사항 통합 알림 서비스',
+  manifest: '/manifest.json',
   appleWebApp: {
     capable: true,
-    statusBarStyle: "default",
-    title: "ZeroTime",
+    statusBarStyle: 'default',
+    title: 'ZeroTime',
   },
   formatDetection: {
     telephone: false,
@@ -20,10 +21,10 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  width: "device-width",
+  width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
-  themeColor: "#3b82f6",
+  themeColor: '#3b82f6',
 };
 
 export default function RootLayout({
@@ -36,12 +37,17 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" href="/logo-192x192.png" />
+        <Script async src="https://www.googletagmanager.com/gtag/js?id=G-SMF31V39T9" />
+        <Script id="ga-init">
+          {`window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-SMF31V39T9');`}
+        </Script>
       </head>
       <body className={`${inter.className} flex h-screen flex-col bg-gray-50 text-gray-900`}>
         <Providers>
-          <main className="flex-1 overflow-hidden">
-            {children}
-          </main>
+          <main className="flex-1 overflow-hidden">{children}</main>
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
Include GA tag scripts in root layout to enable tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Google Analytics to the app shell to enable pageview tracking across routes.
> 
> - Injects GA `gtag` via `next/script` in `app/layout.tsx` with measurement ID `G-SMF31V39T9` and initialization script
> - Minor formatting and quote-style updates; no other functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b50bca2b4acf2011a40b763fb171d47cde99eb4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->