### PR TITLE
fix(header): 로고 버튼 위치 원복 + 탭 애니메이션 제거

### DIFF
--- a/app/_components/layout/SharedHeader.tsx
+++ b/app/_components/layout/SharedHeader.tsx
@@ -41,7 +41,7 @@ export default function SharedHeader({ title, onMenuClick }: SharedHeaderProps) 
           <button
             type="button"
             aria-label="맨 위로 이동 및 새로고침"
-            className="appearance-none bg-transparent border-none p-0 m-0 leading-none cursor-pointer active:scale-95 transition-transform"
+            className="appearance-none bg-transparent border-none p-0 m-0 leading-none cursor-pointer flex items-center"
             onClick={() => window.dispatchEvent(new CustomEvent('logo-tap'))}
           >
             <Logo className="h-7 w-auto text-gray-900" />


### PR DESCRIPTION
## Summary
- 로고 `<button>` 래핑으로 인한 위치 이동 수정 (`flex items-center` 추가)
- 불필요한 탭 눌림 애니메이션 제거 (`active:scale-95 transition-transform` 삭제)

## Changes
- `SharedHeader.tsx` line 44: className 한 줄 수정

## Related
- PR #166 (로고 탭 기능 구현) 머지 후 발견된 UI 이슈 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated logo button styling to use flexbox layout with centered alignment
  * Removed animation effect from logo button's active state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->