### PR TITLE
fix(keywords): 키워드 알림 배지 미표시 버그 수정 + 키워드 필터 dot 배지 추가

### DIFF
--- a/app/(main)/(home)/page.tsx
+++ b/app/(main)/(home)/page.tsx
@@ -81,7 +81,7 @@ function HomeContent() {
     scrollContainerRef,
   });
 
-  const { keywordNotices, keywordCount, refreshKeywordNotices, markKeywordNoticesSeen } = useNotificationBadge();
+  const { keywordNotices, keywordCount, refreshKeywordNotices, markKeywordNoticesSeen, hasNewKeywordNotices } = useNotificationBadge();
 
   // 게시판 목록
   const selectedBoards = selectedCategories;
@@ -252,16 +252,17 @@ function HomeContent() {
       {/* User Stats Banner */}
       <UserStatsBanner isLoggedIn={isLoggedIn} onSignupClick={() => router.push('/login')} />
 
-      {/* 카테고리 필터 */}
-      <div className="shrink-0" style={{ touchAction: 'none' }}>
-        <CategoryFilter
-          activeFilter={filter}
-          onFilterChange={(f) => setFilter(f as any)}
-          isLoggedIn={isLoggedIn}
-          onSettingsClick={() => router.push('/filter')}
-          onShowToast={showToast}
-        />
-      </div>
+       {/* 카테고리 필터 */}
+       <div className="shrink-0" style={{ touchAction: 'none' }}>
+         <CategoryFilter
+           activeFilter={filter}
+           onFilterChange={(f) => setFilter(f as any)}
+           isLoggedIn={isLoggedIn}
+           onSettingsClick={() => router.push('/filter')}
+           onShowToast={showToast}
+           hasNewKeywordNotices={hasNewKeywordNotices}
+         />
+       </div>
 
       {/* 키워드 필터일 때만 키워드 설정 바 표시 */}
       {filter === 'KEYWORD' && (

--- a/app/_components/ui/CategoryFilter.tsx
+++ b/app/_components/ui/CategoryFilter.tsx
@@ -7,6 +7,7 @@ interface CategoryFilterProps {
   isLoggedIn: boolean; // 로그인 상태
   onSettingsClick: () => void; // 설정 버튼 클릭 콜백
   onShowToast: (message: string, type?: 'success' | 'error' | 'info') => void; // 토스트 메시지 표시
+  hasNewKeywordNotices?: boolean;
 }
 
 // 전체 필터 목록 (Guest/User 공통)
@@ -20,7 +21,7 @@ const ALL_FILTERS = [
 // 로그인 필요 필터 목록
 const LOGIN_REQUIRED_FILTERS = ['UNREAD', 'KEYWORD', 'FAVORITE'];
 
-export default function CategoryFilter({ activeFilter, onFilterChange, isLoggedIn, onSettingsClick, onShowToast }: CategoryFilterProps) {
+export default function CategoryFilter({ activeFilter, onFilterChange, isLoggedIn, onSettingsClick, onShowToast, hasNewKeywordNotices }: CategoryFilterProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
   useEffect(() => {
@@ -91,18 +92,21 @@ export default function CategoryFilter({ activeFilter, onFilterChange, isLoggedI
         {ALL_FILTERS.map((filter) => {
           const isActive = activeFilter === filter.key;
 
-          return (
-            <button
-              key={filter.key}
-              onClick={() => handleFilterClick(filter.key)}
-              className={`whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-all active:scale-95 ${isActive
-                ? 'bg-gray-900 text-white shadow-md'
-                : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
-                }`}
-            >
-              {filter.label}
-            </button>
-          );
+           return (
+             <button
+               key={filter.key}
+               onClick={() => handleFilterClick(filter.key)}
+               className={`relative whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-all active:scale-95 ${isActive
+                 ? 'bg-gray-900 text-white shadow-md'
+                 : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                 }`}
+             >
+               {filter.label}
+               {filter.key === 'KEYWORD' && hasNewKeywordNotices && !isActive && (
+                 <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-gray-50" />
+               )}
+             </button>
+           );
         })}
       </div>
     </div>

--- a/app/_context/NotificationBadgeContext.tsx
+++ b/app/_context/NotificationBadgeContext.tsx
@@ -49,16 +49,20 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
     }
   };
 
-  const refreshKeywordNotices = async () => {
-    const keywords = await getMyKeywords();
-    setKeywordCount(keywords.length);
-    if (keywords.length === 0) {
-      setKeywordNotices([]);
-      return;
-    }
-    const data = await getKeywordNotices(0, 200, true);
-    setKeywordNotices(data);
-  };
+   const refreshKeywordNotices = async () => {
+     try {
+       const keywords = await getMyKeywords();
+       setKeywordCount(keywords.length);
+       if (keywords.length === 0) {
+         setKeywordNotices([]);
+         return;
+       }
+       const data = await getKeywordNotices(0, 200, true);
+       setKeywordNotices(data);
+     } catch (error) {
+       console.error('Failed to refresh keyword notices', error);
+     }
+   };
 
   const updateKeywordBadge = (items: Notice[]) => {
     if (typeof window === 'undefined') return;
@@ -77,16 +81,15 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       setNewKeywordCount(0);
       return;
     }
-    const seenAt = localStorage.getItem('keyword_notice_seen_at');
-    if (!seenAt) {
-      localStorage.setItem('keyword_notice_seen_at', new Date(latest).toISOString());
-      setHasNewKeywordNotices(false);
-      setNewKeywordCount(0);
-      return;
-    }
-
-    const seenTime = new Date(seenAt).getTime();
-    setHasNewKeywordNotices(latest > seenTime);
+     const seenAt = localStorage.getItem('keyword_notice_seen_at');
+     const seenTime = seenAt ? new Date(seenAt).getTime() : 0;
+     if (isNaN(seenTime)) {
+       // localStorage 오염 방어: 잘못된 값이면 모든 공지를 새 알림으로 처리
+       setHasNewKeywordNotices(true);
+       setNewKeywordCount(items.length);
+       return;
+     }
+     setHasNewKeywordNotices(latest > seenTime);
 
     const newCount = items.filter(notice => {
       const noticeTime = new Date(notice.created_at ?? notice.date).getTime();

--- a/app/_lib/utils/notice.ts
+++ b/app/_lib/utils/notice.ts
@@ -31,10 +31,14 @@ export function mergeNoticesForAll(primary: Notice[], extra: Notice[]): Notice[]
  */
 export function getLatestKeywordNoticeAt(items: Notice[]): number | null {
   if (items.length === 0) return null;
-  
-  return items
+
+  const timestamps = items
     .map((notice) => new Date(notice.created_at ?? notice.date).getTime())
-    .reduce((latest, current) => (current > latest ? current : latest), 0);
+    .filter((t) => !isNaN(t));
+
+  if (timestamps.length === 0) return null;
+
+  return Math.max(...timestamps);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **버그 수정**: 키워드 알림 배지가 아예 표시되지 않던 근본 원인 수정
- **기능 추가**: 홈 화면 CategoryFilter "키워드" 버튼에 새 매치 여부 red dot 배지 추가
- **두 배지 동기화**: 동일한 `NotificationBadgeContext` 상태 사용 → 알림 확인 시 동시 클리어

## Root Cause

`updateKeywordBadge`에서 `localStorage`에 `keyword_notice_seen_at`이 없을 때(첫 방문 시), `seenAt`을 즉시 최신 공지 시간으로 설정하고 `count=0`을 반환했음. 결과적으로 모든 기존 공지가 "이미 본 것"으로 처리되어 배지가 영원히 0으로 표시됨.

## Changes

### `app/_context/NotificationBadgeContext.tsx`
- `updateKeywordBadge`: `seenAt`이 null이면 `seenTime = 0`으로 처리 → 첫 방문 시 모든 공지를 새 알림으로 표시
- `isNaN(seenTime)` 가드 추가 → localStorage 오염 방어
- `refreshKeywordNotices`에 try-catch 추가 → visibilitychange 이벤트에서 에러 전파 방지

### `app/_lib/utils/notice.ts`
- `getLatestKeywordNoticeAt`: NaN 날짜 필터링 추가, 모두 NaN이면 `null` 반환 (기존: `0` 반환 가능)

### `app/_components/ui/CategoryFilter.tsx`
- `hasNewKeywordNotices?: boolean` prop 추가
- "키워드" 버튼에 조건부 red dot 배지 렌더링 (활성 탭일 때는 숨김)

### `app/(main)/(home)/page.tsx`
- `useNotificationBadge()`에서 `hasNewKeywordNotices` destructure
- `CategoryFilter`에 `hasNewKeywordNotices` prop 전달

## Verification

- ✅ `npm run build` — TypeScript strict 모드 통과, 17개 정적 페이지 생성 성공
- ✅ `npm run lint` — 0 errors (기존 warnings만 존재)