### PR TITLE
fix(keywords, filter): 키워드·게시판 변경 후 새로고침 없이 즉시 반영

### DIFF
--- a/app/(main)/keywords/page.tsx
+++ b/app/(main)/keywords/page.tsx
@@ -7,6 +7,7 @@ import Button from '@/_components/ui/Button';
 import { useRouter } from 'next/navigation'; // Added missing import for useRouter
 import { useEffect } from 'react'; // Added missing import for useEffect
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useNotificationBadge } from '@/_context/NotificationBadgeContext';
 
 /**
  * 키워드 관리 페이지
@@ -17,6 +18,7 @@ export default function KeywordsPage() {
   const router = useRouter();
   const smartBack = useSmartBack();
   const { isLoggedIn, isAuthLoaded } = useUser();
+  const { refreshKeywordNotices } = useNotificationBadge();
 
   useEffect(() => {
     if (isAuthLoaded && !isLoggedIn) {
@@ -29,8 +31,7 @@ export default function KeywordsPage() {
   };
 
   const handleUpdate = () => {
-    // 키워드 업데이트 완료
-    // 페이지는 그대로 유지 (사용자가 뒤로가기로 이동)
+    refreshKeywordNotices();
   };
 
   // 인증 상태 로딩 중이거나 비로그인 상태(리다이렉트 중)일 때는 아무것도 렌더링하지 않음

--- a/app/_lib/hooks/useSelectedCategories.ts
+++ b/app/_lib/hooks/useSelectedCategories.ts
@@ -111,6 +111,10 @@ export function useSelectedCategories() {
         await updateUserSubscriptions(categories);
         // 성공 시 localStorage 캐시 저장
         localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(categories));
+        // ['user', 'init'] 캐시 무효화 → 홈 페이지 마운트 시 최신 구독 정보 로드
+        queryClient.invalidateQueries({ queryKey: ['user', 'init'] });
+        // 공지 목록 캐시 무효화 → 변경된 게시판 구독에 맞는 공지 다시 로드
+        queryClient.invalidateQueries({ queryKey: ['notices', 'infinite'] });
       } catch (error) {
         console.error('Failed to save subscriptions to backend:', error);
         // 실패 시 롤백


### PR DESCRIPTION
## Summary
- 키워드 추가/삭제 후 새로고침을 해야만 홈·알림 페이지에 반영되던 문제 수정
- 게시판 필터 적용 후 새로고침을 해야만 공지 목록이 갱신되던 문제 수정

## 변경 내용

### 1. `app/(main)/keywords/page.tsx`
- `handleUpdate`가 빈 함수여서 키워드 변경 후 `NotificationBadgeContext`의 `keywordCount`, `keywordNotices`가 갱신되지 않는 문제
- `refreshKeywordNotices()`를 호출하도록 수정하여 키워드 변경 즉시 컨텍스트 상태가 서버와 동기화됨

### 2. `app/_lib/hooks/useSelectedCategories.ts`
- `updateSelectedCategories`에서 백엔드 저장 후 React Query 캐시를 무효화하지 않아, 홈 페이지 재마운트 시 `ensureQueryData`가 stale 캐시를 반환하는 문제
- `['user', 'init']` 쿼리 무효화 → 홈 페이지 마운트 시 최신 구독 정보 로드
- `['notices', 'infinite']` 쿼리 무효화 → 변경된 게시판에 맞는 공지 목록 다시 로드

## 원인 분석
두 문제 모두 동일한 패턴: 데이터를 변경한 후 관련 캐시/컨텍스트를 갱신하지 않아서 이전 페이지로 돌아가면 stale 상태가 그대로 표시됨

## Test plan
- [ ] 키워드 추가 후 뒤로 가기 → 홈 키워드 탭에 즉시 반영되는지 확인
- [ ] 키워드 삭제 후 뒤로 가기 → 홈 키워드 탭에 즉시 반영되는지 확인
- [ ] 게시판 필터에서 게시판 추가/삭제 후 적용 → 홈 공지 목록이 즉시 갱신되는지 확인
- [ ] 알림 페이지에서도 키워드 변경이 즉시 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Keyword notices now refresh automatically when you update your keywords
  * Updates to category subscriptions now properly refresh related notices and home content in real-time

<!-- end of auto-generated comment: release notes by coderabbit.ai -->