### PR TITLE
feat: 이력관리 UI 통합 정비 및 예시 데이터 최신화

### DIFF
--- a/app/(main)/(home)/_components/onboarding/ReviewSummary.tsx
+++ b/app/(main)/(home)/_components/onboarding/ReviewSummary.tsx
@@ -258,7 +258,7 @@ export default function ReviewSummary({
       </section>
 
       <p className="px-1 text-[11px] text-gray-400">
-        완료를 누르면 온보딩과 이력 정보가 저장됩니다. (프로필 &gt; 이력 관리에서 수정할 수 있습니다.)
+        완료를 누르면 온보딩과 이력 정보가 저장됩니다. (프로필 &gt; 이력관리에서 수정할 수 있습니다.)
       </p>
     </div>
   );

--- a/app/(main)/profile/_components/career/ResumePreview.tsx
+++ b/app/(main)/profile/_components/career/ResumePreview.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import type { CareerProfile } from '@/_types/career';
+
+import ActivitySection from './sections/ActivitySection';
+import CertificationSection from './sections/CertificationSection';
 import ContactSection from './sections/ContactSection';
 import EducationSection from './sections/EducationSection';
-import WorkSection from './sections/WorkSection';
-import SkillTagsSection from './sections/SkillTagsSection';
-import CertificationSection from './sections/CertificationSection';
-import ActivitySection from './sections/ActivitySection';
 import MentorQnASection from './sections/MentorQnASection';
+import SkillTagsSection from './sections/SkillTagsSection';
+import WorkSection from './sections/WorkSection';
 
 type EditingSection =
   | 'contact'
@@ -35,6 +36,9 @@ export default function ResumePreview({
   onSaveSuccess,
 }: ResumePreviewProps) {
   const isEmpty = !profile || profile.id === 0;
+  const isSectionBlocked = (section: Exclude<EditingSection, null>) =>
+    Boolean(editingSection && editingSection !== section);
+  const showMentorSection = Boolean(profile?.is_mentor);
 
   return (
     <div className="mx-auto max-w-2xl">
@@ -51,7 +55,7 @@ export default function ResumePreview({
 
           <div className="border-t border-gray-100" />
 
-          <div className={`${editingSection && editingSection !== 'educations' ? 'opacity-50 pointer-events-none' : ''}`}>
+          <div className={isSectionBlocked('educations') ? 'pointer-events-none opacity-50' : ''}>
             <EducationSection
               profile={profile}
               isEditing={editingSection === 'educations'}
@@ -64,7 +68,7 @@ export default function ResumePreview({
 
           <div className="border-t border-gray-100" />
 
-          <div className={`${editingSection && editingSection !== 'works' ? 'opacity-50 pointer-events-none' : ''}`}>
+          <div className={isSectionBlocked('works') ? 'pointer-events-none opacity-50' : ''}>
             <WorkSection
               profile={profile}
               isEditing={editingSection === 'works'}
@@ -77,7 +81,7 @@ export default function ResumePreview({
 
           <div className="border-t border-gray-100" />
 
-          <div className={`${editingSection && editingSection !== 'skills' ? 'opacity-50 pointer-events-none' : ''}`}>
+          <div className={isSectionBlocked('skills') ? 'pointer-events-none opacity-50' : ''}>
             <SkillTagsSection
               profile={profile}
               isEditing={editingSection === 'skills'}
@@ -88,9 +92,25 @@ export default function ResumePreview({
             />
           </div>
 
+          {showMentorSection && (
+            <>
+              <div className="border-t border-gray-100" />
+              <div className={isSectionBlocked('mentor-qna') ? 'pointer-events-none opacity-50' : ''}>
+                <MentorQnASection
+                  profile={profile}
+                  isEditing={editingSection === 'mentor-qna'}
+                  onEdit={() => onEditSection('mentor-qna')}
+                  onCancel={onCancelEdit}
+                  onSaveSuccess={() => onSaveSuccess('선배님 Q&A')}
+                  isEmpty={isEmpty}
+                />
+              </div>
+            </>
+          )}
+
           <div className="border-t border-gray-100" />
 
-          <div className={`${editingSection && editingSection !== 'certifications' ? 'opacity-50 pointer-events-none' : ''}`}>
+          <div className={isSectionBlocked('certifications') ? 'pointer-events-none opacity-50' : ''}>
             <CertificationSection
               profile={profile}
               isEditing={editingSection === 'certifications'}
@@ -103,7 +123,7 @@ export default function ResumePreview({
 
           <div className="border-t border-gray-100" />
 
-          <div className={`${editingSection && editingSection !== 'activities' ? 'opacity-50 pointer-events-none' : ''}`}>
+          <div className={isSectionBlocked('activities') ? 'pointer-events-none opacity-50' : ''}>
             <ActivitySection
               profile={profile}
               isEditing={editingSection === 'activities'}
@@ -114,29 +134,13 @@ export default function ResumePreview({
             />
           </div>
 
-          {profile?.is_mentor && (
-            <>
-              <div className="border-t border-gray-100" />
-              <div className={`${editingSection && editingSection !== 'mentor-qna' ? 'opacity-50 pointer-events-none' : ''}`}>
-                <MentorQnASection
-                  profile={profile}
-                  isEditing={editingSection === 'mentor-qna'}
-                  onEdit={() => onEditSection('mentor-qna')}
-                  onCancel={onCancelEdit}
-                  onSaveSuccess={() => onSaveSuccess('멘토 Q&A')}
-                  isEmpty={isEmpty}
-                />
-              </div>
-            </>
+          {isEmpty && (
+            <div className="mt-8 rounded-lg bg-blue-50 px-4 py-3 text-center">
+              <p className="text-sm font-medium text-blue-900">아직 작성된 이력이 없어요</p>
+              <p className="mt-1 text-xs text-blue-600">각 섹션 옆 ✎ 아이콘을 눌러 이력을 추가해보세요!</p>
+            </div>
           )}
         </div>
-
-        {isEmpty && (
-          <div className="mt-8 rounded-lg bg-blue-50 px-4 py-3 text-center">
-            <p className="text-sm font-medium text-blue-900">아직 작성된 이력이 없어요</p>
-            <p className="mt-1 text-xs text-blue-600">각 섹션 옆 ✎ 아이콘을 눌러 이력을 추가해보세요!</p>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/app/(main)/profile/_components/career/sections/ActivitySection.tsx
+++ b/app/(main)/profile/_components/career/sections/ActivitySection.tsx
@@ -1,9 +1,19 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
 import { FiEdit3, FiPlus, FiTrash2 } from 'react-icons/fi';
+
 import { useSaveCareerActivities } from '@/_lib/hooks/useCareer';
 import type { CareerProfile, Activity } from '@/_types/career';
+
+type EditableActivity = Omit<Activity, 'id'>;
+
+const toEditableActivity = (activity: Activity): EditableActivity => {
+  const editable = { ...activity };
+  delete editable.id;
+  return editable;
+};
 
 interface ActivitySectionProps {
   profile: CareerProfile | null;
@@ -23,11 +33,11 @@ export default function ActivitySection({
   isEmpty,
 }: ActivitySectionProps) {
   const saveMutation = useSaveCareerActivities();
-  const [activities, setActivities] = useState<Omit<Activity, 'id'>[]>([]);
+  const [activities, setActivities] = useState<EditableActivity[]>([]);
 
   useEffect(() => {
     if (profile && profile.activities.length > 0) {
-      setActivities(profile.activities.map(({ id, ...rest }) => rest));
+      setActivities(profile.activities.map(toEditableActivity));
     } else {
       setActivities([]);
     }
@@ -48,7 +58,11 @@ export default function ActivitySection({
     setActivities(activities.filter((_, i) => i !== index));
   };
 
-  const handleChange = (index: number, field: keyof Omit<Activity, 'id'>, value: any) => {
+  const handleChange = <K extends keyof EditableActivity>(
+    index: number,
+    field: K,
+    value: EditableActivity[K],
+  ) => {
     const updated = [...activities];
     updated[index] = { ...updated[index], [field]: value };
     setActivities(updated);
@@ -66,7 +80,7 @@ export default function ActivitySection({
 
   const handleCancel = () => {
     if (profile && profile.activities.length > 0) {
-      setActivities(profile.activities.map(({ id, ...rest }) => rest));
+      setActivities(profile.activities.map(toEditableActivity));
     } else {
       setActivities([]);
     }
@@ -103,7 +117,7 @@ export default function ActivitySection({
                     type="text"
                     value={activity.period || ''}
                     onChange={(e) => handleChange(idx, 'period', e.target.value || null)}
-                    placeholder="2023.03-12"
+                    placeholder="2025.03-2026.02"
                     className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
                   />
                 </div>
@@ -155,7 +169,7 @@ export default function ActivitySection({
     ? [
         {
           name: '창업 경진대회',
-          period: '2023.03-06',
+          period: '2025.03-2026.02',
           description: '팀 프로젝트로 참여하여 우수상 수상',
         },
       ]

--- a/app/(main)/profile/_components/career/sections/CertificationSection.tsx
+++ b/app/(main)/profile/_components/career/sections/CertificationSection.tsx
@@ -1,9 +1,19 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
 import { FiEdit3, FiPlus, FiTrash2 } from 'react-icons/fi';
+
 import { useSaveCareerCertifications } from '@/_lib/hooks/useCareer';
 import type { CareerProfile, Certification } from '@/_types/career';
+
+type EditableCertification = Omit<Certification, 'id'>;
+
+const toEditableCertification = (certification: Certification): EditableCertification => {
+  const editable = { ...certification };
+  delete editable.id;
+  return editable;
+};
 
 interface CertificationSectionProps {
   profile: CareerProfile | null;
@@ -23,11 +33,11 @@ export default function CertificationSection({
   isEmpty,
 }: CertificationSectionProps) {
   const saveMutation = useSaveCareerCertifications();
-  const [certifications, setCertifications] = useState<Omit<Certification, 'id'>[]>([]);
+  const [certifications, setCertifications] = useState<EditableCertification[]>([]);
 
   useEffect(() => {
     if (profile && profile.certifications.length > 0) {
-      setCertifications(profile.certifications.map(({ id, ...rest }) => rest));
+      setCertifications(profile.certifications.map(toEditableCertification));
     } else {
       setCertifications([]);
     }
@@ -47,7 +57,11 @@ export default function CertificationSection({
     setCertifications(certifications.filter((_, i) => i !== index));
   };
 
-  const handleChange = (index: number, field: keyof Omit<Certification, 'id'>, value: any) => {
+  const handleChange = <K extends keyof EditableCertification>(
+    index: number,
+    field: K,
+    value: EditableCertification[K],
+  ) => {
     const updated = [...certifications];
     updated[index] = { ...updated[index], [field]: value };
     setCertifications(updated);
@@ -65,7 +79,7 @@ export default function CertificationSection({
 
   const handleCancel = () => {
     if (profile && profile.certifications.length > 0) {
-      setCertifications(profile.certifications.map(({ id, ...rest }) => rest));
+      setCertifications(profile.certifications.map(toEditableCertification));
     } else {
       setCertifications([]);
     }
@@ -132,8 +146,8 @@ export default function CertificationSection({
   const isSectionEmpty = isEmpty || !profile || profile.certifications.length === 0;
   const displayCerts = isSectionEmpty
     ? [
-        { name: 'TOEIC 900점', date: '2023.06' },
-        { name: '정보처리기사', date: '2023.09' },
+        { name: 'TOEIC 900점', date: '2025.06' },
+        { name: '정보처리기사', date: '2026.01' },
       ]
     : profile?.certifications || [];
 

--- a/app/(main)/profile/_components/career/sections/EducationSection.tsx
+++ b/app/(main)/profile/_components/career/sections/EducationSection.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
 import { FiEdit3, FiPlus, FiTrash2 } from 'react-icons/fi';
+
 import { useSaveCareerEducations } from '@/_lib/hooks/useCareer';
-import type { CareerProfile, Education } from '@/_types/career';
 import { DEGREE_LABELS, STATUS_LABELS } from '@/_types/career';
+import type { CareerProfile, Education } from '@/_types/career';
+
+type EditableEducation = Omit<Education, 'id'>;
+
+const toEditableEducation = (education: Education): EditableEducation => {
+  const editable = { ...education };
+  delete editable.id;
+  return editable;
+};
 
 interface EducationSectionProps {
   profile: CareerProfile | null;
@@ -24,11 +34,11 @@ export default function EducationSection({
   isEmpty,
 }: EducationSectionProps) {
   const saveMutation = useSaveCareerEducations();
-  const [educations, setEducations] = useState<Omit<Education, 'id'>[]>([]);
+  const [educations, setEducations] = useState<EditableEducation[]>([]);
 
   useEffect(() => {
     if (profile && profile.educations.length > 0) {
-      setEducations(profile.educations.map(({ id, ...rest }) => rest));
+      setEducations(profile.educations.map(toEditableEducation));
     } else {
       setEducations([]);
     }
@@ -54,7 +64,11 @@ export default function EducationSection({
     setEducations(educations.filter((_, i) => i !== index));
   };
 
-  const handleChange = (index: number, field: keyof Omit<Education, 'id'>, value: any) => {
+  const handleChange = <K extends keyof EditableEducation>(
+    index: number,
+    field: K,
+    value: EditableEducation[K],
+  ) => {
     const updated = [...educations];
     updated[index] = { ...updated[index], [field]: value };
     setEducations(updated);
@@ -72,7 +86,7 @@ export default function EducationSection({
 
   const handleCancel = () => {
     if (profile && profile.educations.length > 0) {
-      setEducations(profile.educations.map(({ id, ...rest }) => rest));
+      setEducations(profile.educations.map(toEditableEducation));
     } else {
       setEducations([]);
     }
@@ -154,7 +168,7 @@ export default function EducationSection({
                   <label className="mb-1 block text-xs font-medium text-gray-600">학위</label>
                   <select
                     value={edu.degree}
-                    onChange={(e) => handleChange(idx, 'degree', e.target.value)}
+                    onChange={(e) => handleChange(idx, 'degree', e.target.value as EditableEducation['degree'])}
                     className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
                   >
                     {Object.entries(DEGREE_LABELS).map(([value, label]) => (
@@ -168,7 +182,7 @@ export default function EducationSection({
                   <label className="mb-1 block text-xs font-medium text-gray-600">상태</label>
                   <select
                     value={edu.status}
-                    onChange={(e) => handleChange(idx, 'status', e.target.value)}
+                    onChange={(e) => handleChange(idx, 'status', e.target.value as EditableEducation['status'])}
                     className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
                   >
                     {Object.entries(STATUS_LABELS).map(([value, label]) => (
@@ -225,8 +239,8 @@ export default function EducationSection({
   const displayEducations = isSectionEmpty
     ? [
         {
-          start_date: '2020.03',
-          end_date: '2024.02',
+          start_date: '2025.03',
+          end_date: '2026.02',
           is_current: false,
           school: '전북대학교',
           major: '컴퓨터공학과',

--- a/app/(main)/profile/_components/career/sections/MentorQnASection.tsx
+++ b/app/(main)/profile/_components/career/sections/MentorQnASection.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+
 import { FiEdit3 } from 'react-icons/fi';
+
 import { useSaveCareerMentorQnA } from '@/_lib/hooks/useCareer';
 import type { CareerProfile, MentorQnA } from '@/_types/career';
 
@@ -79,38 +81,44 @@ export default function MentorQnASection({
         <div className="space-y-4">
           <div>
             <label className="mb-2 block text-xs font-medium text-gray-600">
-              수도권 취창업을 목표한 적이 있나요?
+              Q1. 수도권 취업/창업을 시도해 본 적이 있나요?
             </label>
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  checked={mentorQnA.targeted_capital === true}
-                  onChange={() => setMentorQnA({ ...mentorQnA, targeted_capital: true })}
-                  className="h-4 w-4"
-                />
-                <span className="text-sm text-gray-700">예</span>
-              </label>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="radio"
-                  checked={mentorQnA.targeted_capital === false}
-                  onChange={() => setMentorQnA({ ...mentorQnA, targeted_capital: false })}
-                  className="h-4 w-4"
-                />
-                <span className="text-sm text-gray-700">아니오</span>
-              </label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setMentorQnA({ ...mentorQnA, targeted_capital: true })}
+                aria-pressed={mentorQnA.targeted_capital === true}
+                className={`rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
+                  mentorQnA.targeted_capital === true
+                    ? 'border-blue-200 bg-blue-50 text-blue-700'
+                    : 'border-transparent bg-gray-100 text-gray-600'
+                }`}
+              >
+                예
+              </button>
+              <button
+                type="button"
+                onClick={() => setMentorQnA({ ...mentorQnA, targeted_capital: false })}
+                aria-pressed={mentorQnA.targeted_capital === false}
+                className={`rounded-lg border px-4 py-2 text-sm font-medium transition-all ${
+                  mentorQnA.targeted_capital === false
+                    ? 'border-blue-200 bg-blue-50 text-blue-700'
+                    : 'border-transparent bg-gray-100 text-gray-600'
+                }`}
+              >
+                아니오
+              </button>
             </div>
           </div>
 
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-600">
-              수도권이 아닌 지역을 택한 이유가 있나요?
+              Q2. 지역에서 취·창업하게 된 이유는 무엇인가요?
             </label>
             <textarea
               value={mentorQnA.reason_for_local || ''}
               onChange={(e) => setMentorQnA({ ...mentorQnA, reason_for_local: e.target.value || null })}
-              placeholder="이유를 자유롭게 작성해주세요"
+              placeholder="이유를 자유롭게 작성해 주세요"
               rows={3}
               className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
             />
@@ -118,12 +126,13 @@ export default function MentorQnASection({
 
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-600">
-              지역 취창업시 도움받은 기관이나 멘토가 있나요?
+              Q3. 지역 취·창업 시 도움받은 기관/멘토가 있나요?
             </label>
+            <p className="mb-1 text-xs text-gray-400">예: 선배나 지인, 취업동아리, 대학일자리센터 등</p>
             <textarea
               value={mentorQnA.helpful_organizations || ''}
               onChange={(e) => setMentorQnA({ ...mentorQnA, helpful_organizations: e.target.value || null })}
-              placeholder="기관명, 프로그램명 등을 작성해주세요"
+              placeholder="도움을 받았던 기관/사람을 적어 주세요"
               rows={3}
               className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
             />
@@ -131,12 +140,12 @@ export default function MentorQnASection({
 
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-600">
-              내가 생각하는 지역 취창업 장점
+              Q4. 지역 취·창업의 장점은 무엇인가요?
             </label>
             <textarea
               value={mentorQnA.local_advantages || ''}
               onChange={(e) => setMentorQnA({ ...mentorQnA, local_advantages: e.target.value || null })}
-              placeholder="장점을 자유롭게 작성해주세요"
+              placeholder="장점을 자유롭게 작성해 주세요"
               rows={3}
               className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
             />
@@ -144,12 +153,12 @@ export default function MentorQnASection({
 
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-600">
-              내가 생각하는 지역 취창업 단점
+              Q5. 지역 취·창업의 단점/아쉬운 점은 무엇인가요?
             </label>
             <textarea
               value={mentorQnA.local_disadvantages || ''}
               onChange={(e) => setMentorQnA({ ...mentorQnA, local_disadvantages: e.target.value || null })}
-              placeholder="단점을 자유롭게 작성해주세요"
+              placeholder="단점이나 아쉬운 점을 자유롭게 작성해 주세요"
               rows={3}
               className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
             />
@@ -157,12 +166,12 @@ export default function MentorQnASection({
 
           <div>
             <label className="mb-1 block text-xs font-medium text-gray-600">
-              지역 취창업을 준비하는 후배에게 해주고 싶은 말
+              Q6. 후배들에게 전하고 싶은 조언을 적어주세요.
             </label>
             <textarea
               value={mentorQnA.advice_for_juniors || ''}
               onChange={(e) => setMentorQnA({ ...mentorQnA, advice_for_juniors: e.target.value || null })}
-              placeholder="후배들에게 전하고 싶은 조언을 작성해주세요"
+              placeholder="후배들에게 전하고 싶은 조언을 적어 주세요"
               rows={4}
               className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
             />
@@ -192,63 +201,72 @@ export default function MentorQnASection({
     return null;
   }
 
+  const mentorQna = profile.mentor_qna;
   const hasContent =
-    profile?.mentor_qna &&
-    (profile.mentor_qna.reason_for_local ||
-      profile.mentor_qna.helpful_organizations ||
-      profile.mentor_qna.local_advantages ||
-      profile.mentor_qna.local_disadvantages ||
-      profile.mentor_qna.advice_for_juniors);
+    mentorQna &&
+    (mentorQna.targeted_capital !== null ||
+      mentorQna.reason_for_local ||
+      mentorQna.helpful_organizations ||
+      mentorQna.local_advantages ||
+      mentorQna.local_disadvantages ||
+      mentorQna.advice_for_juniors);
 
   return (
     <div className="relative">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-base font-bold tracking-widest text-gray-900">멘토 Q&A</h3>
+        <h3 className="text-base font-bold tracking-widest text-gray-900">선배님 Q&A</h3>
         <button
           onClick={onEdit}
           className="text-gray-300 transition-colors hover:text-gray-500"
-          aria-label="멘토 Q&A 수정"
+          aria-label="선배님 Q&A 수정"
         >
           <FiEdit3 size={16} />
         </button>
       </div>
 
-      {isEmpty || !hasContent ? (
-        <p className="text-xs text-gray-300">후배들을 위한 멘토 Q&A를 작성해보세요</p>
+      {isEmpty || !mentorQna || !hasContent ? (
+        <p className="text-xs text-gray-300">후배들을 위한 선배님 Q&A를 작성해보세요</p>
       ) : (
         <div className="space-y-4 text-sm">
-          {profile?.mentor_qna?.reason_for_local && (
+          {mentorQna.targeted_capital !== null && (
             <div>
-              <p className="mb-1 text-xs font-medium text-gray-500">Q. 수도권이 아닌 지역을 택한 이유가 있나요?</p>
-              <p className="text-gray-700">{profile.mentor_qna.reason_for_local}</p>
+              <p className="mb-1 text-xs font-medium text-gray-500">Q1. 수도권 취업/창업을 시도해 본 적이 있나요?</p>
+              <p className="text-gray-700">{mentorQna.targeted_capital ? '예' : '아니오'}</p>
             </div>
           )}
 
-          {profile?.mentor_qna?.helpful_organizations && (
+          {mentorQna.reason_for_local && (
             <div>
-              <p className="mb-1 text-xs font-medium text-gray-500">Q. 지역 취·창업시 도움받은 기관이나 멘토가 있나요?</p>
-              <p className="text-gray-700">{profile.mentor_qna.helpful_organizations}</p>
+              <p className="mb-1 text-xs font-medium text-gray-500">Q2. 지역에서 취·창업하게 된 이유는 무엇인가요?</p>
+              <p className="text-gray-700">{mentorQna.reason_for_local}</p>
             </div>
           )}
 
-          {profile?.mentor_qna?.local_advantages && (
+          {mentorQna.helpful_organizations && (
             <div>
-              <p className="mb-1 text-xs font-medium text-gray-500">Q. 내가 생각하는 지역 취·창업 장점</p>
-              <p className="text-gray-700">{profile.mentor_qna.local_advantages}</p>
+              <p className="mb-1 text-xs font-medium text-gray-500">Q3. 지역 취·창업 시 도움받은 기관/멘토가 있나요?</p>
+              <p className="text-gray-700">{mentorQna.helpful_organizations}</p>
             </div>
           )}
 
-          {profile?.mentor_qna?.local_disadvantages && (
+          {mentorQna.local_advantages && (
             <div>
-              <p className="mb-1 text-xs font-medium text-gray-500">Q. 내가 생각하는 지역 취·창업 단점</p>
-              <p className="text-gray-700">{profile.mentor_qna.local_disadvantages}</p>
+              <p className="mb-1 text-xs font-medium text-gray-500">Q4. 지역 취·창업의 장점은 무엇인가요?</p>
+              <p className="text-gray-700">{mentorQna.local_advantages}</p>
             </div>
           )}
 
-          {profile?.mentor_qna?.advice_for_juniors && (
+          {mentorQna.local_disadvantages && (
             <div>
-              <p className="mb-1 text-xs font-medium text-gray-500">Q. 지역 취·창업을 준비하는 후배에게 해주고 싶은 말</p>
-              <p className="text-gray-700">{profile.mentor_qna.advice_for_juniors}</p>
+              <p className="mb-1 text-xs font-medium text-gray-500">Q5. 지역 취·창업의 단점/아쉬운 점은 무엇인가요?</p>
+              <p className="text-gray-700">{mentorQna.local_disadvantages}</p>
+            </div>
+          )}
+
+          {mentorQna.advice_for_juniors && (
+            <div>
+              <p className="mb-1 text-xs font-medium text-gray-500">Q6. 후배들에게 전하고 싶은 조언을 적어주세요.</p>
+              <p className="text-gray-700">{mentorQna.advice_for_juniors}</p>
             </div>
           )}
         </div>

--- a/app/(main)/profile/_components/career/sections/WorkSection.tsx
+++ b/app/(main)/profile/_components/career/sections/WorkSection.tsx
@@ -1,10 +1,20 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+
 import { FiEdit3, FiPlus, FiTrash2 } from 'react-icons/fi';
+
 import { useSaveCareerWorks } from '@/_lib/hooks/useCareer';
-import type { CareerProfile, WorkExperience } from '@/_types/career';
 import { EMPLOYMENT_TYPE_LABELS } from '@/_types/career';
+import type { CareerProfile, WorkExperience } from '@/_types/career';
+
+type EditableWork = Omit<WorkExperience, 'id'>;
+
+const toEditableWork = (work: WorkExperience): EditableWork => {
+  const editable = { ...work };
+  delete editable.id;
+  return editable;
+};
 
 interface WorkSectionProps {
   profile: CareerProfile | null;
@@ -24,11 +34,11 @@ export default function WorkSection({
   isEmpty,
 }: WorkSectionProps) {
   const saveMutation = useSaveCareerWorks();
-  const [works, setWorks] = useState<Omit<WorkExperience, 'id'>[]>([]);
+  const [works, setWorks] = useState<EditableWork[]>([]);
 
   useEffect(() => {
     if (profile && profile.works.length > 0) {
-      setWorks(profile.works.map(({ id, ...rest }) => rest));
+      setWorks(profile.works.map(toEditableWork));
     } else {
       setWorks([]);
     }
@@ -53,7 +63,11 @@ export default function WorkSection({
     setWorks(works.filter((_, i) => i !== index));
   };
 
-  const handleChange = (index: number, field: keyof Omit<WorkExperience, 'id'>, value: any) => {
+  const handleChange = <K extends keyof EditableWork>(
+    index: number,
+    field: K,
+    value: EditableWork[K],
+  ) => {
     const updated = [...works];
     updated[index] = { ...updated[index], [field]: value };
     setWorks(updated);
@@ -71,7 +85,7 @@ export default function WorkSection({
 
   const handleCancel = () => {
     if (profile && profile.works.length > 0) {
-      setWorks(profile.works.map(({ id, ...rest }) => rest));
+      setWorks(profile.works.map(toEditableWork));
     } else {
       setWorks([]);
     }
@@ -152,7 +166,9 @@ export default function WorkSection({
                 <label className="mb-1 block text-xs font-medium text-gray-600">고용형태</label>
                 <select
                   value={work.employment_type}
-                  onChange={(e) => handleChange(idx, 'employment_type', e.target.value)}
+                  onChange={(e) =>
+                    handleChange(idx, 'employment_type', e.target.value as EditableWork['employment_type'])
+                  }
                   className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm outline-none focus:border-gray-900"
                 >
                   {Object.entries(EMPLOYMENT_TYPE_LABELS).map(([value, label]) => (
@@ -208,7 +224,7 @@ export default function WorkSection({
   const displayWorks = isSectionEmpty
     ? [
         {
-          start_date: '2024.03',
+          start_date: '2025.03',
           end_date: null,
           is_current: true,
           company: '(주)예시기업',


### PR DESCRIPTION
- 이력관리 섹션을 단일 카드 구조로 통합하고 안내 박스 제거

- 선배님 Q&A 문구와 질문 순서를 온보딩 기준에 맞춰 정렬

- 자격증/학력/경력/대외활동 예시 날짜를 2025~2026 기준으로 최신화

- 프로필 섹션의 타입 경고(any, unused, import/order) 정리

- 최종확인 문구에서 '이력관리' 표기 통일