### PR TITLE
fix: pull-to-refresh 텍스트가 spinner와 함께 도는 문제 수정

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -453,17 +453,16 @@ function HomeContent() {
           >
             {refreshing ? (
               <div className="w-6 h-6 border-2 border-blue-500 rounded-full animate-spin border-t-transparent"></div>
-            ) : (
+            ) : isPulling && pullDistance > 0 ? (
               <div
                 className="text-sm font-medium text-gray-600"
                 style={{
                   transform: `scale(${Math.min(pullDistance / 40, 1)})`,
-                  transition: 'transform 0.1s ease-out',
                 }}
               >
                 {pullDistance > 30 ? '↓ 놓아서 새로고침' : '↓ 당겨서 새로고침'}
               </div>
-            )}
+            ) : null}
           </div>
 
           {/* 3. 공지사항 리스트 (Pull to Refresh 지원) */}

--- a/app/notifications/keyword/page.tsx
+++ b/app/notifications/keyword/page.tsx
@@ -185,17 +185,16 @@ function KeywordNotificationsClient() {
           >
             {refreshing ? (
               <div className="w-6 h-6 border-2 border-blue-500 rounded-full animate-spin border-t-transparent"></div>
-            ) : (
+            ) : isPulling && pullDistance > 0 ? (
               <div
                 className="text-sm font-medium text-gray-600"
                 style={{
                   transform: `scale(${Math.min(pullDistance / 40, 1)})`,
-                  transition: 'transform 0.1s ease-out',
                 }}
               >
                 {pullDistance > 30 ? '↓ 놓아서 새로고침' : '↓ 당겨서 새로고침'}
               </div>
-            )}
+            ) : null}
           </div>
 
           {!isLoggedIn ? (


### PR DESCRIPTION
문제:
  - React 상태 업데이트가 개별 렌더링되면서 중간 상태가 보임
  - setIsPulling(false) → setPullDistance(0) → setRefreshing(true)
  - 렌더링 2에서 텍스트가 scale(0)으로 줄어들며 spinner와 겹침
  - 모바일에서 텍스트가 작게 뱅글뱅글 도는 것처럼 보임

해결:
  - 조건부 렌더링 강화: refreshing ? spinner : isPulling && pullDistance > 0 ? text : null
  - isPulling이 false가 되거나 pullDistance가 0이면 텍스트 즉시 제거
  - 텍스트의 불필요한 transition 제거

적용:
  - app/(home)/page.tsx
  - app/notifications/keyword/page.tsx