### PR TITLE
feat(home): 로고 탭 → 스크롤 투 탑 + 새로고침

### DIFF
--- a/app/(main)/(home)/page.tsx
+++ b/app/(main)/(home)/page.tsx
@@ -83,22 +83,6 @@ function HomeContent() {
 
   const { keywordNotices, keywordCount, refreshKeywordNotices, markKeywordNoticesSeen } = useNotificationBadge();
 
-  // Logo tap 이벤트 핸들러
-  const handleLogoTap = useCallback(async () => {
-    scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
-    if (filter === 'KEYWORD') {
-      await refreshKeywordNotices();
-    } else {
-      await refetch();
-    }
-  }, [filter, refetch, refreshKeywordNotices, scrollContainerRef]);
-
-  // Logo tap 이벤트 리스너 등록
-  useEffect(() => {
-    window.addEventListener('logo-tap', handleLogoTap);
-    return () => window.removeEventListener('logo-tap', handleLogoTap);
-  }, [handleLogoTap]);
-
   // 게시판 목록
   const selectedBoards = selectedCategories;
   const selectedBoardsParam = useMemo(
@@ -130,6 +114,20 @@ function HomeContent() {
     refetchOnMount: false,
     refetchOnReconnect: false,
   });
+
+  const handleLogoTap = useCallback(async () => {
+    scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    if (filter === 'KEYWORD') {
+      await refreshKeywordNotices();
+    } else {
+      await refetch();
+    }
+  }, [filter, refetch, refreshKeywordNotices, scrollContainerRef]);
+
+  useEffect(() => {
+    window.addEventListener('logo-tap', handleLogoTap);
+    return () => window.removeEventListener('logo-tap', handleLogoTap);
+  }, [handleLogoTap]);
 
   // 모든 페이지의 공지사항을 하나의 배열로 합치기
   const notices = useMemo<Notice[]>(() => {

--- a/app/(main)/(home)/page.tsx
+++ b/app/(main)/(home)/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useMemo, useRef, Suspense } from 'react';
+import { useEffect, useState, useMemo, useRef, Suspense, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useInView } from 'react-intersection-observer';
@@ -82,6 +82,22 @@ function HomeContent() {
   });
 
   const { keywordNotices, keywordCount, refreshKeywordNotices, markKeywordNoticesSeen } = useNotificationBadge();
+
+  // Logo tap 이벤트 핸들러
+  const handleLogoTap = useCallback(async () => {
+    scrollContainerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    if (filter === 'KEYWORD') {
+      await refreshKeywordNotices();
+    } else {
+      await refetch();
+    }
+  }, [filter, refetch, refreshKeywordNotices, scrollContainerRef]);
+
+  // Logo tap 이벤트 리스너 등록
+  useEffect(() => {
+    window.addEventListener('logo-tap', handleLogoTap);
+    return () => window.removeEventListener('logo-tap', handleLogoTap);
+  }, [handleLogoTap]);
 
   // 게시판 목록
   const selectedBoards = selectedCategories;

--- a/app/_components/layout/SharedHeader.tsx
+++ b/app/_components/layout/SharedHeader.tsx
@@ -38,7 +38,14 @@ export default function SharedHeader({ title, onMenuClick }: SharedHeaderProps) 
       {/* Center: Logo or title */}
       <div className="absolute left-1/2 -translate-x-1/2 transform">
         {title === 'logo' ? (
-          <Logo className="h-7 w-auto text-gray-900" />
+          <button
+            type="button"
+            aria-label="맨 위로 이동 및 새로고침"
+            className="appearance-none bg-transparent border-none p-0 m-0 leading-none cursor-pointer active:scale-95 transition-transform"
+            onClick={() => window.dispatchEvent(new CustomEvent('logo-tap'))}
+          >
+            <Logo className="h-7 w-auto text-gray-900" />
+          </button>
         ) : (
           <h1 className="text-base font-bold text-gray-800 whitespace-nowrap">{title}</h1>
         )}

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -120,3 +120,71 @@ test.describe('홈 페이지 - 데스크톱 뷰', () => {
     await expect(menuBtn).toBeHidden();
   });
 });
+
+test.describe('홈 페이지 - 로고 탭', () => {
+  test('로고 버튼이 존재하고 탭 가능하다', async ({ asGuest }) => {
+    await asGuest.goto('/');
+    const logoBtn = asGuest.getByRole('button', { name: /맨 위로 이동/ });
+    await expect(logoBtn).toBeVisible();
+    await expect(logoBtn).toBeEnabled();
+  });
+
+  test('로고 탭 시 logo-tap CustomEvent가 발생한다', async ({ asGuest }) => {
+    await asGuest.goto('/');
+    await expect(asGuest.locator('.animate-spin')).toHaveCount(0, { timeout: 10_000 });
+
+    await asGuest.evaluate(() => {
+      (window as unknown as Record<string, unknown>).__logoTapFired = false;
+      window.addEventListener('logo-tap', () => {
+        (window as unknown as Record<string, unknown>).__logoTapFired = true;
+      });
+    });
+
+    const logoBtn = asGuest.getByRole('button', { name: /맨 위로 이동/ });
+    await logoBtn.click();
+
+    const fired = await asGuest.evaluate(
+      () => (window as unknown as Record<string, unknown>).__logoTapFired
+    );
+    expect(fired).toBe(true);
+  });
+
+  test('로고 탭 시 공지사항 API refetch가 발생한다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/');
+    await expect(asLoggedInUser.locator('.animate-spin')).toHaveCount(0, { timeout: 10_000 });
+
+    await asLoggedInUser.evaluate(() => {
+      const el = document.querySelector('.h-full.overflow-y-auto');
+      if (el) el.scrollTop = 300;
+    });
+
+    const refetchPromise = asLoggedInUser.waitForRequest(
+      (req) => req.url().includes('/notices') && req.method() === 'GET',
+      { timeout: 10_000 }
+    );
+
+    await asLoggedInUser.getByRole('button', { name: /맨 위로 이동/ }).click();
+
+    await refetchPromise;
+  });
+
+  test('이미 상단에 있어도 로고 탭 시 refetch가 발생한다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/');
+    await expect(asLoggedInUser.locator('.animate-spin')).toHaveCount(0, { timeout: 10_000 });
+
+    const scrollTop = await asLoggedInUser.evaluate(() => {
+      const el = document.querySelector('.h-full.overflow-y-auto');
+      return el ? el.scrollTop : 0;
+    });
+    expect(scrollTop).toBe(0);
+
+    const refetchPromise = asLoggedInUser.waitForRequest(
+      (req) => req.url().includes('/notices') && req.method() === 'GET',
+      { timeout: 10_000 }
+    );
+
+    await asLoggedInUser.getByRole('button', { name: /맨 위로 이동/ }).click();
+
+    await refetchPromise;
+  });
+});


### PR DESCRIPTION
## Summary
- 홈 화면 상단 "ZEROTIME" 로고 탭 시 맨 위로 스크롤 + 데이터 새로고침 (트위터/인스타 패턴)
- CustomEvent 기반 디커플링으로 SharedHeader ↔ HomeContent 통신
- 이미 상단에 있어도 항상 새로고침 실행

## Changes
- **SharedHeader.tsx**: Logo를 `<button>`으로 래핑, 클릭 시 `logo-tap` CustomEvent dispatch, `aria-label` + `active:scale-95` 터치 피드백
- **page.tsx**: `handleLogoTap` (useCallback) + useEffect 리스너 등록/해제, KEYWORD 필터 분기 처리
- **e2e/home.spec.ts**: 로고 탭 E2E 테스트 4개 추가

## Not Changed
- Logo.tsx, ScrollToTop.tsx 수정 없음
- 새 npm 의존성 없음
- 새 Context/store 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logo is now clickable and scrolls to the top of the page while refreshing displayed content.

* **Tests**
  * Added test coverage for logo interaction and content refresh functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->