### PR TITLE
fix(app): pull-to-refresh 텍스트와 로딩 애니메이션 겹침 현상 수정

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -448,7 +448,7 @@ function HomeContent() {
             style={{
               height: refreshing ? '64px' : isPulling ? `${pullDistance}px` : '0px',
               opacity: refreshing ? 1 : isPulling ? Math.min(pullDistance / 50, 1) : 0,
-              transition: isPulling ? 'none' : 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease-out',
+              transition: (isPulling || refreshing) ? 'none' : 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease-out',
             }}
           >
             {refreshing ? (

--- a/app/notifications/keyword/page.tsx
+++ b/app/notifications/keyword/page.tsx
@@ -180,7 +180,7 @@ function KeywordNotificationsClient() {
             style={{
               height: refreshing ? '64px' : isPulling ? `${pullDistance}px` : '0px',
               opacity: refreshing ? 1 : isPulling ? Math.min(pullDistance / 50, 1) : 0,
-              transition: isPulling ? 'none' : 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease-out',
+              transition: (isPulling || refreshing) ? 'none' : 'height 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease-out',
             }}
           >
             {refreshing ? (


### PR DESCRIPTION
문제:
  - 손을 떼는 순간 텍스트가 0.3초 transition으로 천천히 사라짐
  - 동시에 로딩 애니메이션이 나타남
  - 결과: 텍스트와 로딩이 0.3초간 겹쳐 보임 (모바일에서 거슬림)

해결:
  - transition 조건 변경: (isPulling || refreshing) ? 'none' : '...'
  - refreshing 상태일 때도 transition 비활성화
  - 텍스트 → 로딩 전환이 즉시 발생 (겹침 없음)

적용:
  - app/(home)/page.tsx
  - app/notifications/keyword/page.tsx