### PR TITLE
hotfix: 온보딩 학생 페이지 무한 건너뛰기 버그 수정

### DIFF
--- a/app/(auth)/onboarding/page.tsx
+++ b/app/(auth)/onboarding/page.tsx
@@ -95,10 +95,10 @@ function OnboardingPageContent() {
     })();
   }, [isAuthLoaded, isLoggedIn, queryClient, router, searchParams, setUser, showToast, user?.email, user?.nickname]);
 
-  const handleOnboardingComplete = (categories: string[]) => {
+  const handleOnboardingComplete = async (categories: string[]) => {
     localStorage.setItem('my_subscribed_categories', JSON.stringify(categories));
     clearPendingOnboarding();
-    router.replace('/');
+    await router.replace('/');
   };
 
   const handleRequireLogin = () => {

--- a/app/(main)/(home)/_components/OnboardingModal.tsx
+++ b/app/(main)/(home)/_components/OnboardingModal.tsx
@@ -33,7 +33,7 @@ import type { PendingOnboardingSubmission } from '@/_lib/onboarding/pendingSubmi
 
 interface OnboardingModalProps {
   isOpen: boolean;
-  onComplete: (categories: string[]) => void;
+  onComplete: (categories: string[]) => void | Promise<void>;
   onShowToast?: (message: string, type?: 'success' | 'error' | 'info') => void;
   isLoggedIn?: boolean;
   onRequireLogin?: (pendingData: PendingOnboardingSubmission) => void;
@@ -323,11 +323,10 @@ export default function OnboardingModal({
       setUser(result.user);
       localStorage.setItem('my_subscribed_categories', JSON.stringify(result.subscribed_boards));
       onShowToast?.('제로타임에 오신 것을 환영합니다! 🎉', 'success');
-      onComplete(result.subscribed_boards);
+      await onComplete(result.subscribed_boards);
     } catch (error) {
       console.error('온보딩 처리 실패:', error);
       alert('정보 저장에 실패했습니다. 다시 시도해주세요.');
-    } finally {
       setIsSubmitting(false);
     }
   };
@@ -361,10 +360,10 @@ export default function OnboardingModal({
       setUser(result.user);
       localStorage.setItem('my_subscribed_categories', JSON.stringify(defaultBoards));
       onShowToast?.('제로타임에 오신 것을 환영합니다! 🎉', 'success');
-      onComplete(defaultBoards);
+      await onComplete(defaultBoards);
     } catch (error) {
       console.error('건너뛰기 실패:', error);
-    } finally {
+      onShowToast?.('저장에 실패했습니다. 다시 시도해주세요.', 'error');
       setIsSubmitting(false);
     }
   };


### PR DESCRIPTION
문제 원인:

router.replace('/')가 비동기인데 await하지 않아서, finally 블록의 setIsSubmitting(false)가 네비게이션 도중에 실행되어 리렌더링이 발생하고 라우팅이 취소될 수 있었습니다
onComplete에서 에러가 발생해도 토스트는 이미 표시된 상태였습니다

수정 내용:
- onComplete 타입을 void | Promise<void>로 변경
- handleSubmit에서 await onComplete() 호출
- handleSkip에서 await onComplete() 호출하고, 에러 시 토스트 표시
- handleOnboardingComplete을 async로 변경하고 await router.replace('/')