### PR TITLE
fix(badge): 키워드 알림 배지 서버 동기화 + 홈 키워드 탭 배지 제거

### DIFF
--- a/app/_context/NotificationBadgeContext.tsx
+++ b/app/_context/NotificationBadgeContext.tsx
@@ -6,6 +6,12 @@ import { getLatestKeywordNoticeAt } from '@/_lib/utils/notice';
 import { useUser } from '@/_lib/hooks/useUser';
 import { useUserStore } from '@/_lib/store/useUserStore';
 import { updateUserProfile } from '@/_lib/api/user';
+import { getQueryClient } from '@/providers';
+
+// Normalize datetime to 3 decimal places (milliseconds) for cross-browser safety
+function normalizeDateTime(s: string): string {
+  return s.replace(/(\.\d{3})\d+/, '$1');
+}
 
 interface NotificationBadgeContextType {
   keywordNotices: Notice[];
@@ -88,7 +94,7 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       const serverSeenAt = user?.keyword_notice_seen_at ?? null;
       const localSeenAt = localStorage.getItem('keyword_notice_seen_at');
       const seenAt = serverSeenAt ?? localSeenAt;
-      const seenTime = seenAt ? new Date(seenAt).getTime() : 0;
+      const seenTime = seenAt ? new Date(normalizeDateTime(seenAt)).getTime() : 0;
      if (isNaN(seenTime)) {
        // localStorage 오염 방어: 잘못된 값이면 모든 공지를 새 알림으로 처리
        setHasNewKeywordNotices(true);
@@ -97,10 +103,10 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
      }
      setHasNewKeywordNotices(latest > seenTime);
 
-    const newCount = items.filter(notice => {
-      const noticeTime = new Date(notice.created_at ?? notice.date).getTime();
-      return noticeTime > seenTime;
-    }).length;
+     const newCount = items.filter(notice => {
+       const noticeTime = new Date(normalizeDateTime(notice.created_at ?? notice.date)).getTime();
+       return noticeTime > seenTime;
+     }).length;
 
     setNewKeywordCount(newCount);
   };
@@ -116,14 +122,19 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       setNewKeywordCount(0);
       setHasNewKeywordNotices(false);
       _badgeClearedAt.current = Date.now();
-      updateUserProfile({ keyword_notice_seen_at: timestamp }).catch(() => {
-        if (prevSeenAt !== null) {
-          localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
-        } else {
-          localStorage.removeItem('keyword_notice_seen_at');
-        }
-        updateKeywordBadge(keywordNoticesRef.current);
-      });
+      updateUserProfile({ keyword_notice_seen_at: timestamp })
+        .then((updatedUser) => {
+          useUserStore.getState().setUser(updatedUser);
+          getQueryClient()?.setQueryData(['user', 'profile'], updatedUser);
+        })
+        .catch(() => {
+          if (prevSeenAt !== null) {
+            localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
+          } else {
+            localStorage.removeItem('keyword_notice_seen_at');
+          }
+          updateKeywordBadge(keywordNoticesRef.current);
+        });
       return;
     }
 
@@ -136,14 +147,19 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
     setHasNewKeywordNotices(false);
     setNewKeywordCount(0);
     _badgeClearedAt.current = Date.now();
-    updateUserProfile({ keyword_notice_seen_at: timestamp }).catch(() => {
-      if (prevSeenAt !== null) {
-        localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
-      } else {
-        localStorage.removeItem('keyword_notice_seen_at');
-      }
-      updateKeywordBadge(keywordNoticesRef.current);
-    });
+    updateUserProfile({ keyword_notice_seen_at: timestamp })
+      .then((updatedUser) => {
+        useUserStore.getState().setUser(updatedUser);
+        getQueryClient()?.setQueryData(['user', 'profile'], updatedUser);
+      })
+      .catch(() => {
+        if (prevSeenAt !== null) {
+          localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
+        } else {
+          localStorage.removeItem('keyword_notice_seen_at');
+        }
+        updateKeywordBadge(keywordNoticesRef.current);
+      });
   };
 
   useEffect(() => {


### PR DESCRIPTION
변경 사항
키워드 배지 서버 동기화
- keyword_notice_seen_at (마지막 확인 시점)을 localStorage 대신 서버(users 테이블)에 저장하여 기기 간 배지 숫자 동기화
- 서버 값을 우선 사용하고 localStorage는 캐시로 유지
- PATCH 실패 시 localStorage rollback 처리

홈 키워드 탭 배지 제거
- CategoryFilter "키워드" 탭의 빨간 점 배지 제거
- 알림 배지는 헤더 벨 아이콘에서만 표시

배포 버그 수정
- 벨 클릭 후 새로고침하면 배지가 원래 숫자대로 다시 나타나는 버그 수정
- 원인: PATCH 성공 후 Zustand store와 React Query 캐시가 업데이트되지 않아 이전 값으로 배지 재계산
- 수정: PATCH .then()에서 store/cache 즉시 동기화 + 날짜 파싱 정규화(마이크로초 방어)

관련 PR
- 백엔드: #159

테스트
- e2e 16/16 통과
- TypeScript 오류 0건

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification badge consistency by standardizing how timestamps are processed across server and local data.
  * Enhanced state synchronization to ensure notification status updates reliably when marked as seen.
  * Better error handling to preserve local notification data if updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->