### PR TITLE
feat(app): 키워드 배지를 API 응답 기반으로 표시

### DIFF
--- a/app/(home)/components/NoticeCard.tsx
+++ b/app/(home)/components/NoticeCard.tsx
@@ -6,7 +6,6 @@ import { FaStar, FaRegStar } from 'react-icons/fa';
 
 interface NoticeCardProps {
   notice: Notice;
-  highlightKeywords?: string[];
   showKeywordPrefix?: boolean;
   onMarkAsRead?: (noticeId: number) => void; // 읽음 처리 콜백 (옵션)
   onToggleFavorite?: (noticeId: number) => void; // 즐겨찾기 토글 콜백 (옵션)
@@ -15,22 +14,8 @@ interface NoticeCardProps {
   onShowToast?: (message: string, type?: 'success' | 'error' | 'info') => void; // 토스트 메시지 표시
 }
 
-const findMatchedKeywords = (title: string, keywords?: string[]) => {
-  if (!keywords || keywords.length === 0) return [];
-  const normalizedTitle = title.toLowerCase();
-  const normalizedKeywords = keywords
-    .map((keyword) => keyword.trim())
-    .filter(Boolean);
-
-  const matched = normalizedKeywords.filter((keyword) =>
-    normalizedTitle.includes(keyword.toLowerCase()),
-  );
-  return Array.from(new Set(matched));
-};
-
 export default function NoticeCard({
   notice,
-  highlightKeywords,
   showKeywordPrefix,
   onMarkAsRead,
   onToggleFavorite,
@@ -75,8 +60,8 @@ export default function NoticeCard({
     }
   };
 
-  const matchedKeywords = showKeywordPrefix
-    ? findMatchedKeywords(notice.title, highlightKeywords)
+  const matchedKeywords = showKeywordPrefix && notice.matched_keywords
+    ? notice.matched_keywords
     : [];
 
   return (

--- a/app/(home)/components/NoticeList.tsx
+++ b/app/(home)/components/NoticeList.tsx
@@ -5,8 +5,7 @@ interface NoticeListProps {
   loading: boolean;
   selectedCategories: string[];
   filteredNotices: Notice[];
-  highlightKeywords?: string[];
-  keywordNoticeIds?: Set<number>;
+  showKeywordPrefix?: boolean;
   onMarkAsRead: (noticeId: number) => void;
   onToggleFavorite?: (noticeId: number) => void;
   isInFavoriteTab?: boolean;
@@ -23,8 +22,7 @@ export default function NoticeList({
   loading,
   selectedCategories,
   filteredNotices,
-  highlightKeywords,
-  keywordNoticeIds,
+  showKeywordPrefix,
   onMarkAsRead,
   onToggleFavorite,
   isInFavoriteTab,
@@ -67,8 +65,7 @@ export default function NoticeList({
             <NoticeCard
               key={notice.id}
               notice={notice}
-              highlightKeywords={highlightKeywords}
-              showKeywordPrefix={keywordNoticeIds?.has(notice.id) ?? false}
+              showKeywordPrefix={showKeywordPrefix}
               onMarkAsRead={onMarkAsRead}
               onToggleFavorite={onToggleFavorite}
               isInFavoriteTab={isInFavoriteTab}

--- a/app/api/index.ts
+++ b/app/api/index.ts
@@ -33,6 +33,7 @@ export interface Notice {
   is_read: boolean; // 읽음 여부 (백엔드에서 제공)
   view: number; // 조회수
   is_favorite: boolean; // 즐겨찾기 여부
+  matched_keywords?: string[]; // 매칭된 키워드 목록 (삭제된 키워드 포함)
 }
 
 // API 함수들 정리


### PR DESCRIPTION
- Notice 타입에 matched_keywords 필드 추가
  * 각 공지마다 매칭된 키워드 목록 포함
  * 삭제된 키워드도 히스토리에 표시됨

- NoticeCard: API에서 받은 키워드 직접 사용
  * highlightKeywords prop 제거
  * notice.matched_keywords 사용
  * 클라이언트 실시간 매칭 완전 제거

- NoticeList: 간소화
  * highlightKeywords prop 제거
  * keywordNoticeIds prop 제거
  * showKeywordPrefix만 사용

효과:
  - 키워드 삭제 후에도 이전 공지의 키워드 배지 유지 ✓
  - 구독 기간 필터링으로 올바른 키워드만 표시 ✓
  - 성능: 단일 쿼리로 해결 ✓