### PR TITLE
fix: 사이드바 푸터에서 베타 워딩 삭제

### DIFF
--- a/app/_components/layout/SidebarContent.tsx
+++ b/app/_components/layout/SidebarContent.tsx
@@ -290,7 +290,7 @@ export default function SidebarContent({ onNavigate, onShowToast, onCollapse }: 
             <br />
             컴퓨터인공지능학부, 경영학과 학생들이 협력하여
             <br />
-            개발 중인 베타 서비스입니다.
+            개발 중인 서비스입니다.
           </p>
 
 


### PR DESCRIPTION
## Summary
- 사이드바 푸터의 "개발 중인 베타 서비스입니다" → "개발 중인 서비스입니다"로 변경

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)