### PR TITLE
fix: improve pull-to-refresh for iOS Safari

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+html,
+body {
+  height: 100%;
+  overscroll-behavior: none;
+}
+
+body {
+  position: fixed;
+  width: 100%;
+  overflow: hidden;
+}
+
 /* 스크롤바 숨기기 (스크롤 가능한 탭 바용) */
 .scrollbar-hide,
 .no-scrollbar {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,7 +47,7 @@ gtag('config', 'G-SMF31V39T9');`}
       </head>
       <body className={`${inter.className} flex h-screen flex-col bg-gray-50 text-gray-900`}>
         <Providers>
-          <main className="flex-1 overflow-hidden">{children}</main>
+          <main className="flex-1 min-h-0 overflow-hidden">{children}</main>
         </Providers>
       </body>
     </html>


### PR DESCRIPTION
- Fix header/filter moving on pull by adding touch-action: none
- Lock body with position: fixed to prevent iOS rubber-band scroll
- Move pull indicator outside overflow-hidden to prevent clipping
- Use non-passive touchmove events for better preventDefault control
- Restructure indicator as flex item with dynamic height instead of absolute positioning