### PR TITLE
fix(sidebar): 데스크톱 사이드바 접기/펼치기 애니메이션 부드럽게 개선

### DIFF
--- a/app/_components/layout/DesktopSidebar.tsx
+++ b/app/_components/layout/DesktopSidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
 import { useToast } from '@/_context/ToastContext';
 import SidebarContent from './SidebarContent';
@@ -31,6 +32,12 @@ export default function DesktopSidebar({ collapsed, onToggle }: DesktopSidebarPr
   const { showToast } = useToast();
   const { user, isLoggedIn } = useUser();
 
+  const [transitionEnabled, setTransitionEnabled] = useState(false);
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setTransitionEnabled(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
   const isAdmin = user?.role === 'admin' || user?.role === 'super_admin';
 
   const isActive = (matchPath: string) => {
@@ -38,9 +45,18 @@ export default function DesktopSidebar({ collapsed, onToggle }: DesktopSidebarPr
     return pathname.startsWith(matchPath);
   };
 
-  if (collapsed) {
-    return (
-      <aside className="hidden md:flex md:w-[60px] md:shrink-0 h-full border-r border-gray-100 bg-white overflow-hidden transition-all duration-300 flex-col items-center py-4 gap-1">
+  return (
+    <aside
+      className={`hidden md:flex md:shrink-0 h-full border-r border-gray-100 bg-white overflow-hidden relative${
+        transitionEnabled ? ' transition-[width] duration-300 ease-in-out' : ''
+      } ${collapsed ? 'md:w-[60px]' : 'md:w-[260px]'}`}
+    >
+      <div
+        className={`absolute inset-y-0 left-0 w-[60px] flex flex-col items-center py-4 gap-1 bg-white z-10${
+          transitionEnabled ? ' transition-opacity duration-200' : ''
+        } ${collapsed ? 'opacity-100 delay-100' : 'opacity-0 pointer-events-none'}`}
+        {...(!collapsed ? { inert: true } : {})}
+      >
         {/* Expand toggle */}
         <button
           onClick={onToggle}
@@ -105,17 +121,20 @@ export default function DesktopSidebar({ collapsed, onToggle }: DesktopSidebarPr
             <FiSettings size={20} />
           </button>
         )}
-      </aside>
-    );
-  }
+      </div>
 
-  return (
-    <aside className="hidden md:flex md:w-[260px] md:shrink-0 h-full border-r border-gray-100 bg-white overflow-y-auto overflow-x-hidden transition-all duration-300">
-      <SidebarContent
-        onNavigate={(path) => router.push(path)}
-        onShowToast={showToast}
-        onCollapse={onToggle}
-      />
+      <div
+        className={`w-[260px] shrink-0 h-full overflow-y-auto overflow-x-hidden${
+          transitionEnabled ? ' transition-opacity duration-200' : ''
+        } ${collapsed ? 'opacity-0 pointer-events-none' : 'opacity-100 delay-100'}`}
+        {...(collapsed ? { inert: true } : {})}
+      >
+        <SidebarContent
+          onNavigate={(path) => router.push(path)}
+          onShowToast={showToast}
+          onCollapse={onToggle}
+        />
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
## 요약

데스크톱 사이드바의 접기/펼치기 애니메이션이 부자연스러운 문제를 수정했습니다.

## 문제

- 사이드바 접기/펼치기 시 `if (collapsed)` 분기로 완전히 다른 JSX를 렌더링
- DOM 요소가 교체되어 `transition-all duration-300`이 있어도 CSS transition이 실제로 작동하지 않음
- 결과적으로 사이드바 폭이 뚝 끊기며 전환됨

## 해결

단일 `<aside>` 요소 안에 두 개의 레이어(collapsed 아이콘 / expanded SidebarContent)를 두고, width CSS transition + opacity cross-fade로 부드러운 전환을 구현했습니다.

## 주요 변경사항

- **단일 aside 구조**: `if/else` 분기 제거 → 하나의 `<aside>`에서 `transition-[width] duration-300 ease-in-out` 적용
- **교차 페이드**: collapsed 아이콘과 expanded SidebarContent가 opacity로 교차 전환 (`transition-opacity duration-200`)
- **초기 마운트 보호**: `transitionEnabled` state + `requestAnimationFrame`으로 페이지 첫 로드 시 애니메이션 플래시 방지
- **접근성**: 숨겨진 레이어에 `inert` 속성 적용 (Tab 키 / 스크린리더 접근 차단)
- **overflow 분리**: `<aside>`에 `overflow-hidden` (width 클리핑), expanded content wrapper에 `overflow-y-auto` (세로 스크롤 보존)

## 변경 파일

- `app/_components/layout/DesktopSidebar.tsx`