### PR TITLE
feat(app): implement API-based keyword badge display

### DIFF
--- a/app/(home)/components/NoticeList.tsx
+++ b/app/(home)/components/NoticeList.tsx
@@ -6,7 +6,7 @@ interface NoticeListProps {
   selectedCategories: string[];
   filteredNotices: Notice[];
   highlightKeywords?: string[];
-  showKeywordPrefix?: boolean;
+  keywordNoticeIds?: Set<number>;
   onMarkAsRead: (noticeId: number) => void;
   onToggleFavorite?: (noticeId: number) => void;
   isInFavoriteTab?: boolean;
@@ -24,7 +24,7 @@ export default function NoticeList({
   selectedCategories,
   filteredNotices,
   highlightKeywords,
-  showKeywordPrefix,
+  keywordNoticeIds,
   onMarkAsRead,
   onToggleFavorite,
   isInFavoriteTab,
@@ -68,7 +68,7 @@ export default function NoticeList({
               key={notice.id}
               notice={notice}
               highlightKeywords={highlightKeywords}
-              showKeywordPrefix={showKeywordPrefix}
+              showKeywordPrefix={keywordNoticeIds?.has(notice.id) ?? false}
               onMarkAsRead={onMarkAsRead}
               onToggleFavorite={onToggleFavorite}
               isInFavoriteTab={isInFavoriteTab}

--- a/app/notifications/keyword/page.tsx
+++ b/app/notifications/keyword/page.tsx
@@ -303,7 +303,7 @@ function KeywordNotificationsClient() {
                   selectedCategories={['keyword']}
                   filteredNotices={keywordNotices}
                   highlightKeywords={keywordList}
-                  showKeywordPrefix
+                  keywordNoticeIds={new Set(keywordNotices.map((n) => n.id))}
                   onMarkAsRead={handleMarkAsRead}
                   onToggleFavorite={handleToggleFavorite}
                   isLoggedIn={isLoggedIn}


### PR DESCRIPTION
- Replace client-side keyword matching with API-based approach
  * Add keywordNoticeIds prop to NoticeList (Set of notice IDs)
  * Show keyword badge only for notices in API response
  * Remove real-time client-side matching to prevent historical notices from showing badges

- Fix keyword badge display logic
  * HOME/ALL tab: show badges only for keywordNotices from API
  * KEYWORD tab: show badges for all notices (already filtered by API)
  * Keyword added after notice published → no badge ✓

- Add pull-to-refresh guards
  * HOME/KEYWORD tab: disable when keywordCount === 0
  * Use refs (filterRef, keywordCountRef) to fix closure issue
  * Prevent refresh when no keywords registered

- Load keywords on app visibility change
  * Refresh keyword list when returning to app
  * Ensure ALL tab shows correct badges after keyword changes

Fixes issue where adding keywords would show badges on all historical matching notices. Now badges only appear on notices published during active subscription periods.