### PR TITLE
fix(notifications): 새 알림 하이라이트 스타일 개선 및 카운트 불일치 수정

### DIFF
--- a/app/(main)/(home)/_components/NoticeCard.tsx
+++ b/app/(main)/(home)/_components/NoticeCard.tsx
@@ -69,7 +69,7 @@ export default function NoticeCard({
   return (
     <div
       role="listitem"
-      className={`transition-all hover:bg-gray-50 md:rounded-xl md:border md:border-gray-100 md:shadow-sm md:hover:-translate-y-0.5 md:hover:shadow-md ${isHighlighted && !notice.is_read ? 'bg-orange-50 animate-blink-orange' : 'bg-white'}`}
+      className={`transition-all hover:bg-gray-50 md:rounded-xl md:border md:border-gray-100 md:shadow-sm md:hover:-translate-y-0.5 md:hover:shadow-md ${isHighlighted && !notice.is_read ? 'bg-blue-50' : 'bg-white'}`}
       style={{ opacity: styleConfig.opacity }}
     >
       <a

--- a/app/(main)/notifications/_components/NotificationsClient.tsx
+++ b/app/(main)/notifications/_components/NotificationsClient.tsx
@@ -7,7 +7,7 @@ import {
   toggleNoticeFavorite,
   Notice,
 } from '@/_lib/api';
-import { useNotificationBadge } from '@/_context/NotificationBadgeContext';
+import { useNotificationBadge, normalizeDateTime } from '@/_context/NotificationBadgeContext';
 import Toast from '@/_components/ui/Toast';
 import { getLoginUrl } from '@/_lib/utils/requireLogin';
 import NoticeList from '@/(main)/(home)/_components/NoticeList';
@@ -131,14 +131,14 @@ export default function NotificationsClient() {
   const searchParams = useSearchParams();
   const lastSeenParam = searchParams.get('last_seen');
 
-  const highlightedIds = useMemo(() => {
-    if (!lastSeenParam || keywordNotices.length === 0) return [];
-    try {
-      const lastSeenTime = new Date(lastSeenParam).getTime();
-      const ids = keywordNotices
-        .filter(notice => {
-          // created_at이 있으면 우선 사용, 없으면 date 사용
-          const noticeTime = new Date(notice.created_at || notice.date).getTime();
+   const highlightedIds = useMemo(() => {
+     if (!lastSeenParam || keywordNotices.length === 0) return [];
+     try {
+       const lastSeenTime = new Date(normalizeDateTime(lastSeenParam)).getTime();
+       const ids = keywordNotices
+         .filter(notice => {
+           // created_at이 있으면 우선 사용, 없으면 date 사용
+           const noticeTime = new Date(normalizeDateTime(notice.created_at ?? notice.date)).getTime();
           // 기준 시점(마지막으로 확인한 시점)보다 나중에 올라온 공지만 강조
           return noticeTime > lastSeenTime;
         })

--- a/app/_components/layout/SharedHeader.tsx
+++ b/app/_components/layout/SharedHeader.tsx
@@ -17,7 +17,9 @@ export default function SharedHeader({ title, onMenuClick }: SharedHeaderProps) 
   const user = useUserStore((state) => state.user);
 
   const handleNotificationClick = () => {
-    const lastSeen = user?.keyword_notice_seen_at ?? null;
+    const serverSeen = user?.keyword_notice_seen_at ?? null;
+    const localSeen = typeof window !== 'undefined' ? localStorage.getItem('keyword_notice_seen_at') : null;
+    const lastSeen = [serverSeen, localSeen].filter(Boolean).sort().pop() ?? null;
     markKeywordNoticesSeen(keywordNotices);
     router.push(lastSeen ? `/notifications?last_seen=${encodeURIComponent(lastSeen)}` : '/notifications');
   };

--- a/app/_context/NotificationBadgeContext.tsx
+++ b/app/_context/NotificationBadgeContext.tsx
@@ -9,7 +9,7 @@ import { updateUserProfile } from '@/_lib/api/user';
 import { getQueryClient } from '@/providers';
 
 // Normalize datetime to 3 decimal places (milliseconds) for cross-browser safety
-function normalizeDateTime(s: string): string {
+export function normalizeDateTime(s: string): string {
   return s.replace(/(\.\d{3})\d+/, '$1');
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,25 +104,7 @@ body {
   animation: bottomSheetUp 0.3s cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-@keyframes blink-orange {
-  0% {
-    background-color: #fff7ed;
-    /* bg-orange-50 */
-  }
 
-  50% {
-    background-color: white;
-  }
-
-  100% {
-    background-color: #fff7ed;
-    /* bg-orange-50 */
-  }
-}
-
-.animate-blink-orange {
-  animation: blink-orange 3s ease-in-out 3 forwards;
-}
 
 /* 탭 컨텐츠 슬라이드 */
 @keyframes slideInRight {


### PR DESCRIPTION
## Summary
- 새 알림 강조를 주황 깜빡임(`animate-blink-orange`)에서 정적 파란 배경(`bg-blue-50`)으로 변경
- 배지 카운트와 하이라이트 카운트 불일치 버그 3가지 원인 수정

## Bug Root Causes Fixed
| # | 원인 | 수정 파일 |
|---|---|---|
| 1 | seenAt 기준점 불일치 — 배지는 max(server, local), 하이라이트는 server만 사용 | `SharedHeader.tsx` |
| 2 | normalizeDateTime 미적용 — 마이크로초 정밀도 차이 | `NotificationsClient.tsx` |
| 3 | `||` vs `??` fallback 불일치 | `NotificationsClient.tsx` |

## Changes
- `NoticeCard.tsx` — `animate-blink-orange` 제거, `bg-blue-50` 정적 배경
- `globals.css` — `blink-orange` 키프레임/클래스 삭제
- `SharedHeader.tsx` — `last_seen` URL param에 `max(server, local)` 사용
- `NotificationBadgeContext.tsx` — `normalizeDateTime` export
- `NotificationsClient.tsx` — `normalizeDateTime` + `??` 적용

## Related
- PR #166, #167, #168 (로고 탭 기능)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of notification highlighting with proper date normalization
  * Notification timestamps now account for both server and local storage data

* **Style**
  * Changed highlighted notification appearance from orange blinking animation to blue background

<!-- end of auto-generated comment: release notes by coderabbit.ai -->