### PR TITLE
perf: 초기 로딩 워터폴 병렬화 — auth/check 제거 및 /users/me/init 통합

### DIFF
--- a/app/(main)/(home)/page.tsx
+++ b/app/(main)/(home)/page.tsx
@@ -57,10 +57,10 @@ function HomeContent() {
 
   // 모든 의존성이 준비되면 쿼리 활성화
   useEffect(() => {
-    if (isMounted && isAuthLoaded && !isCategoriesLoading && selectedCategories.length > 0) {
+    if (isMounted && !isCategoriesLoading && selectedCategories.length > 0) {
       setIsQueryReady(true);
     }
-  }, [isMounted, isAuthLoaded, isCategoriesLoading, selectedCategories.length]);
+  }, [isMounted, isCategoriesLoading, selectedCategories.length]);
 
   // Pull to Refresh용 스크롤 컨테이너 ref 초기화
   const { scrollContainerRef, isPulling, pullDistance, refreshing } = usePullToRefresh({

--- a/app/_lib/api/auth.ts
+++ b/app/_lib/api/auth.ts
@@ -36,16 +36,6 @@ export const isAuthReady = () => isAuthInitialized;
 // 토큰 존재 여부 확인
 export const checkHasToken = () => hasAccessToken();
 
-// Refresh Token 쿠키 존재 여부 확인 (경량 체크)
-export const checkRefreshToken = async (): Promise<boolean> => {
-    try {
-        const response = await authApi.get<{ hasToken: boolean }>('/auth/check');
-        return response.data.hasToken;
-    } catch (error) {
-        return false;
-    }
-};
-
 // Refresh Token으로 새 Access Token 발급
 export const refreshAccessToken = async (): Promise<string | null> => {
     try {
@@ -59,6 +49,16 @@ export const refreshAccessToken = async (): Promise<string | null> => {
         return null;
     } catch (error) {
         clearAccessToken();
+        if (
+            typeof window !== 'undefined' &&
+            error instanceof Error &&
+            'response' in (error as unknown as Record<string, unknown>)
+        ) {
+            const status = (error as {response?: {status?: number}}).response?.status;
+            if (status === 401 || status === 403) {
+                localStorage.removeItem('session_hint');
+            }
+        }
         return null;
     }
 };
@@ -76,6 +76,13 @@ export const initializeAuth = async (): Promise<boolean> => {
     }
 
     initializationPromise = (async () => {
+        // session_hint 없으면 게스트 — refresh 시도 없이 조기 반환
+        const hasSessionHint = typeof window !== 'undefined' &&
+                                localStorage.getItem('session_hint') !== null;
+        if (!hasSessionHint) {
+            isAuthInitialized = true;
+            return false;
+        }
         try {
             const token = await refreshAccessToken();
             isAuthInitialized = true;
@@ -99,6 +106,9 @@ export const logoutUser = async (): Promise<void> => {
         // 로그아웃 요청 실패해도 로컬 상태는 정리
     } finally {
         clearAccessToken();
+        if (typeof window !== 'undefined') {
+            localStorage.removeItem('session_hint');
+        }
         isAuthInitialized = false;
     }
 };
@@ -108,4 +118,7 @@ export const resetAuthState = (): void => {
     isAuthInitialized = false;
     initializationPromise = null;
     clearAccessToken();
+    if (typeof window !== 'undefined') {
+        localStorage.removeItem('session_hint');
+    }
 };

--- a/app/_lib/api/auth.ts
+++ b/app/_lib/api/auth.ts
@@ -77,16 +77,6 @@ export const initializeAuth = async (): Promise<boolean> => {
 
     initializationPromise = (async () => {
         try {
-            // 1. 먼저 refresh token 쿠키가 있는지 확인 (경량 체크)
-            const hasRefreshToken = await checkRefreshToken();
-
-            // 2. 쿠키가 없으면 refresh 요청하지 않음 (401 에러 방지)
-            if (!hasRefreshToken) {
-                isAuthInitialized = true;
-                return false;
-            }
-
-            // 3. 쿠키가 있으면 refresh 요청
             const token = await refreshAccessToken();
             isAuthInitialized = true;
             return !!token;

--- a/app/_lib/api/user.ts
+++ b/app/_lib/api/user.ts
@@ -25,6 +25,12 @@ export const getUserSubscriptions = async () => {
     return response.data;
 };
 
+// 유저 정보 + 구독 합산 조회 (병렬화용)
+export const getUserInit = async () => {
+    const response = await api.get<{ user: UserProfile; subscriptions: UserSubscription[] }>('/users/me/init');
+    return response.data;
+};
+
 // 구독 업데이트 (전체 교체)
 export const updateUserSubscriptions = async (boardCodes: string[]) => {
     const response = await api.put<UpdateSubscriptionsResponse>('/users/me/subscriptions', {

--- a/app/_lib/auth/tokenStore.ts
+++ b/app/_lib/auth/tokenStore.ts
@@ -17,7 +17,14 @@ export function getAccessToken(): string | null {
  * Access Token 설정
  */
 export function setAccessToken(token: string | null): void {
-    accessToken = token;
+    if (token) {
+        accessToken = token;
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('session_hint', 'active');
+        }
+    } else {
+        accessToken = null;
+    }
 }
 
 /**

--- a/app/_lib/hooks/useSelectedCategories.ts
+++ b/app/_lib/hooks/useSelectedCategories.ts
@@ -1,10 +1,9 @@
 import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { BOARD_LIST, GUEST_FILTER_KEY, GUEST_DEFAULT_BOARDS } from '@/_lib/constants/boards';
-import { getUserSubscriptions, updateUserSubscriptions } from '@/_lib/api';
+import { getUserInit, getUserSubscriptions, updateUserSubscriptions } from '@/_lib/api';
 import { useAuthInitialized } from '@/providers';
 import { checkHasToken } from '@/_lib/api/auth';
-import type { UserSubscription } from '@/_types/user';
 
 const USER_STORAGE_KEY = 'my_subscribed_categories'; // 로그인 사용자 캐시 키
 
@@ -37,19 +36,29 @@ export function useSelectedCategories() {
       }
 
       if (isLoggedIn) {
-        // ✅ User: React Query 캐시 우선 조회 (useUser가 /users/me/init으로 이미 fetch했을 수 있음)
+        // ✅ User: ensureQueryData로 ['user', 'init'] 캐시 활용 (race condition 해결)
         try {
-          const cached = queryClient.getQueryData<UserSubscription[]>(['user', 'subscriptions']);
-          const subscriptions = cached ?? await getUserSubscriptions();
+          const initData = await queryClient.ensureQueryData({
+            queryKey: ['user', 'init'],
+            queryFn: getUserInit,
+          });
+          const subscriptions = initData.subscriptions;
           const boardCodes = subscriptions.map(sub => sub.board_code);
           setSelectedCategories(boardCodes);
 
           // localStorage에 캐시 저장
           localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(boardCodes));
         } catch (error) {
-          console.error('Failed to load subscriptions from API:', error);
-          // API 실패 시 빈 배열 (page.tsx에서 home_campus로 fallback)
-          setSelectedCategories([]);
+          try {
+            const subscriptions = await getUserSubscriptions();
+            const boardCodes = subscriptions.map(sub => sub.board_code);
+            setSelectedCategories(boardCodes);
+            localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(boardCodes));
+          } catch (fallbackError) {
+            console.error('Failed to load subscriptions:', fallbackError);
+            // API 실패 시 빈 배열 (page.tsx에서 home_campus로 fallback)
+            setSelectedCategories([]);
+          }
         }
       } else {
         // ✅ Guest: localStorage에서만 읽기 (API 호출 차단)

--- a/app/_lib/hooks/useSelectedCategories.ts
+++ b/app/_lib/hooks/useSelectedCategories.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { BOARD_LIST, GUEST_FILTER_KEY, GUEST_DEFAULT_BOARDS } from '@/_lib/constants/boards';
 import { getUserSubscriptions, updateUserSubscriptions } from '@/_lib/api';
-import { useUser } from '@/_lib/hooks/useUser';
+import { useAuthInitialized } from '@/providers';
+import { checkHasToken } from '@/_lib/api/auth';
 
 const USER_STORAGE_KEY = 'my_subscribed_categories'; // 로그인 사용자 캐시 키
 
@@ -16,13 +17,15 @@ export function useSelectedCategories() {
   // SSR-safe: 서버와 클라이언트의 초기 상태를 동일하게 유지
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const { isLoggedIn, isAuthLoaded } = useUser();
+  const isAuthInitialized = useAuthInitialized();
+  const hasToken = isAuthInitialized && checkHasToken();
+  const isLoggedIn = hasToken;
 
   // 초기 로딩: 로그인 여부에 따라 다른 저장소 사용
   useEffect(() => {
     const loadCategories = async () => {
       // 인증 상태 확인이 안 되었다면 대기
-      if (!isAuthLoaded) return;
+      if (!isAuthInitialized) return;
 
       // 클라이언트에서만 실행
       if (typeof window === 'undefined') {
@@ -80,7 +83,7 @@ export function useSelectedCategories() {
     };
 
     loadCategories();
-  }, [isAuthLoaded, isLoggedIn]);
+  }, [isAuthInitialized, hasToken]);
 
   // 선택 변경: 로그인 여부에 따라 다른 저장소에 저장
   const updateSelectedCategories = async (categories: string[]) => {

--- a/app/_lib/hooks/useSelectedCategories.ts
+++ b/app/_lib/hooks/useSelectedCategories.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { BOARD_LIST, GUEST_FILTER_KEY, GUEST_DEFAULT_BOARDS } from '@/_lib/constants/boards';
 import { getUserSubscriptions, updateUserSubscriptions } from '@/_lib/api';
 import { useAuthInitialized } from '@/providers';
 import { checkHasToken } from '@/_lib/api/auth';
+import type { UserSubscription } from '@/_types/user';
 
 const USER_STORAGE_KEY = 'my_subscribed_categories'; // 로그인 사용자 캐시 키
 
@@ -18,6 +20,7 @@ export function useSelectedCategories() {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const isAuthInitialized = useAuthInitialized();
+  const queryClient = useQueryClient();
   const hasToken = isAuthInitialized && checkHasToken();
   const isLoggedIn = hasToken;
 
@@ -34,9 +37,10 @@ export function useSelectedCategories() {
       }
 
       if (isLoggedIn) {
-        // ✅ User: 백엔드 API에서 구독 정보 가져오기
+        // ✅ User: React Query 캐시 우선 조회 (useUser가 /users/me/init으로 이미 fetch했을 수 있음)
         try {
-          const subscriptions = await getUserSubscriptions();
+          const cached = queryClient.getQueryData<UserSubscription[]>(['user', 'subscriptions']);
+          const subscriptions = cached ?? await getUserSubscriptions();
           const boardCodes = subscriptions.map(sub => sub.board_code);
           setSelectedCategories(boardCodes);
 
@@ -83,7 +87,7 @@ export function useSelectedCategories() {
     };
 
     loadCategories();
-  }, [isAuthInitialized, hasToken]);
+  }, [isAuthInitialized, hasToken, isLoggedIn, queryClient]);
 
   // 선택 변경: 로그인 여부에 따라 다른 저장소에 저장
   const updateSelectedCategories = async (categories: string[]) => {

--- a/app/_lib/hooks/useUser.ts
+++ b/app/_lib/hooks/useUser.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getUserProfile, getUserInit, updateUserProfile, checkHasToken } from '@/_lib/api';
+import { getUserInit, updateUserProfile, checkHasToken } from '@/_lib/api';
 import { useUserStore } from '@/_lib/store/useUserStore';
 import type { UserProfileUpdate } from '@/_types/user';
 import { useEffect, useState } from 'react';

--- a/app/_lib/hooks/useUser.ts
+++ b/app/_lib/hooks/useUser.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getUserProfile, updateUserProfile, checkHasToken } from '@/_lib/api';
+import { getUserProfile, getUserInit, updateUserProfile, checkHasToken } from '@/_lib/api';
 import { useUserStore } from '@/_lib/store/useUserStore';
 import type { UserProfileUpdate } from '@/_types/user';
 import { useEffect, useState } from 'react';
@@ -17,13 +17,14 @@ export function useUser() {
     const setUser = useUserStore((state) => state.setUser);
     const [isInternalLoaded, setIsInternalLoaded] = useState(false);
     const isAuthInitialized = useAuthInitialized();
+    const queryClient = useQueryClient();
 
     // 인증 초기화 완료 후 메모리의 토큰 확인
     const hasToken = isAuthInitialized && checkHasToken();
 
     const query = useQuery({
-        queryKey: ['user', 'profile'],
-        queryFn: getUserProfile,
+        queryKey: ['user', 'init'],
+        queryFn: getUserInit,
         staleTime: 1000 * 60 * 5, // 5분
         enabled: hasToken,
         retry: (failureCount, error) => {
@@ -38,7 +39,12 @@ export function useUser() {
     // 조회 성공 시 Zustand Store 업데이트 / 실패 시 초기화
     useEffect(() => {
         if (query.data) {
-            setUser(query.data);
+            // 1. Zustand Store 업데이트
+            setUser(query.data.user);
+            // 2. ['user', 'profile'] 캐시 동기화 (7곳의 setQueryData 호환성 유지)
+            queryClient.setQueryData(['user', 'profile'], query.data.user);
+            // 3. ['user', 'subscriptions'] 캐시 동기화 (useSelectedCategories 캐시 우선 조회용)
+            queryClient.setQueryData(['user', 'subscriptions'], query.data.subscriptions);
             setIsInternalLoaded(true);
         } else if (query.isError) {
             setUser(null);
@@ -48,7 +54,7 @@ export function useUser() {
             setUser(null);
             setIsInternalLoaded(true);
         }
-    }, [query.data, query.isError, hasToken, isAuthInitialized, setUser]);
+    }, [query.data, query.isError, hasToken, isAuthInitialized, setUser, queryClient]);
 
     return {
         ...query,

--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -116,8 +116,7 @@ export async function mockAuthenticatedAPIs(page: Page, options?: {
 }) {
   const user = options?.isNewUser ? MOCK_NEW_USER : (options?.user ?? MOCK_USER);
 
-  // session_hint 플래그 설정 (로그인 상태 시뮬레이션)
-  await page.evaluate(() => localStorage.setItem('session_hint', 'active'));
+  await page.addInitScript(() => localStorage.setItem('session_hint', 'active'));
 
   // Auth refresh: 성공
   await page.route('**/auth/refresh', apiOnly((route) =>

--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -116,6 +116,9 @@ export async function mockAuthenticatedAPIs(page: Page, options?: {
 }) {
   const user = options?.isNewUser ? MOCK_NEW_USER : (options?.user ?? MOCK_USER);
 
+  // session_hint 플래그 설정 (로그인 상태 시뮬레이션)
+  await page.evaluate(() => localStorage.setItem('session_hint', 'active'));
+
   // Auth refresh: 성공
   await page.route('**/auth/refresh', apiOnly((route) =>
     json(route, { access_token: 'test-jwt-token-for-e2e' })

--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -53,11 +53,6 @@ function json(route: Route, data: unknown, status = 200) {
  * 게스트 (비로그인) 상태 API 모킹
  */
 export async function mockGuestAPIs(page: Page) {
-  // Auth check: 토큰 없음
-  await page.route('**/auth/check', apiOnly((route) =>
-    json(route, { hasToken: false })
-  ));
-
   // Auth refresh: 실패
   await page.route('**/auth/refresh', apiOnly((route) =>
     json(route, { detail: 'Not authenticated' }, 401)
@@ -121,14 +116,14 @@ export async function mockAuthenticatedAPIs(page: Page, options?: {
 }) {
   const user = options?.isNewUser ? MOCK_NEW_USER : (options?.user ?? MOCK_USER);
 
-  // Auth check: 토큰 있음
-  await page.route('**/auth/check', apiOnly((route) =>
-    json(route, { hasToken: true })
-  ));
-
   // Auth refresh: 성공
   await page.route('**/auth/refresh', apiOnly((route) =>
     json(route, { access_token: 'test-jwt-token-for-e2e' })
+  ));
+
+  // Users/me/init: 유저 정보 + 구독 합산 (병렬화용)
+  await page.route('**/users/me/init', apiOnly((route) =>
+    json(route, { user, subscriptions: MOCK_SUBSCRIPTIONS })
   ));
 
   // Users/me


### PR DESCRIPTION
## Summary

모바일 환경에서 앱 진입 시 5단계 순차 네트워크 요청을 2~3단계로 줄여 체감 로딩 시간을 단축합니다.

**Before** (5 sequential rounds):
```
auth/check → auth/refresh → users/me → subscriptions → notices
```

**After** (2-3 rounds):
```
auth/refresh → users/me/init (user + subscriptions 동시) → notices
```

## Changes

### 1. `app/_lib/api/auth.ts` — `/auth/check` 제거
- `initializeAuth()`에서 `checkRefreshToken()` 사전 체크를 제거하고, 바로 `refreshAccessToken()` 호출
- refresh token이 없으면 서버가 401 반환 → 동일한 결과, 왕복 1회 절약

### 2. `app/_lib/api/user.ts` — `getUserInit()` 추가
- 새 백엔드 엔드포인트 `GET /users/me/init`을 호출하는 API 함수
- 기존 `getUserProfile`, `getUserSubscriptions` 함수는 그대로 유지

### 3. `app/_lib/hooks/useUser.ts` — 이중 캐시 전략
- queryKey: `['user', 'profile']` → `['user', 'init']`
- queryFn: `getUserProfile` → `getUserInit`
- useEffect에서 응답을 3곳에 분배:
  - `setUser(query.data.user)` — Zustand Store
  - `setQueryData(['user', 'profile'], query.data.user)` — 7곳의 기존 setQueryData 호환성 유지
  - `setQueryData(['user', 'subscriptions'], query.data.subscriptions)` — 구독 캐시

### 4. `app/_lib/hooks/useSelectedCategories.ts` — useUser 의존 제거
- `useUser()` 훅 대신 `useAuthInitialized()` + `checkHasToken()`으로 직접 게이트
- 구독 데이터를 React Query 캐시(`['user', 'subscriptions']`)에서 우선 조회, 없으면 API fallback
- auth 완료 즉시 구독 로딩 시작 가능 (useUser 완료 대기 불필요)

### 5. `app/(main)/(home)/page.tsx` — isQueryReady 디커플링
- 공지 쿼리 활성화 조건에서 `isAuthLoaded` 제거
- 카테고리 로딩 완료 즉시 공지 fetch 시작

### 6. `e2e/fixtures/api-mocks.ts` — E2E mock 동기화
- `/auth/check` mock 제거 (guest + authenticated)
- `/users/me/init` mock 추가 (authenticated)

## Compatibility

`setQueryData(['user', 'profile'], UserProfile)` 호출하는 7곳 모두 호환성 유지됨:
- `useUpdateUser` onSuccess
- `onboarding/page.tsx`
- `OnboardingModal.tsx` (3곳)
- `NotificationBadgeContext.tsx` (2곳)

`useUser()` 반환 인터페이스 불변: `user`, `isLoggedIn`, `isAuthLoaded`, `refetch` 등

## Dependencies

- **Backend PR 필요**: `jbnu-alarm-api-v1` 의 `feat/auth-waterfall-parallelization` 브랜치가 먼저 배포되어야 합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined authentication and session initialization to reduce startup work for guest and signed-in users.
  * Improved caching and preloading of user profile and subscription data to cut redundant network requests and speed load times.
* **New Features**
  * Added a combined user+subscriptions initialization path to parallelize data loading.
* **Tests**
  * Updated end-to-end mocks to reflect the new initialization flow and client-side session behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->