### PR TITLE
feat: 키워드 알림 개수 표시 및 신규 알림 강조 기능 구현

### DIFF
--- a/app/(routes)/(home)/_components/HomeHeader.tsx
+++ b/app/(routes)/(home)/_components/HomeHeader.tsx
@@ -3,14 +3,14 @@ import { FiUser, FiBell } from 'react-icons/fi';
 interface HomeHeaderProps {
   // 알림 버튼 클릭 핸들러 (추후 구현)
   onNotificationClick?: () => void;
-  showNotificationBadge?: boolean;
+  notificationCount?: number;
   // 메뉴 버튼 클릭 핸들러
   onMenuClick: () => void;
 }
 
 import Logo from '@/_components/ui/Logo';
 
-export default function HomeHeader({ onNotificationClick, showNotificationBadge, onMenuClick }: HomeHeaderProps) {
+export default function HomeHeader({ onNotificationClick, notificationCount = 0, onMenuClick }: HomeHeaderProps) {
   return (
     <header className="relative flex h-16 shrink-0 items-center justify-between border-b border-gray-100 bg-white px-5">
       {/* Left: User Icon (Menu) */}
@@ -37,8 +37,10 @@ export default function HomeHeader({ onNotificationClick, showNotificationBadge,
           aria-label="알림"
         >
           <FiBell size={19} />
-          {showNotificationBadge && (
-            <span className="absolute right-2 top-2 h-2 w-2 rounded-full bg-red-500" />
+          {notificationCount > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-[17px] min-w-[17px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white shadow-sm ring-2 ring-white">
+              {notificationCount > 99 ? '99+' : notificationCount}
+            </span>
           )}
         </button>
       </div>

--- a/app/(routes)/(home)/_components/NoticeCard.tsx
+++ b/app/(routes)/(home)/_components/NoticeCard.tsx
@@ -12,6 +12,7 @@ interface NoticeCardProps {
   isInFavoriteTab?: boolean; // 즐겨찾기 탭 여부 (항상 unread 스타일 표시)
   isLoggedIn?: boolean; // 로그인 여부
   onShowToast?: (message: string, type?: 'success' | 'error' | 'info') => void; // 토스트 메시지 표시
+  isHighlighted?: boolean; // 신규 알림 강조 여부
 }
 
 export default function NoticeCard({
@@ -22,6 +23,7 @@ export default function NoticeCard({
   isInFavoriteTab,
   isLoggedIn,
   onShowToast,
+  isHighlighted,
 }: NoticeCardProps) {
   // 읽음 상태에 따른 스타일 결정
   // 즐겨찾기 탭에서는 항상 unread 스타일 표시
@@ -67,7 +69,7 @@ export default function NoticeCard({
   return (
     <div
       role="listitem"
-      className="bg-white transition-all hover:bg-gray-50 md:rounded-xl md:border md:border-gray-100 md:shadow-sm md:hover:-translate-y-0.5 md:hover:shadow-md"
+      className={`transition-all hover:bg-gray-50 md:rounded-xl md:border md:border-gray-100 md:shadow-sm md:hover:-translate-y-0.5 md:hover:shadow-md ${isHighlighted && !notice.is_read ? 'bg-orange-50 animate-blink-orange' : 'bg-white'}`}
       style={{ opacity: styleConfig.opacity }}
     >
       <a

--- a/app/(routes)/(home)/_components/NoticeList.tsx
+++ b/app/(routes)/(home)/_components/NoticeList.tsx
@@ -16,6 +16,7 @@ interface NoticeListProps {
   emptyDescription?: string;
   emptyActionLabel?: string;
   onEmptyActionClick?: () => void;
+  highlightedIds?: number[]; // 강조 표시할 공지 ID 목록
 }
 
 export default function NoticeList({
@@ -33,6 +34,7 @@ export default function NoticeList({
   emptyDescription,
   emptyActionLabel,
   onEmptyActionClick,
+  highlightedIds = [],
 }: NoticeListProps) {
   return (
     <div className="min-h-full p-0 bg-gray-50 md:p-5" role="list">
@@ -72,6 +74,7 @@ export default function NoticeList({
               isInFavoriteTab={isInFavoriteTab}
               isLoggedIn={isLoggedIn}
               onShowToast={onShowToast}
+              isHighlighted={highlightedIds.includes(notice.id)}
             />
           ))
         ) : (

--- a/app/(routes)/(home)/page.tsx
+++ b/app/(routes)/(home)/page.tsx
@@ -94,6 +94,7 @@ function HomeContent() {
     keywordNotices,
     keywordCount,
     hasNewKeywordNotices,
+    newKeywordCount, // 훅에서 반환한 값 사용
     loadKeywordNotices,
     loadKeywordNoticesSilent,
     loadKeywordCount,
@@ -289,10 +290,12 @@ function HomeContent() {
             <HomeHeader
               onMenuClick={() => setIsSidebarOpen(true)}
               onNotificationClick={() => {
+                // 이전 확인 시간을 쿼리 파라미터로 전달
+                const lastSeen = localStorage.getItem('keyword_notice_seen_at');
                 markKeywordNoticesSeen(keywordNotices);
-                router.push('/notifications');
+                router.push(lastSeen ? `/notifications?last_seen=${encodeURIComponent(lastSeen)}` : '/notifications');
               }}
-              showNotificationBadge={isLoggedIn && hasNewKeywordNotices}
+              notificationCount={newKeywordCount}
             />
           </div>
 

--- a/app/(routes)/notifications/page.tsx
+++ b/app/(routes)/notifications/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from 'react';
 import NotificationsClient from './_components/NotificationsClient';
 
 export default function NotificationsPage() {
-  return <NotificationsClient />;
+  return (
+    <Suspense fallback={null}>
+      <NotificationsClient />
+    </Suspense>
+  );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,3 +52,18 @@ body {
 .animate-slide-up {
   animation: slideUp 0.3s ease-out;
 }
+@keyframes blink-orange {
+  0% {
+    background-color: #fff7ed; /* bg-orange-50 */
+  }
+  50% {
+    background-color: white;
+  }
+  100% {
+    background-color: #fff7ed; /* bg-orange-50 */
+  }
+}
+
+.animate-blink-orange {
+  animation: blink-orange 3s ease-in-out 3 forwards;
+}


### PR DESCRIPTION
- 헤더 알림 종 아이콘에 읽지 않은 키워드 알림 개수 배지 추가\n- 알림 목록 진입 시 신규 알림 주황색 배경 및 부드러운 깜빡임 효과 적용\n- 알림 확인 시(클릭 또는 재방문) 강조 효과 자동 해제 로직 구현\n- 키워드 등록 시점 이후의 공지만 알림으로 표시되도록 로직 보완