### PR TITLE
fix: 유저 수 3자리 이상일 때 숫자 겹침 오류 수정

### DIFF
--- a/app/_components/ui/UserStatsBanner.tsx
+++ b/app/_components/ui/UserStatsBanner.tsx
@@ -44,7 +44,7 @@ function RollingDigit({ digit, delay }: { digit: string; delay: number }) {
     return (
         <span
             className="inline-block overflow-hidden relative"
-            style={{ width: '0.6em', lineHeight: '1' }}
+            style={{ width: '1ch', height: '1em', lineHeight: '1', textAlign: 'center' }}
         >
             {/* 이전 숫자 (위로 올라가며 사라짐) */}
             <span
@@ -117,7 +117,7 @@ function AnimatedCount({ value }: { value: number }) {
     const chars = formatted.split('');
 
     return (
-        <span className="inline-flex items-baseline font-bold text-blue-600" aria-label={`${displayValue}명`}>
+        <span className="inline-flex items-baseline font-bold text-blue-600" style={{ fontVariantNumeric: 'tabular-nums' }} aria-label={`${displayValue}명`}>
             {chars.map((char, i) => (
                 <RollingDigit
                     key={`${chars.length}-${i}`}


### PR DESCRIPTION
## Summary
- RollingDigit 컨테이너 너비를 `0.6em`에서 `1ch`로 변경하여 볼드 폰트에서도 정확한 폭 확보
- 명시적 `height: 1em` 설정으로 롤링 애니메이션 안정화
- `tabular-nums` 적용으로 자릿수 간 균일한 간격 유지

## Test plan
- [ ] 유저 수 1~2자리에서 숫자 표시 정상 확인
- [ ] 유저 수 3자리 이상에서 숫자 겹침 없이 표시되는지 확인
- [ ] 카운트업 롤링 애니메이션이 자연스럽게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)