### PR TITLE
feat: 키워드 알림 배지 서버 동기화 + 홈 키워드 탭 배지 제거 + CodeRabbit 설정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+      - beta
+      - develop
+  tools:
+    eslint:
+      enabled: true
+    biome:
+      enabled: true
+    gitleaks:
+      enabled: true
+chat:
+  auto_reply: true

--- a/app/(main)/(home)/page.tsx
+++ b/app/(main)/(home)/page.tsx
@@ -81,7 +81,7 @@ function HomeContent() {
     scrollContainerRef,
   });
 
-  const { keywordNotices, keywordCount, refreshKeywordNotices, markKeywordNoticesSeen, hasNewKeywordNotices } = useNotificationBadge();
+  const { keywordNotices, keywordCount, refreshKeywordNotices, markKeywordNoticesSeen } = useNotificationBadge();
 
   // 게시판 목록
   const selectedBoards = selectedCategories;
@@ -252,17 +252,16 @@ function HomeContent() {
       {/* User Stats Banner */}
       <UserStatsBanner isLoggedIn={isLoggedIn} onSignupClick={() => router.push('/login')} />
 
-       {/* 카테고리 필터 */}
-       <div className="shrink-0" style={{ touchAction: 'none' }}>
-         <CategoryFilter
-           activeFilter={filter}
-           onFilterChange={(f) => setFilter(f as any)}
-           isLoggedIn={isLoggedIn}
-           onSettingsClick={() => router.push('/filter')}
-           onShowToast={showToast}
-           hasNewKeywordNotices={hasNewKeywordNotices}
-         />
-       </div>
+        {/* 카테고리 필터 */}
+        <div className="shrink-0" style={{ touchAction: 'none' }}>
+          <CategoryFilter
+            activeFilter={filter}
+            onFilterChange={(f) => setFilter(f as any)}
+            isLoggedIn={isLoggedIn}
+            onSettingsClick={() => router.push('/filter')}
+            onShowToast={showToast}
+          />
+        </div>
 
       {/* 키워드 필터일 때만 키워드 설정 바 표시 */}
       {filter === 'KEYWORD' && (

--- a/app/_components/layout/SharedHeader.tsx
+++ b/app/_components/layout/SharedHeader.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { FiUser, FiBell } from 'react-icons/fi';
 import Logo from '@/_components/ui/Logo';
 import { useNotificationBadge } from '@/_context/NotificationBadgeContext';
-import { useUser } from '@/_lib/hooks/useUser';
+import { useUserStore } from '@/_lib/store/useUserStore';
 
 interface SharedHeaderProps {
   title: string; // 'logo' | '프로필' | '친해지길 바래'
@@ -13,11 +13,11 @@ interface SharedHeaderProps {
 
 export default function SharedHeader({ title, onMenuClick }: SharedHeaderProps) {
   const router = useRouter();
-  const { isLoggedIn } = useUser();
   const { newKeywordCount, markKeywordNoticesSeen, keywordNotices } = useNotificationBadge();
+  const user = useUserStore((state) => state.user);
 
   const handleNotificationClick = () => {
-    const lastSeen = localStorage.getItem('keyword_notice_seen_at');
+    const lastSeen = user?.keyword_notice_seen_at ?? null;
     markKeywordNoticesSeen(keywordNotices);
     router.push(lastSeen ? `/notifications?last_seen=${encodeURIComponent(lastSeen)}` : '/notifications');
   };

--- a/app/_components/ui/CategoryFilter.tsx
+++ b/app/_components/ui/CategoryFilter.tsx
@@ -7,7 +7,6 @@ interface CategoryFilterProps {
   isLoggedIn: boolean; // 로그인 상태
   onSettingsClick: () => void; // 설정 버튼 클릭 콜백
   onShowToast: (message: string, type?: 'success' | 'error' | 'info') => void; // 토스트 메시지 표시
-  hasNewKeywordNotices?: boolean;
 }
 
 // 전체 필터 목록 (Guest/User 공통)
@@ -21,7 +20,7 @@ const ALL_FILTERS = [
 // 로그인 필요 필터 목록
 const LOGIN_REQUIRED_FILTERS = ['UNREAD', 'KEYWORD', 'FAVORITE'];
 
-export default function CategoryFilter({ activeFilter, onFilterChange, isLoggedIn, onSettingsClick, onShowToast, hasNewKeywordNotices }: CategoryFilterProps) {
+export default function CategoryFilter({ activeFilter, onFilterChange, isLoggedIn, onSettingsClick, onShowToast }: CategoryFilterProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
   useEffect(() => {
@@ -100,12 +99,9 @@ export default function CategoryFilter({ activeFilter, onFilterChange, isLoggedI
                  ? 'bg-gray-900 text-white shadow-md'
                  : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
                  }`}
-             >
-               {filter.label}
-               {filter.key === 'KEYWORD' && hasNewKeywordNotices && !isActive && (
-                 <span className="absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-gray-50" />
-               )}
-             </button>
+              >
+                {filter.label}
+              </button>
            );
         })}
       </div>

--- a/app/_context/NotificationBadgeContext.tsx
+++ b/app/_context/NotificationBadgeContext.tsx
@@ -4,6 +4,8 @@ import { createContext, useContext, useState, useEffect, useRef, Dispatch, SetSt
 import { Notice, getKeywordNotices, getMyKeywords } from '@/_lib/api';
 import { getLatestKeywordNoticeAt } from '@/_lib/utils/notice';
 import { useUser } from '@/_lib/hooks/useUser';
+import { useUserStore } from '@/_lib/store/useUserStore';
+import { updateUserProfile } from '@/_lib/api/user';
 
 interface NotificationBadgeContextType {
   keywordNotices: Notice[];
@@ -23,6 +25,7 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
   const [keywordCount, setKeywordCount] = useState<number | null>(null);
   const [hasNewKeywordNotices, setHasNewKeywordNotices] = useState(false);
   const [newKeywordCount, setNewKeywordCount] = useState(0);
+  const keywordNoticesRef = useRef<Notice[]>([]);
 
   // 레이스 컨디션 방어: markSeen 후 2초 이내 배지 재계산 스킵
   const _badgeClearedAt = useRef<number>(0);
@@ -81,8 +84,11 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       setNewKeywordCount(0);
       return;
     }
-     const seenAt = localStorage.getItem('keyword_notice_seen_at');
-     const seenTime = seenAt ? new Date(seenAt).getTime() : 0;
+      const user = useUserStore.getState().user;
+      const serverSeenAt = user?.keyword_notice_seen_at ?? null;
+      const localSeenAt = localStorage.getItem('keyword_notice_seen_at');
+      const seenAt = serverSeenAt ?? localSeenAt;
+      const seenTime = seenAt ? new Date(seenAt).getTime() : 0;
      if (isNaN(seenTime)) {
        // localStorage 오염 방어: 잘못된 값이면 모든 공지를 새 알림으로 처리
        setHasNewKeywordNotices(true);
@@ -104,24 +110,54 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
 
     // 빈 배열 fallback: 지금까지 본 것으로 처리
     if (items.length === 0) {
-      localStorage.setItem('keyword_notice_seen_at', new Date().toISOString());
+      const prevSeenAt = localStorage.getItem('keyword_notice_seen_at');
+      const timestamp = new Date().toISOString();
+      localStorage.setItem('keyword_notice_seen_at', timestamp);
       setNewKeywordCount(0);
       setHasNewKeywordNotices(false);
       _badgeClearedAt.current = Date.now();
+      updateUserProfile({ keyword_notice_seen_at: timestamp }).catch(() => {
+        if (prevSeenAt !== null) {
+          localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
+        } else {
+          localStorage.removeItem('keyword_notice_seen_at');
+        }
+        updateKeywordBadge(keywordNoticesRef.current);
+      });
       return;
     }
 
     const latest = getLatestKeywordNoticeAt(items);
     if (!latest) return; // 데이터 있는데 null이면 실제 버그 → 그냥 return
 
-    localStorage.setItem('keyword_notice_seen_at', new Date(latest).toISOString());
+    const prevSeenAt = localStorage.getItem('keyword_notice_seen_at');
+    const timestamp = new Date(latest).toISOString();
+    localStorage.setItem('keyword_notice_seen_at', timestamp);
     setHasNewKeywordNotices(false);
     setNewKeywordCount(0);
     _badgeClearedAt.current = Date.now();
+    updateUserProfile({ keyword_notice_seen_at: timestamp }).catch(() => {
+      if (prevSeenAt !== null) {
+        localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
+      } else {
+        localStorage.removeItem('keyword_notice_seen_at');
+      }
+      updateKeywordBadge(keywordNoticesRef.current);
+    });
   };
 
   useEffect(() => {
+    keywordNoticesRef.current = keywordNotices;
+  }, [keywordNotices]);
+
+  useEffect(() => {
     if (isLoggedIn) {
+      const user = useUserStore.getState().user;
+      if (user?.keyword_notice_seen_at) {
+        localStorage.setItem('keyword_notice_seen_at', user.keyword_notice_seen_at);
+      } else {
+        localStorage.removeItem('keyword_notice_seen_at');
+      }
       (async () => {
         const count = await loadKeywordCount();
         if (count > 0) {

--- a/app/_types/user.ts
+++ b/app/_types/user.ts
@@ -12,6 +12,7 @@ export interface UserProfile {
     role: string; // "user" | "admin" | "super_admin"
     user_type: 'student' | 'mentor';
     created_at: string;
+    keyword_notice_seen_at: string | null;
 }
 
 // 사용자 정보 업데이트 요청
@@ -22,6 +23,7 @@ export interface UserProfileUpdate {
     admission_year?: number;
     fcm_token?: string;
     profile_image?: string;
+    keyword_notice_seen_at?: string;
 }
 
 // 온보딩 완료 요청

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -15,7 +15,7 @@ export const MOCK_USER = {
   role: 'user',
   user_type: 'student' as const,
   created_at: '2024-01-01T00:00:00',
-  keyword_notice_seen_at: null,
+  keyword_notice_seen_at: null as string | null,
 };
 
 // 신규 유저 (온보딩 미완료)

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -15,6 +15,7 @@ export const MOCK_USER = {
   role: 'user',
   user_type: 'student' as const,
   created_at: '2024-01-01T00:00:00',
+  keyword_notice_seen_at: null,
 };
 
 // 신규 유저 (온보딩 미완료)
@@ -30,6 +31,7 @@ export const MOCK_NEW_USER = {
   role: 'user',
   user_type: 'student' as const,
   created_at: '2024-06-01T00:00:00',
+  keyword_notice_seen_at: null,
 };
 
 // 공지사항 목록

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -34,3 +34,47 @@ test.describe('알림 페이지 - 반응형', () => {
     await expect(asGuest.getByText('알림').first()).toBeVisible({ timeout: 10_000 });
   });
 });
+
+test.describe('키워드 배지 서버 동기화', () => {
+  test('벨 클릭 시 PATCH /users/me에 keyword_notice_seen_at 전송', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/');
+    await asLoggedInUser.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    const patchPromise = asLoggedInUser.waitForRequest(
+      (req) => req.url().includes('/users/me') && req.method() === 'PATCH',
+      { timeout: 15_000 }
+    );
+
+    await asLoggedInUser.locator('[aria-label="알림"]').click();
+    const patchReq = await patchPromise;
+
+    const body = JSON.parse(patchReq.postData() || '{}');
+    expect(body).toHaveProperty('keyword_notice_seen_at');
+    expect(body.keyword_notice_seen_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('홈 키워드 탭에 빨간 점 배지가 없음', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/');
+    await asLoggedInUser.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    await expect(asLoggedInUser.locator('.h-2.w-2.rounded-full.bg-red-500')).toHaveCount(0, {
+      timeout: 5000,
+    });
+  });
+
+  test('서버 seen_at 미래 값이면 배지 숫자 0', async ({ page }) => {
+    const { mockAuthenticatedAPIs } = await import('./fixtures/api-mocks');
+    const { MOCK_USER } = await import('./fixtures/test-data');
+
+    await mockAuthenticatedAPIs(page, {
+      user: { ...MOCK_USER, keyword_notice_seen_at: '2099-01-01T00:00:00Z' },
+    });
+
+    await page.goto('/');
+    await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    await expect(page.locator('[aria-label="알림"] .bg-red-500')).toHaveCount(0, {
+      timeout: 5000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `NotificationBadgeContext`가 서버의 `keyword_notice_seen_at` 값을 authority로 사용 (localStorage는 캐시)
- 벨 클릭 시 `PATCH /users/me`로 타임스탬프를 서버에 저장, 실패 시 localStorage rollback
- 홈 화면 CategoryFilter "키워드" 탭의 빨간 점 배지 제거 (헤더 벨 아이콘에서만 배지 표시)
- `SharedHeader`에서 localStorage 직접 접근 제거, Zustand store로 교체
- Playwright e2e 테스트 3개 추가
- CodeRabbit AI 코드 리뷰 설정 추가 (eslint + biome + gitleaks)

## Changes
- `app/_types/user.ts` — UserProfile, UserProfileUpdate에 `keyword_notice_seen_at` 추가
- `app/_context/NotificationBadgeContext.tsx` — 서버 동기화 + rollback 로직
- `app/_components/layout/SharedHeader.tsx` — localStorage → useUserStore
- `app/_components/ui/CategoryFilter.tsx` — `hasNewKeywordNotices` prop + 빨간 점 제거
- `app/(main)/(home)/page.tsx` — prop 전달 제거
- `e2e/fixtures/test-data.ts` — MOCK_USER에 필드 추가
- `e2e/notifications.spec.ts` — e2e 테스트 3개 추가
- `.coderabbit.yaml` — CodeRabbit 설정

## Test
```
npx tsc --noEmit                                          # 0 errors
npx playwright test e2e/notifications.spec.ts --reporter=list  # 16/16 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyword category notification badge behavior and display.

* **Improvements**
  * Notification state now persists correctly across user sessions and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->