### PR TITLE
fix: 키워드 2글자 프론트엔드 검증 추가 및 불안정 코드 revert

### DIFF
--- a/app/(main)/(home)/_hooks/useKeywordNotices.ts
+++ b/app/(main)/(home)/_hooks/useKeywordNotices.ts
@@ -1,9 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Notice, getAllKeywordNotices, getMyKeywords } from '@/_lib/api';
+import { useState, useEffect } from 'react';
+import { Notice, getKeywordNotices, getMyKeywords } from '@/_lib/api';
 import { getLatestKeywordNoticeAt } from '@/_lib/utils/notice';
 import { FilterType } from '@/_types/filter';
-
-const KEYWORD_SEEN_EVENT = 'keyword-notices-seen';
 
 /**
  * 키워드 공지사항 관련 로직을 관리하는 Hook
@@ -20,7 +18,7 @@ export function useKeywordNotices(isLoggedIn: boolean, filter: FilterType) {
   // 키워드 공지 로딩
   const loadKeywordNotices = async () => {
     try {
-      const data = await getAllKeywordNotices(true);
+      const data = await getKeywordNotices(0, 200, true);
       setKeywordNotices(data);
     } catch (error) {
       console.error('Failed to load keyword notices', error);
@@ -30,7 +28,7 @@ export function useKeywordNotices(isLoggedIn: boolean, filter: FilterType) {
   // 키워드 공지 로딩 (백그라운드, 에러 무시)
   const loadKeywordNoticesSilent = async () => {
     try {
-      const data = await getAllKeywordNotices(true);
+      const data = await getKeywordNotices(0, 200, true);
       setKeywordNotices(data);
     } catch (error) {
       console.error('Failed to load keyword notices', error);
@@ -52,7 +50,7 @@ export function useKeywordNotices(isLoggedIn: boolean, filter: FilterType) {
   };
 
   // 새 키워드 공지 배지 업데이트
-  const updateKeywordBadge = useCallback((items: Notice[]) => {
+  const updateKeywordBadge = (items: Notice[]) => {
     if (typeof window === 'undefined') return;
     if (items.length === 0) {
       setHasNewKeywordNotices(false);
@@ -67,33 +65,32 @@ export function useKeywordNotices(isLoggedIn: boolean, filter: FilterType) {
     }
     const seenAt = localStorage.getItem('keyword_notice_seen_at');
     if (!seenAt) {
-      const unreadCount = items.filter(n => !n.is_read).length;
-      if (unreadCount > 0) {
-        // 읽지 않은 매칭 공지가 있으면 "새 알림 있음"으로 표시
-        setHasNewKeywordNotices(true);
-        setNewKeywordCount(unreadCount);
-        // seenAt은 사용자가 KEYWORD 탭에 실제로 진입했을 때만 설정
-        // (markKeywordNoticesSeen에서 처리)
+      // 처음 접속하거나 이력이 없을 때는 현재 목록을 모두 '이미 본 것'으로 간주하거나 현재 시간으로 초기화
+      // 사용자 요청: 크롤러 추가 시점(00:00) 이후의 것만 알림으로 받고 싶어함.
+      // 백엔드에서 이미 키워드 추가 시점 이후의 공지만 주므로, 
+      // 여기서 seenAt을 설치 시점(현재 최신 공지의 시각 또는 현재 시각)으로 잡으면
+      // 이후에 새로 들어오는 공지만 '새 알림'이 됨.
+      if (items.length > 0) {
+        localStorage.setItem('keyword_notice_seen_at', new Date(latest).toISOString());
       } else {
         localStorage.setItem('keyword_notice_seen_at', new Date().toISOString());
-        setHasNewKeywordNotices(false);
-        setNewKeywordCount(0);
       }
+      setHasNewKeywordNotices(false);
+      setNewKeywordCount(0);
       return;
     }
 
     const seenTime = new Date(seenAt).getTime();
+    setHasNewKeywordNotices(latest > seenTime);
 
-    // 새 알림 = seenTime 이후 생성 + 아직 읽지 않은 공지만
+    // 새 알림 개수 계산 (seenTime보다 나중에 생성된 공지들)
     const newCount = items.filter(notice => {
-      if (notice.is_read) return false;
       const noticeTime = new Date(notice.created_at ?? notice.date).getTime();
       return noticeTime > seenTime;
     }).length;
 
-    setHasNewKeywordNotices(newCount > 0);
     setNewKeywordCount(newCount);
-  }, []);
+  };
 
   // 키워드 공지 읽음 처리
   const markKeywordNoticesSeen = (items: Notice[]) => {
@@ -102,9 +99,6 @@ export function useKeywordNotices(isLoggedIn: boolean, filter: FilterType) {
     if (!latest) return;
     localStorage.setItem('keyword_notice_seen_at', new Date(latest).toISOString());
     setHasNewKeywordNotices(false);
-    setNewKeywordCount(0);
-    // 다른 훅 인스턴스에 알림
-    window.dispatchEvent(new Event(KEYWORD_SEEN_EVENT));
   };
 
   // 초기화: 로그인 시 키워드 공지 로드
@@ -143,14 +137,7 @@ export function useKeywordNotices(isLoggedIn: boolean, filter: FilterType) {
       return;
     }
     updateKeywordBadge(keywordNotices);
-  }, [keywordNotices, isLoggedIn, updateKeywordBadge]);
-
-  // 다른 훅 인스턴스에서 seen 처리 시 배지 재계산
-  useEffect(() => {
-    const handleSeen = () => updateKeywordBadge(keywordNotices);
-    window.addEventListener(KEYWORD_SEEN_EVENT, handleSeen);
-    return () => window.removeEventListener(KEYWORD_SEEN_EVENT, handleSeen);
-  }, [keywordNotices, updateKeywordBadge]);
+  }, [keywordNotices, isLoggedIn]);
 
   // 키워드 필터 진입 시 읽음 처리
   useEffect(() => {

--- a/app/(main)/keywords/_components/KeywordsModalContent.tsx
+++ b/app/(main)/keywords/_components/KeywordsModalContent.tsx
@@ -54,6 +54,10 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
       showToastMessage('키워드를 입력해 주세요.', 'info');
       return;
     }
+    if (trimmed.length < 2) {
+      showToastMessage('키워드는 2글자 이상 입력해 주세요.', 'info');
+      return;
+    }
     if (!isLoggedIn) {
       showToastMessage('로그인 후 사용할 수 있습니다.', 'info');
       return;

--- a/app/(main)/keywords/_components/KeywordsModalContent.tsx
+++ b/app/(main)/keywords/_components/KeywordsModalContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { addKeyword, deleteKeyword, getMyKeywords, Keyword } from '@/_lib/api';
 import { useUser } from '@/_lib/hooks/useUser';
@@ -20,7 +20,6 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
   const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('info');
   const [showToast, setShowToast] = useState(false);
   const [toastKey, setToastKey] = useState(0);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   const showToastMessage = (message: string, type: 'success' | 'error' | 'info' = 'info') => {
     setToastMessage(message);
@@ -62,16 +61,11 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
       showToastMessage('로그인 후 사용할 수 있습니다.', 'info');
       return;
     }
-    if (keywords.length >= 20) {
-      showToastMessage('키워드는 최대 20개까지 등록할 수 있어요.', 'info');
-      return;
-    }
 
     try {
       const created = await addKeyword(trimmed);
       setKeywords((prev) => [created, ...prev]);
       setKeywordInput('');
-      inputRef.current?.focus();
       showToastMessage('키워드가 추가되었습니다.', 'success');
       onUpdate?.();
     } catch (error) {
@@ -124,12 +118,11 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
               <label className="text-sm font-semibold text-gray-700">키워드 추가</label>
               <div className="mt-3 flex gap-2">
                 <input
-                  ref={inputRef}
                   value={keywordInput}
                   onChange={(e) => setKeywordInput(e.target.value)}
                   placeholder="키워드 입력 (예: 공모전, 장학금)"
                   className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
-                  onKeyDown={(e) => {
+                  onKeyPress={(e) => {
                     if (e.key === 'Enter') handleAddKeyword();
                   }}
                 />

--- a/app/(main)/notifications/_components/NotificationsClient.tsx
+++ b/app/(main)/notifications/_components/NotificationsClient.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
-  getAllKeywordNotices,
+  getKeywordNotices,
   getMyKeywords,
   markNoticeAsRead,
   toggleNoticeFavorite,
@@ -81,7 +81,7 @@ export default function NotificationsClient() {
         return;
       }
 
-      const notices = await getAllKeywordNotices(true);
+      const notices = await getKeywordNotices(0, 200, true);
       setKeywordNotices(notices);
       setLoadError(null);
     } catch (error) {

--- a/app/_components/ui/KeywordSettingsBar.tsx
+++ b/app/_components/ui/KeywordSettingsBar.tsx
@@ -15,9 +15,7 @@ export default function KeywordSettingsBar({
     <div className="shrink-0 border-b border-gray-100 bg-white px-5 py-3">
       <div className="flex items-center justify-between rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
         <span className="text-sm font-medium text-gray-700">
-          {keywordCount > 0
-            ? `알림 받는 키워드 ${keywordCount}개`
-            : '키워드를 추가하면 관련 공지를 모아볼 수 있어요'}
+          알림 받는 키워드 {keywordCount}개
         </span>
         <button
           onClick={onSettingsClick}

--- a/app/_lib/api/keywords.ts
+++ b/app/_lib/api/keywords.ts
@@ -35,25 +35,3 @@ export const getKeywordNotices = async (
     });
     return response.data;
 };
-
-// 키워드 공지 전체 조회
-export const getAllKeywordNotices = async (
-    includeRead: boolean = true,
-    pageSize: number = 50,
-): Promise<Notice[]> => {
-    const allNotices: Notice[] = [];
-    let page = 0;
-
-    while (page < 20) {
-        const batch = await getKeywordNotices(page, pageSize, includeRead);
-        allNotices.push(...batch);
-
-        if (batch.length < pageSize) {
-            break;
-        }
-
-        page += 1;
-    }
-
-    return allNotices;
-};

--- a/app/_lib/hooks/useKeywordNotices.ts
+++ b/app/_lib/hooks/useKeywordNotices.ts
@@ -1,8 +1,6 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { Notice, getKeywordNotices, getMyKeywords } from '@/_lib/api';
 import { getLatestKeywordNoticeAt } from '@/_lib/utils/notice';
-
-const KEYWORD_SEEN_EVENT = 'keyword-notices-seen';
 
 /**
  * 키워드 공지 알림 카운트만 관리하는 경량 훅 (SharedHeader용)
@@ -45,7 +43,7 @@ export function useKeywordNotices(isLoggedIn: boolean) {
     }
   };
 
-  const updateKeywordBadge = useCallback((items: Notice[]) => {
+  const updateKeywordBadge = (items: Notice[]) => {
     if (typeof window === 'undefined') return;
     if (items.length === 0) {
       setHasNewKeywordNotices(false);
@@ -60,29 +58,26 @@ export function useKeywordNotices(isLoggedIn: boolean) {
     }
     const seenAt = localStorage.getItem('keyword_notice_seen_at');
     if (!seenAt) {
-      const unreadCount = items.filter(n => !n.is_read).length;
-      if (unreadCount > 0) {
-        setHasNewKeywordNotices(true);
-        setNewKeywordCount(unreadCount);
+      if (items.length > 0) {
+        localStorage.setItem('keyword_notice_seen_at', new Date(latest).toISOString());
       } else {
         localStorage.setItem('keyword_notice_seen_at', new Date().toISOString());
-        setHasNewKeywordNotices(false);
-        setNewKeywordCount(0);
       }
+      setHasNewKeywordNotices(false);
+      setNewKeywordCount(0);
       return;
     }
 
     const seenTime = new Date(seenAt).getTime();
+    setHasNewKeywordNotices(latest > seenTime);
 
     const newCount = items.filter(notice => {
-      if (notice.is_read) return false;
       const noticeTime = new Date(notice.created_at ?? notice.date).getTime();
       return noticeTime > seenTime;
     }).length;
 
-    setHasNewKeywordNotices(newCount > 0);
     setNewKeywordCount(newCount);
-  }, []);
+  };
 
   const markKeywordNoticesSeen = (items: Notice[]) => {
     if (typeof window === 'undefined') return;
@@ -91,8 +86,6 @@ export function useKeywordNotices(isLoggedIn: boolean) {
     localStorage.setItem('keyword_notice_seen_at', new Date(latest).toISOString());
     setHasNewKeywordNotices(false);
     setNewKeywordCount(0);
-    // 다른 훅 인스턴스에 알림
-    window.dispatchEvent(new Event(KEYWORD_SEEN_EVENT));
   };
 
   // 초기화: 로그인 시 키워드 공지 로드
@@ -117,14 +110,7 @@ export function useKeywordNotices(isLoggedIn: boolean) {
       return;
     }
     updateKeywordBadge(keywordNotices);
-  }, [keywordNotices, isLoggedIn, updateKeywordBadge]);
-
-  // 다른 훅 인스턴스에서 seen 처리 시 배지 재계산
-  useEffect(() => {
-    const handleSeen = () => updateKeywordBadge(keywordNotices);
-    window.addEventListener(KEYWORD_SEEN_EVENT, handleSeen);
-    return () => window.removeEventListener(KEYWORD_SEEN_EVENT, handleSeen);
-  }, [keywordNotices, updateKeywordBadge]);
+  }, [keywordNotices, isLoggedIn]);
 
   return {
     keywordNotices,

--- a/e2e/keywords.spec.ts
+++ b/e2e/keywords.spec.ts
@@ -25,4 +25,30 @@ test.describe('키워드 페이지 - 로그인 사용자', () => {
     await expect(asLoggedInUser.getByText('장학금')).toBeVisible({ timeout: 10_000 });
     await expect(asLoggedInUser.getByText('수강신청')).toBeVisible({ timeout: 10_000 });
   });
+
+  test('키워드 추가 후 목록에 표시된다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/keywords');
+    await expect(asLoggedInUser.getByText('키워드 알림')).toBeVisible({ timeout: 10_000 });
+
+    await asLoggedInUser.fill('input[placeholder*="키워드 입력"]', '장학금');
+    await asLoggedInUser.getByRole('button', { name: '추가' }).click();
+    await expect(asLoggedInUser.getByText('장학금')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('키워드 삭제 후 목록에서 제거된다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/keywords');
+    await expect(asLoggedInUser.getByText('장학금')).toBeVisible({ timeout: 10_000 });
+
+    await asLoggedInUser.getByRole('button', { name: '장학금 삭제' }).click();
+    await expect(asLoggedInUser.getByText('장학금')).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test('1글자 키워드 입력 시 안내 메시지 표시', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/keywords');
+    await expect(asLoggedInUser.getByText('키워드 알림')).toBeVisible({ timeout: 10_000 });
+
+    await asLoggedInUser.fill('input[placeholder*="키워드 입력"]', '전');
+    await asLoggedInUser.getByRole('button', { name: '추가' }).click();
+    await expect(asLoggedInUser.getByText('키워드는 2글자 이상 입력해 주세요.')).toBeVisible({ timeout: 10_000 });
+  });
 });


### PR DESCRIPTION
## Summary

키워드 프론트엔드 2글자 검증 추가, E2E 테스트 강화, 불안정한 9c468c1 커밋 revert

## Changes

### 1. 키워드 최소 2글자 프론트엔드 검증 추가 (`e651e34`)
- `KeywordsModalContent.tsx`에 `trimmed.length < 2` 클라이언트 사이드 검증
- 서버 API 호출 전에 사용자에게 즉시 안내 메시지 표시

### 2. 키워드 Playwright E2E 테스트 강화 (`78be9ef`)
- `e2e/keywords.spec.ts`에 1글자 키워드 거부 테스트 추가
- 2글자 이상 키워드 정상 등록 테스트 추가

### 3. 키워드 알림 로딩 변경 되돌리기 (`261c7d6`)
- 커밋 9c468c1 (`fix(notification): 키워드 알림 로딩 범위 확장`) 전체 revert
- 제거 항목: `useRef`/`inputRef`, 20개 제한, `onKeyDown` 변경, `getAllKeywordNotices` 등
- 사유: 검증되지 않은 코드가 PR#147을 통해 머지됨, 추후 리팩토링 예정

## Files Changed
- `app/(main)/keywords/_components/KeywordsModalContent.tsx` — 2글자 검증 + 9c468c1 revert
- `app/(main)/(home)/_hooks/useKeywordNotices.ts` — revert
- `app/_lib/hooks/useKeywordNotices.ts` — revert
- `app/(main)/notifications/_components/NotificationsClient.tsx` — revert
- `app/_components/ui/KeywordSettingsBar.tsx` — revert
- `app/_lib/api/keywords.ts` — revert (getAllKeywordNotices 제거)
- `e2e/keywords.spec.ts` — E2E 테스트 추가

## Testing
- Playwright E2E: `npx playwright test e2e/keywords.spec.ts` → 14/14 PASS