### PR TITLE
fix: resolve filter caching issue by adding filter to queryKey

### DIFF
--- a/app/(routes)/(home)/page.tsx
+++ b/app/(routes)/(home)/page.tsx
@@ -107,7 +107,6 @@ function HomeContent() {
   );
 
   // 무한 스크롤 쿼리
-  const isFavoriteFilter = filter === 'FAVORITE';
   const {
     data: noticePages,
     fetchNextPage,
@@ -116,14 +115,14 @@ function HomeContent() {
     isLoading,
     refetch,
   } = useInfiniteQuery({
-    // queryKey에서 동적으로 변하는 값들 제거
-    queryKey: ['notices', 'infinite', selectedBoardsParam],
+    // filter를 queryKey에 포함하여 필터별 독립적인 캐시 유지
+    queryKey: ['notices', 'infinite', selectedBoardsParam, filter],
     queryFn: ({ pageParam }) => fetchNoticesInfinite(
       pageParam,
       20,
       true,
       selectedBoards,
-      isFavoriteFilter
+      filter === 'FAVORITE'  // 클로저 문제 방지를 위해 직접 참조
     ),
     getNextPageParam: (lastPage) => lastPage.next_cursor,
     initialPageParam: null as string | null,


### PR DESCRIPTION
- Add filter to useInfiniteQuery queryKey for independent cache per filter
- Remove isFavoriteFilter variable to avoid closure issues
- Use filter directly in queryFn for accurate real-time value
- Fixes data not updating when switching between ALL/FAVORITE/KEYWORD filters