### PR TITLE
feat(chinba): 외부 링크 유입 시 Smart Back 네비게이션 적용

### DIFF
--- a/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
@@ -7,6 +7,7 @@ import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import Toast from '@/_components/ui/Toast';
 import FullPageModal from '@/_components/layout/FullPageModal';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import { useUser } from '@/_lib/hooks/useUser';
 import { useChinbaEventDetail, useDeleteChinbaEvent, useCompleteChinbaEvent } from '@/_lib/hooks/useChinba';
 import TeamScheduleTab from './TeamScheduleTab';
@@ -25,6 +26,7 @@ function formatDateRange(dates: string[]): string {
 export default function ChinbaDetailClient() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const smartBack = useSmartBack();
   const eventId = searchParams.get('id') || '';
   const lastTabKey = `chinba:event:${eventId}:last-tab`;
 
@@ -165,7 +167,7 @@ export default function ChinbaDetailClient() {
   // Loading state
   if (!isAuthLoaded || isLoading) {
     return (
-      <FullPageModal isOpen={true} onClose={() => router.back()} title="친바">
+      <FullPageModal isOpen={true} onClose={smartBack} title="친바">
         <div className="flex h-full items-center justify-center">
           <LoadingSpinner size="lg" />
         </div>
@@ -176,7 +178,7 @@ export default function ChinbaDetailClient() {
   // Error state
   if (error || !event) {
     return (
-      <FullPageModal isOpen={true} onClose={() => router.back()} title="친바">
+      <FullPageModal isOpen={true} onClose={smartBack} title="친바">
         <div className="flex h-full flex-col items-center justify-center">
           <p className="text-sm text-gray-500">이벤트를 찾을 수 없습니다</p>
           <button
@@ -192,7 +194,7 @@ export default function ChinbaDetailClient() {
 
   return (
     <>
-      <FullPageModal isOpen={true} onClose={() => router.back()} title={event.title || '친바'}>
+      <FullPageModal isOpen={true} onClose={smartBack} title={event.title || '친바'}>
         {/* Event Detail Header */}
         <div className="shrink-0 px-4 pb-2 border-b border-gray-100">
           <div className="flex items-center justify-between">

--- a/app/_lib/hooks/useSmartBack.ts
+++ b/app/_lib/hooks/useSmartBack.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+const HAS_HISTORY_KEY = '__zt_has_app_history';
+
+export function useSmartBack(fallbackPath: string = '/') {
+  const router = useRouter();
+
+  return useCallback(() => {
+    const hasAppHistory = sessionStorage.getItem(HAS_HISTORY_KEY) === '1';
+    if (hasAppHistory) {
+      router.back();
+    } else {
+      router.replace(fallbackPath);
+    }
+  }, [router, fallbackPath]);
+}

--- a/app/_lib/navigation/NavigationTracker.tsx
+++ b/app/_lib/navigation/NavigationTracker.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+const HAS_HISTORY_KEY = '__zt_has_app_history';
+
+export default function NavigationTracker() {
+  const pathname = usePathname();
+  const initialPathname = useRef(pathname);
+
+  useEffect(() => {
+    if (pathname !== initialPathname.current) {
+      sessionStorage.setItem(HAS_HISTORY_KEY, '1');
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import Script from 'next/script';
 import './globals.css';
 import DevHostMetaTag from './_components/system/DevHostMetaTag';
 import ServiceWorkerRegistration from './_components/system/ServiceWorkerRegistration';
+import NavigationTracker from './_lib/navigation/NavigationTracker';
 import Providers from './providers';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -58,6 +59,7 @@ gtag('config', 'G-SMF31V39T9');`}
       <body className={`${inter.className} flex h-screen flex-col bg-gray-50 text-gray-900`}>
         <ServiceWorkerRegistration />
         <Providers>
+          <NavigationTracker />
           <main className="flex-1 min-h-0 overflow-hidden">{children}</main>
         </Providers>
       </body>


### PR DESCRIPTION
## Summary
- 카카오톡 등 외부에서 친바 링크(`/chinba/event?id=xxx`)로 유입된 사용자가 뒤로가기 시 앱 밖으로 이탈하는 문제 해결
- `NavigationTracker` + `useSmartBack` 패턴으로 앱 내 히스토리 유무에 따라 `router.back()` / `router.replace('/')` 분기
- ChinbaDetailClient의 3개 `router.back()` 호출을 `smartBack()`으로 교체

## 변경 파일
| 파일 | 변경 |
|------|------|
| `app/_lib/navigation/NavigationTracker.tsx` | 신규 - pathname 변경 추적 |
| `app/_lib/hooks/useSmartBack.ts` | 신규 - smart back 훅 |
| `app/layout.tsx` | NavigationTracker 추가 |
| `app/(main)/chinba/event/_components/ChinbaDetailClient.tsx` | `router.back()` → `smartBack()` |

## 동작

| 시나리오 | Before | After |
|----------|--------|-------|
| 카톡 링크 → 뒤로 | 카카오톡으로 이탈 | 홈(`/`)으로 이동 |
| 직접 URL → 뒤로 | 빈 페이지 | 홈으로 이동 |
| 홈 → 친바 → 이벤트 → 뒤로 | 친바 메인 | 친바 메인 (동일) |
| 새로고침 → 뒤로 | 브라우저 기본 | 홈으로 이동 |

## Test plan
- [ ] 카톡 인앱 브라우저에서 친바 링크 공유 → 뒤로가기 → 홈 도착 확인
- [ ] 새 탭에서 `/chinba/event?id=xxx` 직접 입력 → 뒤로가기 → 홈 도착 확인
- [ ] 앱 내 이동: 홈 → 친바 → 이벤트 → 뒤로가기 → 친바 메인 확인
- [ ] 이벤트 페이지 새로고침 → 뒤로가기 → 홈 도착 확인
- [ ] 탭 전환("전체 일정"↔"내 일정") 후 뒤로가기 동작 확인

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)