### PR TITLE
feat(chinba): 알림·키워드·필터·친바생성 페이지에도 Smart Back 적용

### DIFF
--- a/app/(main)/chinba/create/_components/ChinbaCreateClient.tsx
+++ b/app/(main)/chinba/create/_components/ChinbaCreateClient.tsx
@@ -8,11 +8,13 @@ import Toast from '@/_components/ui/Toast';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import { getLoginUrl } from '@/_lib/utils/requireLogin';
 import { useCreateChinbaEvent } from '@/_lib/hooks/useChinba';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import { useUser } from '@/_lib/hooks/useUser';
 import DateSelector from './DateSelector';
 
 export default function ChinbaCreateClient() {
   const router = useRouter();
+  const smartBack = useSmartBack();
   const createEvent = useCreateChinbaEvent();
   const { isLoggedIn } = useUser();
 
@@ -75,7 +77,7 @@ export default function ChinbaCreateClient() {
 
   return (
     <>
-      <FullPageModal isOpen={true} onClose={() => router.back()} title="새 일정 만들기">
+      <FullPageModal isOpen={true} onClose={smartBack} title="새 일정 만들기">
         {/* Content */}
         <div className="flex-1 overflow-y-auto px-4">
           {error && (

--- a/app/(main)/filter/page.tsx
+++ b/app/(main)/filter/page.tsx
@@ -2,15 +2,17 @@
 
 import { useRouter } from 'next/navigation';
 import { useSelectedCategories } from '@/_lib/hooks/useSelectedCategories';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import BoardFilterContent from './_components/BoardFilterContent';
 
 export default function FilterPage() {
     const router = useRouter();
+    const smartBack = useSmartBack();
     const { selectedCategories, updateSelectedCategories } = useSelectedCategories();
 
     const handleClose = () => {
-        router.back();
+        smartBack();
     };
 
     const handleApply = async (boards: string[]) => {
@@ -22,7 +24,7 @@ export default function FilterPage() {
         } catch (error) {
             console.error('Failed to apply filters:', error);
             // 에러 시에도 일단 뒤로가기 시도하거나 알림 표시 가능
-            router.back();
+            smartBack();
         }
     };
 

--- a/app/(main)/keywords/page.tsx
+++ b/app/(main)/keywords/page.tsx
@@ -6,6 +6,7 @@ import KeywordsModalContent from './_components/KeywordsModalContent';
 import Button from '@/_components/ui/Button';
 import { useRouter } from 'next/navigation'; // Added missing import for useRouter
 import { useEffect } from 'react'; // Added missing import for useEffect
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 
 /**
  * 키워드 관리 페이지
@@ -14,6 +15,7 @@ import { useEffect } from 'react'; // Added missing import for useEffect
  */
 export default function KeywordsPage() {
   const router = useRouter();
+  const smartBack = useSmartBack();
   const { isLoggedIn, isAuthLoaded } = useUser();
 
   useEffect(() => {
@@ -23,7 +25,7 @@ export default function KeywordsPage() {
   }, [isAuthLoaded, isLoggedIn, router]);
 
   const handleClose = () => {
-    router.back();
+    smartBack();
   };
 
   const handleUpdate = () => {

--- a/app/(main)/notifications/_components/NotificationsClient.tsx
+++ b/app/(main)/notifications/_components/NotificationsClient.tsx
@@ -16,12 +16,14 @@ import { usePullToRefresh } from '@/_lib/hooks/usePullToRefresh';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import KeywordSettingsBar from '@/_components/ui/KeywordSettingsBar';
 import PullToRefreshIndicator from '@/_components/ui/PullToRefreshIndicator';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import { useUser } from '@/_lib/hooks/useUser';
 
 type LoadMode = 'initial' | 'refresh' | 'retry';
 
 export default function NotificationsClient() {
   const router = useRouter();
+  const smartBack = useSmartBack();
   const { isLoggedIn } = useUser();
   const [keywordCount, setKeywordCount] = useState<number | null>(null);
   const [keywordNotices, setKeywordNotices] = useState<Notice[]>([]);
@@ -205,7 +207,7 @@ export default function NotificationsClient() {
 
   return (
     <>
-      <FullPageModal isOpen={true} onClose={() => router.back()} title="알림">
+      <FullPageModal isOpen={true} onClose={smartBack} title="알림">
         <KeywordSettingsBar
           keywordCount={keywordCountLabel}
           onSettingsClick={() => {


### PR DESCRIPTION
## Summary
- PR #143 머지 후 추가된 커밋으로, 나머지 FullPageModal 페이지에도 Smart Back 적용
- `NotificationsClient`, `KeywordsPage`, `ChinbaCreateClient`, `FilterPage`의 `router.back()` → `smartBack()` 교체

## 변경 파일
| 파일 | 변경 |
|------|------|
| `app/(main)/notifications/_components/NotificationsClient.tsx` | `router.back()` → `smartBack()` |
| `app/(main)/keywords/page.tsx` | `router.back()` → `smartBack()` |
| `app/(main)/chinba/create/_components/ChinbaCreateClient.tsx` | `router.back()` → `smartBack()` |
| `app/(main)/filter/page.tsx` | `router.back()` → `smartBack()` |

## Test plan
- [ ] 외부 링크로 각 페이지 직접 접속 → 뒤로가기 → 홈 도착 확인
- [ ] 앱 내 이동 후 뒤로가기 → 이전 페이지로 정상 이동 확인

Refs #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)