### PR TITLE
fix(notification): 키워드 알림 배지 새로고침 시 재등장하는 버그 근본 원인 수정

### DIFF
--- a/app/_context/NotificationBadgeContext.tsx
+++ b/app/_context/NotificationBadgeContext.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect, useRef, Dispatch, SetStateAction, ReactNode } from 'react';
-import { Notice, getKeywordNotices, getMyKeywords } from '@/_lib/api';
+import { createContext, useContext, useState, useEffect, useRef, useCallback, Dispatch, SetStateAction, ReactNode } from 'react';
+import { API_BASE_URL, Notice, getKeywordNotices, getMyKeywords } from '@/_lib/api';
 import { getLatestKeywordNoticeAt } from '@/_lib/utils/notice';
 import { useUser } from '@/_lib/hooks/useUser';
 import { useUserStore } from '@/_lib/store/useUserStore';
 import { updateUserProfile } from '@/_lib/api/user';
+import { getAccessToken } from '@/_lib/auth/tokenStore';
 import { getQueryClient } from '@/providers';
 
 // Normalize datetime to 3 decimal places (milliseconds) for cross-browser safety
@@ -35,8 +36,9 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
 
   // 레이스 컨디션 방어: markSeen 후 2초 이내 배지 재계산 스킵
   const _badgeClearedAt = useRef<number>(0);
+  const _syncPending = useRef(false);
 
-  const loadKeywordCount = async () => {
+  const loadKeywordCount = useCallback(async () => {
     try {
       const data = await getMyKeywords();
       const count = data.length;
@@ -47,33 +49,33 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       setKeywordCount(0);
       return 0;
     }
-  };
+  }, []);
 
-  const loadKeywordNoticesSilent = async () => {
+  const loadKeywordNoticesSilent = useCallback(async () => {
     try {
       const data = await getKeywordNotices(0, 200, true);
       setKeywordNotices(data);
     } catch (error) {
       console.error('Failed to load keyword notices', error);
     }
-  };
+  }, []);
 
-   const refreshKeywordNotices = async () => {
-     try {
-       const keywords = await getMyKeywords();
-       setKeywordCount(keywords.length);
-       if (keywords.length === 0) {
+    const refreshKeywordNotices = useCallback(async () => {
+      try {
+        const keywords = await getMyKeywords();
+        setKeywordCount(keywords.length);
+        if (keywords.length === 0) {
          setKeywordNotices([]);
          return;
        }
        const data = await getKeywordNotices(0, 200, true);
        setKeywordNotices(data);
-     } catch (error) {
-       console.error('Failed to refresh keyword notices', error);
-     }
-   };
+      } catch (error) {
+        console.error('Failed to refresh keyword notices', error);
+      }
+    }, []);
 
-  const updateKeywordBadge = (items: Notice[]) => {
+  const updateKeywordBadge = useCallback((items: Notice[]) => {
     if (typeof window === 'undefined') return;
 
     // 레이스 컨디션 방어: markSeen 후 2초 이내면 스킵
@@ -93,7 +95,14 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       const user = useUserStore.getState().user;
       const serverSeenAt = user?.keyword_notice_seen_at ?? null;
       const localSeenAt = localStorage.getItem('keyword_notice_seen_at');
-      const seenAt = serverSeenAt ?? localSeenAt;
+      let seenAt: string | null = null;
+      if (serverSeenAt && localSeenAt) {
+        const serverTime = new Date(normalizeDateTime(serverSeenAt)).getTime();
+        const localTime = new Date(normalizeDateTime(localSeenAt)).getTime();
+        seenAt = serverTime > localTime ? serverSeenAt : localSeenAt;
+      } else {
+        seenAt = serverSeenAt ?? localSeenAt;
+      }
       const seenTime = seenAt ? new Date(normalizeDateTime(seenAt)).getTime() : 0;
      if (isNaN(seenTime)) {
        // localStorage 오염 방어: 잘못된 값이면 모든 공지를 새 알림으로 처리
@@ -109,7 +118,7 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
      }).length;
 
     setNewKeywordCount(newCount);
-  };
+  }, []);
 
   const markKeywordNoticesSeen = (items: Notice[]) => {
     if (typeof window === 'undefined') return;
@@ -122,16 +131,16 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       setNewKeywordCount(0);
       setHasNewKeywordNotices(false);
       _badgeClearedAt.current = Date.now();
+      _syncPending.current = true;
       updateUserProfile({ keyword_notice_seen_at: timestamp })
         .then((updatedUser) => {
+          _syncPending.current = false;
           useUserStore.getState().setUser(updatedUser);
           getQueryClient()?.setQueryData(['user', 'profile'], updatedUser);
         })
         .catch(() => {
           if (prevSeenAt !== null) {
             localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
-          } else {
-            localStorage.removeItem('keyword_notice_seen_at');
           }
           updateKeywordBadge(keywordNoticesRef.current);
         });
@@ -147,16 +156,16 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
     setHasNewKeywordNotices(false);
     setNewKeywordCount(0);
     _badgeClearedAt.current = Date.now();
+    _syncPending.current = true;
     updateUserProfile({ keyword_notice_seen_at: timestamp })
       .then((updatedUser) => {
+        _syncPending.current = false;
         useUserStore.getState().setUser(updatedUser);
         getQueryClient()?.setQueryData(['user', 'profile'], updatedUser);
       })
       .catch(() => {
         if (prevSeenAt !== null) {
           localStorage.setItem('keyword_notice_seen_at', prevSeenAt);
-        } else {
-          localStorage.removeItem('keyword_notice_seen_at');
         }
         updateKeywordBadge(keywordNoticesRef.current);
       });
@@ -169,10 +178,28 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
   useEffect(() => {
     if (isLoggedIn) {
       const user = useUserStore.getState().user;
-      if (user?.keyword_notice_seen_at) {
-        localStorage.setItem('keyword_notice_seen_at', user.keyword_notice_seen_at);
-      } else {
-        localStorage.removeItem('keyword_notice_seen_at');
+      const serverSeenAt = user?.keyword_notice_seen_at ?? null;
+      const localSeenAt = localStorage.getItem('keyword_notice_seen_at');
+
+      if (serverSeenAt && localSeenAt) {
+        const serverTime = new Date(normalizeDateTime(serverSeenAt)).getTime();
+        const localTime = new Date(normalizeDateTime(localSeenAt)).getTime();
+        if (!isNaN(serverTime) && !isNaN(localTime)) {
+          localStorage.setItem('keyword_notice_seen_at', serverTime > localTime ? serverSeenAt : localSeenAt);
+        } else if (!isNaN(serverTime)) {
+          localStorage.setItem('keyword_notice_seen_at', serverSeenAt);
+        } else if (!isNaN(localTime)) {
+          localStorage.setItem('keyword_notice_seen_at', localSeenAt);
+        }
+      } else if (serverSeenAt && !localSeenAt) {
+        localStorage.setItem('keyword_notice_seen_at', serverSeenAt);
+      } else if (!serverSeenAt && localSeenAt) {
+        updateUserProfile({ keyword_notice_seen_at: localSeenAt })
+          .then((updatedUser) => {
+            useUserStore.getState().setUser(updatedUser);
+            getQueryClient()?.setQueryData(['user', 'profile'], updatedUser);
+          })
+          .catch(() => {});
       }
       (async () => {
         const count = await loadKeywordCount();
@@ -186,7 +213,7 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       setNewKeywordCount(0);
       setHasNewKeywordNotices(false);
     }
-  }, [isLoggedIn]);
+  }, [isLoggedIn, loadKeywordCount, loadKeywordNoticesSilent]);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -195,7 +222,7 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
       return;
     }
     updateKeywordBadge(keywordNotices);
-  }, [keywordNotices, isLoggedIn]);
+  }, [keywordNotices, isLoggedIn, updateKeywordBadge]);
 
   useEffect(() => {
     const handleVisibility = () => {
@@ -205,7 +232,39 @@ export function NotificationBadgeProvider({ children }: { children: ReactNode })
     };
     document.addEventListener('visibilitychange', handleVisibility);
     return () => document.removeEventListener('visibilitychange', handleVisibility);
-  }, [isLoggedIn]);
+  }, [isLoggedIn, refreshKeywordNotices]);
+
+  useEffect(() => {
+    const syncOnUnload = () => {
+      if (!_syncPending.current) return;
+      const localVal = localStorage.getItem('keyword_notice_seen_at');
+      if (!localVal) return;
+      const token = getAccessToken();
+      if (!token) return;
+
+      fetch(`${API_BASE_URL}/users/me`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ keyword_notice_seen_at: localVal }),
+        keepalive: true,
+      }).catch(() => {});
+      _syncPending.current = false;
+    };
+
+    const handleHidden = () => {
+      if (document.visibilityState === 'hidden') syncOnUnload();
+    };
+
+    document.addEventListener('visibilitychange', handleHidden);
+    window.addEventListener('pagehide', syncOnUnload);
+    return () => {
+      document.removeEventListener('visibilitychange', handleHidden);
+      window.removeEventListener('pagehide', syncOnUnload);
+    };
+  }, []);
 
   return (
     <NotificationBadgeContext.Provider

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -78,3 +78,57 @@ test.describe('키워드 배지 서버 동기화', () => {
     });
   });
 });
+
+test.describe('키워드 배지 localStorage 새로고침 시나리오', () => {
+  test('markKeywordNoticesSeen 후 localStorage keyword_notice_seen_at 값이 존재해야 함', async ({ page }) => {
+    const { mockAuthenticatedAPIs } = await import('./fixtures/api-mocks');
+
+    await mockAuthenticatedAPIs(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('keyword_notice_seen_at', '2024-01-01T00:00:00.000Z');
+    });
+
+    await page.goto('/notifications');
+    await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    const value = await page.evaluate(() => localStorage.getItem('keyword_notice_seen_at'));
+    expect(value).not.toBeNull();
+  });
+
+  test('keyword_notice_seen_at localStorage 값이 새로고침 후에도 유지되어야 함', async ({ page }) => {
+    const { mockAuthenticatedAPIs } = await import('./fixtures/api-mocks');
+
+    await mockAuthenticatedAPIs(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('keyword_notice_seen_at', '2024-06-01T12:00:00.000Z');
+    });
+
+    await page.goto('/');
+    await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    await page.reload();
+    await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    const value = await page.evaluate(() => localStorage.getItem('keyword_notice_seen_at'));
+    expect(value).not.toBeNull();
+  });
+
+  test('서버 keyword_notice_seen_at이 null이어도 기존 localStorage 값을 삭제하지 않아야 함', async ({ page }) => {
+    const { mockAuthenticatedAPIs } = await import('./fixtures/api-mocks');
+    const { MOCK_USER } = await import('./fixtures/test-data');
+
+    await mockAuthenticatedAPIs(page, {
+      user: { ...MOCK_USER, keyword_notice_seen_at: null },
+    });
+    await page.addInitScript(() => {
+      localStorage.setItem('keyword_notice_seen_at', '2023-12-01T00:00:00.000Z');
+    });
+
+    await page.goto('/');
+    await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
+
+    const value = await page.evaluate(() => localStorage.getItem('keyword_notice_seen_at'));
+    expect(value).not.toBeNull();
+    expect(value).toBe('2023-12-01T00:00:00.000Z');
+  });
+});

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -84,13 +84,17 @@ test.describe('키워드 배지 localStorage 새로고침 시나리오', () => {
     const { mockAuthenticatedAPIs } = await import('./fixtures/api-mocks');
 
     await mockAuthenticatedAPIs(page);
-    await page.addInitScript(() => {
-      localStorage.setItem('keyword_notice_seen_at', '2024-01-01T00:00:00.000Z');
-    });
 
-    await page.goto('/notifications');
+    await page.goto('/');
     await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
 
+    // 벨 클릭 → markKeywordNoticesSeen(keywordNotices) 호출 → localStorage 설정
+    await page.locator('[aria-label="알림"]').click();
+
+    // 네비게이션 완료 대기 (홈 → /notifications)
+    await page.waitForURL('**/notifications**', { timeout: 10_000 });
+
+    // markKeywordNoticesSeen이 localStorage에 keyword_notice_seen_at을 설정했는지 확인
     const value = await page.evaluate(() => localStorage.getItem('keyword_notice_seen_at'));
     expect(value).not.toBeNull();
   });

--- a/e2e/notifications.spec.ts
+++ b/e2e/notifications.spec.ts
@@ -109,8 +109,12 @@ test.describe('키워드 배지 localStorage 새로고침 시나리오', () => {
     await page.reload();
     await page.locator('[aria-label="알림"]').waitFor({ timeout: 10_000 });
 
+    // localStorage 보존 확인
     const value = await page.evaluate(() => localStorage.getItem('keyword_notice_seen_at'));
     expect(value).not.toBeNull();
+
+    // 새로고침 후 배지 카운트가 0 이어야 함 (숫자 배지 없음)
+    await expect(page.locator('[aria-label="알림"] .bg-red-500')).toHaveCount(0, { timeout: 5000 });
   });
 
   test('서버 keyword_notice_seen_at이 null이어도 기존 localStorage 값을 삭제하지 않아야 함', async ({ page }) => {


### PR DESCRIPTION
## 요약

키워드 알림 배지가 알림 페이지 방문 후 사라지지만, **새로고침하면 기존 숫자가 다시 나타나는 반복 버그**의 근본 원인 3가지를 수정합니다.

## 근본 원인 분석

| # | 원인 | 설명 |
|---|------|------|
| 1 | **파괴적 localStorage 삭제** | init effect에서 서버 `keyword_notice_seen_at`이 null이면 `localStorage.removeItem()`을 호출 → 새로고침 시 "본 시점" 정보가 사라져 모든 공지가 새 알림으로 처리됨 |
| 2 | **잘못된 우선순위** | `serverSeenAt ?? localSeenAt`으로 서버 값을 무조건 우선 → 로컬에서 방금 업데이트한 최신 값이 무시됨 |
| 3 | **페이지 언로드 시 API 미완료** | `updateUserProfile()`이 fire-and-forget → 새로고침하면 fetch가 abort되어 서버에 저장 안 됨 |

## 수정 내용

### 1. WAL(Write-Ahead Log) 패턴 도입 (`init effect`)

`localStorage.removeItem()` 을 완전히 제거하고, 4가지 케이스로 분기:

- **서버 O + 로컬 O** → `max(서버, 로컬)` 을 localStorage에 저장
- **서버 O + 로컬 X** → 서버 값을 localStorage에 복사
- **서버 X + 로컬 O** → localStorage 유지 + 서버에 push (WAL replay)
- **서버 X + 로컬 X** → 아무것도 안 함

### 2. `max(server, local)` 우선순위 (`updateKeywordBadge`)

서버와 로컬 값이 모두 존재할 때, 타임스탬프를 비교하여 **더 최신인 값**을 사용합니다.

### 3. 페이지 언로드 동기화 (새 `useEffect`)

- `visibilitychange(hidden)` + `pagehide` 이벤트에서 `fetch(keepalive: true)` 로 서버에 동기화
- `_syncPending` ref로 dirty flag 관리 → 불필요한 PATCH 방지
- `sendBeacon` 미사용 (JWT 헤더 전송 불가)
- `beforeunload`/`unload` 미사용 (iOS Safari 미지원)

## 변경 파일

| 파일 | 변경 | 설명 |
|------|------|------|
| `app/_context/NotificationBadgeContext.tsx` | 수정 | 핵심 버그 3건 수정 |
| `e2e/notifications.spec.ts` | 추가 | 배지 새로고침 시나리오 E2E 테스트 3건 추가 |

## 테스트

- [x] `npm run build` 성공
- [x] `npx tsc --noEmit` 에러 없음
- [x] 금지 패턴 미사용 확인 (`sendBeacon`, `beforeunload`, `removeItem`)
- [x] E2E 테스트 추가: localStorage 보존, 새로고침 후 유지, 서버 null 시 비파괴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced notification badge state synchronization and persistence across page reloads and browser sessions.
  * Improved reliability of notification status tracking with better handling during page navigation and unload events.

* **Tests**
  * Added comprehensive test coverage for notification badge persistence scenarios and state management across page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->