### PR TITLE
feat(chinba): 팀 관리 프론트엔드 전체 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ next-env.d.ts
 /public/sw.js
 /public/sw.js.map
 /public/workbox-*.js
-/public/swe-worker-*.js
+/public/swe-worker-*.js.omc/

--- a/app/(main)/(home)/_components/OnboardingModal.tsx
+++ b/app/(main)/(home)/_components/OnboardingModal.tsx
@@ -244,6 +244,7 @@ export default function OnboardingModal({
   const [userType, setUserType] = useState<UserType | null>(null);
   const [formData, setFormData] = useState<UserInfoFormData>({
     nickname: '',
+    username: '',
     school: '',
     dept_code: '',
     dept_name: '',
@@ -418,6 +419,7 @@ export default function OnboardingModal({
     setUserType(null);
     setFormData({
       nickname: '',
+      username: '',
       school: '',
       dept_code: '',
       dept_name: '',

--- a/app/(main)/chinba/_components/BottomTabBar.tsx
+++ b/app/(main)/chinba/_components/BottomTabBar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { FiHome, FiUsers, FiUser } from 'react-icons/fi';
+
+const tabs = [
+  { href: '/chinba', label: '홈', icon: FiHome },
+  { href: '/chinba/team', label: '팀', icon: FiUsers },
+  { href: '/chinba/my', label: 'MY', icon: FiUser },
+];
+
+export default function BottomTabBar() {
+  const pathname = usePathname();
+
+  const normalized = pathname.replace(/\/$/, '') || '/';
+
+  const isActive = (href: string) =>
+    href === '/chinba' ? normalized === '/chinba' : normalized.startsWith(href);
+
+  return (
+    <div className="shrink-0 flex items-center border-t border-gray-100 bg-white pb-safe">
+      {tabs.map((tab) => {
+        const Icon = tab.icon;
+        const active = isActive(tab.href);
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`flex flex-1 flex-col items-center gap-0.5 py-2.5 transition-colors ${
+              active ? 'text-gray-900' : 'text-gray-400'
+            }`}
+          >
+            <Icon size={22} strokeWidth={active ? 2.5 : 1.5} />
+            <span className={`text-[11px] ${active ? 'font-bold' : 'font-medium'}`}>
+              {tab.label}
+            </span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/ChinbaTimetableView.tsx
+++ b/app/(main)/chinba/_components/ChinbaTimetableView.tsx
@@ -2,13 +2,12 @@
 
 import { useRouter } from 'next/navigation';
 import { FiPlus, FiUsers } from 'react-icons/fi';
-import { TimetableTab } from '@/_components/timetable';
 import { useUser } from '@/_lib/hooks/useUser';
 import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
 import { ChinbaEventList } from './ChinbaEventList';
-import BottomSheet from '@/_components/layout/BottomSheet';
+import TeamStatsBanner from '@/_components/ui/TeamStatsBanner';
 
 export default function ChinbaTimetableView() {
   const router = useRouter();
@@ -26,10 +25,12 @@ export default function ChinbaTimetableView() {
 
   return (
     <div className="flex flex-col h-full">
+      <TeamStatsBanner />
+
       {/* Chinba Event List Header */}
       <div className="shrink-0 px-4 pt-4 pb-2">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-bold text-gray-800">내 친바 일정</h2>
+          <h2 className="text-lg font-bold text-gray-800">내 친바 일정</h2>
           <button
             onClick={() => router.push('/chinba/create')}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-white bg-gray-900 hover:bg-gray-800 rounded-full transition-colors active:scale-95"
@@ -66,10 +67,6 @@ export default function ChinbaTimetableView() {
         )}
       </div>
 
-      {/* Timetable Bottom Sheet */}
-      <BottomSheet title="내 시간표 관리">
-        <TimetableTab />
-      </BottomSheet>
     </div>
   );
 }

--- a/app/(main)/chinba/_components/MyTabContent.tsx
+++ b/app/(main)/chinba/_components/MyTabContent.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { TimetableTab } from '@/_components/timetable';
+
+export default function MyTabContent() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 px-4 pt-4 pb-2">
+        <h2 className="text-lg font-bold text-gray-900">MY</h2>
+      </div>
+
+      {/* Timetable */}
+      <div className="flex-1 min-h-0">
+        <TimetableTab />
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/GroupManageView.tsx
+++ b/app/(main)/chinba/_components/team/GroupManageView.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import FullPageModal from '@/_components/layout/FullPageModal';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useGroups, useParseGroups, useSaveGroups, useGroupSets, useCreateGroupSet } from '@/_lib/hooks/useGroups';
+import type { GroupInput, GroupParseResponse, GroupSet } from '@/_types/team';
+
+import GroupCurrentView from './groups/GroupCurrentView';
+import GroupTextInput from './groups/GroupTextInput';
+import GroupParsePreview from './groups/GroupParsePreview';
+import GroupInlineEditor from './groups/GroupInlineEditor';
+
+type Step = 'current' | 'set-select' | 'input' | 'preview' | 'edit';
+
+export default function GroupManageView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const teamId = Number(searchParams.get('id'));
+  const goBack = useSmartBack(`/chinba/team/detail?id=${teamId}&tab=mannaja`);
+
+  const { data: groupsData, isLoading } = useGroups(teamId);
+  const { data: groupSetsData, isLoading: setsLoading } = useGroupSets(teamId);
+  const parseGroups = useParseGroups(teamId);
+  const saveGroups = useSaveGroups(teamId);
+  const createGroupSet = useCreateGroupSet(teamId);
+
+  const hasExistingGroups = (groupsData?.groups ?? []).length > 0;
+  const groupSets = groupSetsData?.group_sets ?? [];
+
+  const [step, setStep] = useState<Step | null>(null);
+  const [parseResult, setParseResult] = useState<GroupParseResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedGroupSetId, setSelectedGroupSetId] = useState<number | null>(null);
+  const [newSetName, setNewSetName] = useState('');
+
+  const initialMode = searchParams.get('mode');
+  const initialSetId = searchParams.get('setId');
+
+  // 데이터 로딩 완료 후 초기 step 결정
+  useEffect(() => {
+    if (!isLoading && !setsLoading && step === null) {
+      if (initialMode === 'edit' && hasExistingGroups) {
+        setSelectedGroupSetId(initialSetId ? Number(initialSetId) : null);
+        setStep('edit');
+      } else if (initialMode === 'recompose' && initialSetId) {
+        setSelectedGroupSetId(Number(initialSetId));
+        setStep('input');
+      } else {
+        setStep(hasExistingGroups ? 'current' : 'set-select');
+      }
+    }
+  }, [isLoading, setsLoading, hasExistingGroups, step, initialMode, initialSetId]);
+
+  const handleSetSelect = async () => {
+    setError(null);
+    if (!selectedGroupSetId && !newSetName.trim()) {
+      setError('그룹세트를 선택하거나 새 이름을 입력해주세요.');
+      return;
+    }
+
+    if (!selectedGroupSetId && newSetName.trim()) {
+      try {
+        const created = await createGroupSet.mutateAsync({ name: newSetName.trim() });
+        setSelectedGroupSetId(created.id);
+        setStep('input');
+      } catch (err: any) {
+        setError(err.response?.data?.detail || '그룹세트 생성에 실패했습니다.');
+      }
+      return;
+    }
+
+    setStep('input');
+  };
+
+  const handleParse = async (text: string) => {
+    setError(null);
+    try {
+      const result = await parseGroups.mutateAsync({ text, group_set_id: selectedGroupSetId ?? undefined });
+      setParseResult(result);
+      setStep('preview');
+    } catch (err: any) {
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        setError('로그인이 필요하거나 권한이 없습니다.');
+      } else if (err.code === 'ECONNABORTED') {
+        setError('AI 분석 시간이 초과되었습니다. 텍스트를 줄여서 다시 시도해주세요.');
+      } else {
+        setError(err.response?.data?.detail || '조 편성 분석에 실패했습니다. 텍스트 형식을 확인해주세요.');
+      }
+    }
+  };
+
+  const handleConfirm = async (groups: GroupInput[]) => {
+    setError(null);
+    try {
+      await saveGroups.mutateAsync({ groups, group_set_id: selectedGroupSetId ?? undefined });
+      router.replace(`/chinba/team/detail?id=${teamId}&tab=mannaja`);
+    } catch (err: any) {
+      setError(err.response?.data?.detail || '조 편성 저장에 실패했습니다.');
+    }
+  };
+
+  if (isLoading || setsLoading) {
+    return (
+      <FullPageModal isOpen={true} onClose={goBack} title="조 편성">
+        <div className="flex items-center justify-center py-16">
+          <LoadingSpinner />
+        </div>
+      </FullPageModal>
+    );
+  }
+
+  return (
+    <FullPageModal isOpen={true} onClose={goBack} title="조 편성">
+      {error && (
+        <div className="mx-4 mb-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+          {error}
+        </div>
+      )}
+      {step === 'current' && (
+        <GroupCurrentView
+          teamId={teamId}
+          groupSets={groupSets}
+          onRecompose={(setId?: number) => {
+            setSelectedGroupSetId(setId ?? null);
+            setStep(setId ? 'input' : 'set-select');
+          }}
+          onEdit={(setId?: number) => {
+            setSelectedGroupSetId(setId ?? null);
+            setStep('edit');
+          }}
+        />
+      )}
+      {step === 'set-select' && (
+        <div className="flex flex-col h-full">
+          <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+            <h3 className="text-sm font-bold text-gray-800">그룹세트 선택</h3>
+            <p className="text-xs text-gray-500">조를 편성할 활동을 선택하거나 새로 만드세요.</p>
+
+            {/* 기존 세트 목록 */}
+            {groupSets.map((gs) => (
+              <button
+                key={gs.id}
+                onClick={() => {
+                  setSelectedGroupSetId(gs.id);
+                  setNewSetName('');
+                }}
+                className={`w-full text-left rounded-xl border p-4 transition-colors ${
+                  selectedGroupSetId === gs.id
+                    ? 'border-gray-900 bg-gray-50'
+                    : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-gray-800">{gs.name}</span>
+                  <span className="text-xs text-gray-400">{gs.group_count}개 조</span>
+                </div>
+              </button>
+            ))}
+
+            {/* 새 세트 입력 */}
+            <div className={`rounded-xl border p-4 space-y-2 ${
+              !selectedGroupSetId && newSetName ? 'border-gray-900 bg-gray-50' : 'border-gray-200'
+            }`}>
+              <label className="text-xs font-medium text-gray-600">새 그룹세트</label>
+              <input
+                type="text"
+                placeholder="예: 친바, 스터디, 프로젝트"
+                value={newSetName}
+                onChange={(e) => {
+                  setNewSetName(e.target.value);
+                  if (e.target.value) setSelectedGroupSetId(null);
+                }}
+                className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+                maxLength={30}
+              />
+            </div>
+          </div>
+
+          <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+            <button
+              onClick={handleSetSelect}
+              disabled={!selectedGroupSetId && !newSetName.trim()}
+              className="w-full rounded-xl bg-gray-900 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+            >
+              {createGroupSet.isPending ? '생성 중...' : '다음'}
+            </button>
+          </div>
+        </div>
+      )}
+      {step === 'input' && (
+        <GroupTextInput
+          onParse={handleParse}
+          isParsing={parseGroups.isPending}
+          onBack={() => { setError(null); setStep('set-select'); }}
+        />
+      )}
+      {step === 'preview' && parseResult && (
+        <GroupParsePreview
+          parsedGroups={parseResult.parsed_groups}
+          unmatchedNames={parseResult.unmatched_names}
+          unassignedMembers={parseResult.unassigned_members}
+          onConfirm={handleConfirm}
+          onBack={() => { setError(null); setStep('input'); }}
+          isSaving={saveGroups.isPending}
+        />
+      )}
+      {step === 'edit' && (
+        <GroupInlineEditor
+          teamId={teamId}
+          groupSetId={selectedGroupSetId ?? undefined}
+          onSave={handleConfirm}
+          onBack={() => { setError(null); setStep('current'); }}
+          isSaving={saveGroups.isPending}
+        />
+      )}
+    </FullPageModal>
+  );
+}

--- a/app/(main)/chinba/_components/team/SubscriptionSection.tsx
+++ b/app/(main)/chinba/_components/team/SubscriptionSection.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useState } from 'react';
+
+import ConfirmModal from '@/_components/ui/ConfirmModal';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useToast } from '@/_context/ToastContext';
+import {
+  useSubscription,
+  useCreateSubscription,
+  useCancelSubscription,
+} from '@/_lib/hooks/useSubscription';
+import type { TierInfo } from '@/_types/team';
+
+interface SubscriptionSectionProps {
+  teamId: number;
+  canManage: boolean;
+}
+
+const CYCLE_LABELS: Record<string, string> = {
+  monthly: '월간',
+  semester: '학기(4개월)',
+  annual: '연간(12개월)',
+};
+
+const STATUS_LABELS: Record<string, { label: string; className: string }> = {
+  active: { label: '구독 중', className: 'bg-green-50 text-green-600' },
+  cancelled: { label: '해지 예정', className: 'bg-yellow-50 text-yellow-600' },
+  expired: { label: '만료', className: 'bg-gray-50 text-gray-400' },
+};
+
+function formatDate(dateStr: string | null) {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatPrice(price: number) {
+  return price.toLocaleString('ko-KR') + '원';
+}
+
+function getTierPrice(tier: TierInfo, cycle: 'monthly' | 'semester' | 'annual') {
+  if (cycle === 'semester') return tier.semester_price;
+  if (cycle === 'annual') return tier.annual_price;
+  return tier.monthly_price;
+}
+
+export default function SubscriptionSection({ teamId, canManage }: SubscriptionSectionProps) {
+  const { showToast } = useToast();
+  const { data: sub, isLoading } = useSubscription(teamId);
+  const createSubscription = useCreateSubscription(teamId);
+  const cancelSubscription = useCancelSubscription(teamId);
+
+  const [selectedCycle, setSelectedCycle] = useState<'monthly' | 'semester' | 'annual'>('monthly');
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+
+  if (isLoading) {
+    return (
+      <section className="mb-6">
+        <h2 className="text-sm font-bold text-gray-800 mb-3">구독 관리</h2>
+        <div className="rounded-xl border border-gray-100 bg-white flex items-center justify-center py-8">
+          <LoadingSpinner size="sm" />
+        </div>
+      </section>
+    );
+  }
+
+  if (!sub) return null;
+
+  const isSubscribed = sub.status === 'active';
+  const isCancelled = sub.status === 'cancelled';
+  const statusInfo = STATUS_LABELS[sub.status ?? ''] ?? { label: '미구독', className: 'bg-gray-50 text-gray-400' };
+
+  // 현재 멤버 수 기반으로 해당하는 티어 찾기
+  const currentTier = sub.available_tiers.find((t) => t.tier === sub.tier);
+
+  const handleSubscribe = async () => {
+    try {
+      await createSubscription.mutateAsync({ billing_cycle: selectedCycle });
+      showToast('구독이 시작되었습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '구독에 실패했습니다', 'error');
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await cancelSubscription.mutateAsync();
+      showToast('구독이 해지되었습니다. 남은 기간까지 사용 가능합니다.', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '해지에 실패했습니다', 'error');
+    }
+    setShowCancelConfirm(false);
+  };
+
+  return (
+    <section className="mb-6">
+      <h2 className="text-sm font-bold text-gray-800 mb-3">구독 관리</h2>
+      <div className="rounded-xl border border-gray-100 bg-white">
+        {/* 현재 구독 상태 */}
+        {(isSubscribed || isCancelled) ? (
+          <div className="p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-gray-800">
+                  {sub.tier_label ?? sub.tier}
+                </span>
+                <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${statusInfo.className}`}>
+                  {statusInfo.label}
+                </span>
+              </div>
+              {sub.amount != null && (
+                <span className="text-sm font-medium text-gray-600">
+                  {formatPrice(sub.amount)}/{CYCLE_LABELS[sub.billing_cycle ?? ''] ?? '월'}
+                </span>
+              )}
+            </div>
+
+            <div className="flex gap-4 text-xs text-gray-500">
+              <div>
+                <span className="text-gray-400">시작일</span>{' '}
+                <span className="font-medium text-gray-600">{formatDate(sub.started_at)}</span>
+              </div>
+              <div>
+                <span className="text-gray-400">만료일</span>{' '}
+                <span className="font-medium text-gray-600">{formatDate(sub.expires_at)}</span>
+              </div>
+            </div>
+
+            {currentTier && (
+              <div className="text-xs text-gray-400">
+                멤버 {sub.member_count}명 ({currentTier.member_range})
+              </div>
+            )}
+
+            {canManage && isSubscribed && (
+              <button
+                onClick={() => setShowCancelConfirm(true)}
+                className="w-full rounded-xl border border-red-100 py-2.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-50"
+              >
+                구독 해지
+              </button>
+            )}
+          </div>
+        ) : (
+          /* 미구독 상태 — 요금제 안내 */
+          <div className="p-4 space-y-4">
+            <div className="text-center py-2">
+              <p className="text-sm font-medium text-gray-600 mb-1">
+                프리미엄 기능을 이용해보세요
+              </p>
+              <p className="text-xs text-gray-400">
+                활동 기록(뭐했니)과 조별 비교(잡아봐) 기능을 사용할 수 있습니다
+              </p>
+            </div>
+
+            {/* 결제 주기 선택 */}
+            {canManage && (
+              <>
+                <div className="flex rounded-lg bg-gray-50 p-1">
+                  {(['monthly', 'semester', 'annual'] as const).map((cycle) => (
+                    <button
+                      key={cycle}
+                      onClick={() => setSelectedCycle(cycle)}
+                      className={`flex-1 rounded-md py-2 text-xs font-medium transition-colors ${
+                        selectedCycle === cycle
+                          ? 'bg-white text-gray-900 shadow-sm'
+                          : 'text-gray-500 hover:text-gray-700'
+                      }`}
+                    >
+                      {CYCLE_LABELS[cycle]}
+                      {cycle === 'semester' && (
+                        <span className="ml-1 text-[10px] text-blue-500">15%</span>
+                      )}
+                      {cycle === 'annual' && (
+                        <span className="ml-1 text-[10px] text-blue-500">25%</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+
+                {/* 요금제 카드 */}
+                <div className="space-y-2">
+                  {sub.available_tiers.map((tier) => {
+                    const price = getTierPrice(tier, selectedCycle);
+                    return (
+                      <div
+                        key={tier.tier}
+                        className="flex items-center justify-between rounded-xl border border-gray-100 px-4 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-semibold text-gray-800">{tier.tier}</p>
+                          <p className="text-xs text-gray-400">{tier.member_range}</p>
+                        </div>
+                        <p className="text-sm font-bold text-gray-800">
+                          {formatPrice(price)}
+                          <span className="text-xs font-normal text-gray-400">
+                            /{CYCLE_LABELS[selectedCycle]}
+                          </span>
+                        </p>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <p className="text-center text-[11px] text-gray-400">
+                  현재 멤버 {sub.member_count}명 · 멤버 수에 따라 요금제가 자동 적용됩니다
+                </p>
+
+                <button
+                  onClick={handleSubscribe}
+                  disabled={createSubscription.isPending}
+                  className="w-full rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-800 active:scale-[0.98] disabled:opacity-50"
+                >
+                  {createSubscription.isPending ? '처리 중...' : '구독하기'}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 해지 확인 모달 */}
+      <ConfirmModal
+        isOpen={showCancelConfirm}
+        onConfirm={handleCancel}
+        onCancel={() => setShowCancelConfirm(false)}
+        title="구독 해지"
+        confirmLabel="해지"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>구독을 해지하시겠습니까?</p>
+        <p className="mt-1 text-xs text-gray-400">
+          남은 기간까지는 프리미엄 기능을 계속 이용할 수 있습니다.
+        </p>
+      </ConfirmModal>
+    </section>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamCreateView.tsx
+++ b/app/(main)/chinba/_components/team/TeamCreateView.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { FiXCircle } from 'react-icons/fi';
+
+import Button from '@/_components/ui/Button';
+import FullPageModal from '@/_components/layout/FullPageModal';
+import { useToast } from '@/_context/ToastContext';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useCreateTeam } from '@/_lib/hooks/useTeam';
+import { getCategoryOptions } from '@/_lib/utils/teamDisplay';
+
+export default function TeamCreateView() {
+  const router = useRouter();
+  const goBack = useSmartBack('/chinba/team');
+  const createTeam = useCreateTeam();
+  const { showToast } = useToast();
+
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const categoryOptions = getCategoryOptions();
+  const canSubmit = name.trim().length > 0 && !createTeam.isPending;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+
+    try {
+      const result = await createTeam.mutateAsync({
+        name: name.trim(),
+        category: category || undefined,
+      });
+      showToast('팀이 생성되었습니다', 'success');
+      router.replace(`/chinba/team/detail?id=${result.id}`);
+    } catch (err: any) {
+      const detail = err.response?.data?.detail || '팀 생성에 실패했습니다';
+      setError(detail);
+      showToast(detail, 'error');
+    }
+  };
+
+  return (
+    <FullPageModal isOpen={true} onClose={goBack} title="팀 만들기">
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4">
+        {error && (
+          <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+
+        <div className="mb-6">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            팀 이름
+          </label>
+          <div className="relative">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 코딩 동아리, 졸업 프로젝트"
+              maxLength={50}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-800 placeholder-gray-400 outline-none focus:border-gray-900 transition-colors"
+            />
+            {name.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setName('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-gray-500 transition-colors"
+              >
+                <FiXCircle size={18} />
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-[11px] text-gray-400 text-right">{name.length}/50</p>
+        </div>
+
+        <div className="mb-6">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            카테고리
+            <span className="ml-1 text-xs font-normal text-gray-400">(선택)</span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {categoryOptions.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setCategory((prev) => (prev === opt.value ? '' : opt.value))}
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors active:scale-95 ${
+                  category === opt.value
+                    ? 'border-gray-900 bg-gray-900 text-white'
+                    : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          {createTeam.isPending ? '만드는 중...' : '만들기'}
+        </Button>
+      </div>
+    </FullPageModal>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { FiSettings } from 'react-icons/fi';
+
+import FullPageModal from '@/_components/layout/FullPageModal';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useGroupSets } from '@/_lib/hooks/useGroups';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useTeamDetail } from '@/_lib/hooks/useTeam';
+import { useAuthInitialized } from '@/providers';
+import GroupFilterBar from '@/(main)/teams/_components/GroupFilterBar';
+import TeamSegmentTabs, { type TeamSegment } from '@/(main)/teams/_components/TeamSegmentTabs';
+import UpgradeModal from '@/(main)/teams/_components/UpgradeModal';
+import ActivityTab from '@/(main)/teams/detail/_components/ActivityTab';
+import JababwaTab from '@/(main)/teams/detail/_components/JababwaTab';
+import MannajaTab from '@/(main)/teams/detail/_components/MannajaTab';
+
+export default function TeamDetailView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const goBack = useSmartBack('/chinba/team');
+
+  const teamId = Number(searchParams.get('id'));
+  const tabParam = searchParams.get('tab') as TeamSegment | null;
+  const initialTab: TeamSegment = tabParam === 'mwoheni' || tabParam === 'jabahbwa' ? tabParam : 'mannaja';
+
+  const isAuthReady = useAuthInitialized();
+  const { data: team, isLoading, isError } = useTeamDetail(teamId);
+  const { data: groupSetsData } = useGroupSets(teamId || undefined);
+  const [activeTab, setActiveTab] = useState<TeamSegment>(initialTab);
+  const [showUpgrade, setShowUpgrade] = useState(false);
+  const [selectedSetId, setSelectedSetId] = useState<number | null>(null);
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+
+  const groupSets = groupSetsData?.group_sets ?? [];
+  const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
+
+  // Sync tab state when URL changes (e.g. browser back/forward)
+  useEffect(() => {
+    const tab = searchParams.get('tab') as TeamSegment | null;
+    const resolved: TeamSegment = tab === 'mwoheni' || tab === 'jabahbwa' ? tab : 'mannaja';
+    if (resolved !== activeTab) {
+      setActiveTab(resolved);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  const isPaidTab = (tab: TeamSegment) => tab === 'mwoheni' || tab === 'jabahbwa';
+  const needsSubscription = team && !team.is_paid;
+
+  const handleTabChange = (tab: TeamSegment) => {
+    if (isPaidTab(tab) && needsSubscription) {
+      setShowUpgrade(true);
+      return;
+    }
+    setActiveTab(tab);
+    router.replace(`/chinba/team/detail?id=${teamId}&tab=${tab}`);
+  };
+
+  const handleSettingsClick = () => {
+    router.push(`/chinba/team/settings?id=${teamId}`);
+  };
+
+  if (!teamId) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-white">
+        <p className="text-sm text-gray-400 mb-3">잘못된 접근입니다</p>
+        <button
+          onClick={goBack}
+          className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  if (!isAuthReady || isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center bg-white">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !team) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-white">
+        <p className="text-sm text-gray-400 mb-3">팀 정보를 불러오지 못했습니다</p>
+        <button
+          onClick={goBack}
+          className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  const renderTabContent = () => {
+    if (activeTab === 'mannaja') {
+      return <MannajaTab teamId={teamId} myRole={team.my_role} memberCount={team.member_count} inviteCode={team.invite_code} selectedSetId={effectiveSetId} selectedGroupId={selectedGroupId} />;
+    }
+    if (activeTab === 'mwoheni') {
+      return <ActivityTab teamId={teamId} myRole={team.my_role} selectedSetId={effectiveSetId} selectedGroupId={selectedGroupId} />;
+    }
+    if (activeTab === 'jabahbwa') {
+      return <JababwaTab teamId={teamId} myRole={team.my_role} selectedSetId={effectiveSetId} selectedGroupId={selectedGroupId} />;
+    }
+    return null;
+  };
+
+  const settingsButton = (
+    <button
+      onClick={handleSettingsClick}
+      className="rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+      aria-label="설정"
+    >
+      <FiSettings size={20} />
+    </button>
+  );
+
+  return (
+    <FullPageModal isOpen={true} onClose={goBack} title={team.name} headerRight={settingsButton}>
+      {/* Segment Tabs */}
+      <div className="shrink-0">
+        <TeamSegmentTabs activeTab={activeTab} onTabChange={handleTabChange} />
+      </div>
+
+      {/* Group Filter */}
+      {groupSets.length > 0 && (
+        <div className="shrink-0 px-4 pt-3">
+          <GroupFilterBar
+            groupSets={groupSets}
+            selectedSetId={effectiveSetId}
+            selectedGroupId={selectedGroupId}
+            onSetChange={setSelectedSetId}
+            onGroupChange={setSelectedGroupId}
+          />
+        </div>
+      )}
+
+      {/* Tab Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-6">
+        {renderTabContent()}
+      </div>
+
+      {/* Upgrade Modal */}
+      <UpgradeModal
+        isOpen={showUpgrade}
+        onClose={() => setShowUpgrade(false)}
+        teamId={teamId}
+      />
+    </FullPageModal>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamEventCreateView.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateView.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FiXCircle } from 'react-icons/fi';
+
+import Button from '@/_components/ui/Button';
+import FullPageModal from '@/_components/layout/FullPageModal';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useGroups, useGroupSets } from '@/_lib/hooks/useGroups';
+import { useCreateTeamEvent } from '@/_lib/hooks/useTeamEvents';
+import DateSelector from '@/(main)/chinba/create/_components/DateSelector';
+
+export default function TeamEventCreateView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const teamId = Number(searchParams.get('id'));
+  const preSetId = searchParams.get('setId') ? Number(searchParams.get('setId')) : null;
+  const preGroupId = searchParams.get('groupId') ? Number(searchParams.get('groupId')) : null;
+  const goBack = useSmartBack(`/chinba/team/detail?id=${teamId}&tab=mannaja`);
+
+  const { data: groupsData } = useGroups(teamId);
+  const { data: groupSetsData } = useGroupSets(teamId);
+  const createEvent = useCreateTeamEvent(teamId);
+
+  const allGroups = groupsData?.groups ?? [];
+  const groupSets = groupSetsData?.group_sets ?? [];
+  const preSetName = preSetId ? groupSets.find((s) => s.id === preSetId)?.name : null;
+
+  // 필터에서 넘어온 setId에 따라 보여줄 그룹 필터링
+  // preSetId 없으면(전체): 빈 배열 → 조 선택 UI 숨김
+  // preSetId 있으면: 해당 세트의 조만 표시
+  const visibleGroups = useMemo(() => {
+    if (!preSetId) return [];
+    const set = groupSets.find((s) => s.id === preSetId);
+    if (set) {
+      const setGroupIds = new Set(set.groups.map((g) => g.id));
+      return allGroups.filter((g) => setGroupIds.has(g.id));
+    }
+    return [];
+  }, [allGroups, groupSets, preSetId]);
+
+  const hasGroups = visibleGroups.length > 0;
+
+  const [title, setTitle] = useState('');
+  const [selectedDates, setSelectedDates] = useState<string[]>([]);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<number[]>([]);
+  const [preselected, setPreselected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 필터에서 특정 조가 선택된 경우만 미리 선택
+  // preGroupId 있으면: 해당 조 1개만 선택
+  // preSetId만 있고 preGroupId 없으면(조: 전체): 아무것도 선택 안 함
+  useEffect(() => {
+    if (preselected || visibleGroups.length === 0) return;
+    if (preGroupId) {
+      setSelectedGroupIds([preGroupId]);
+    }
+    setPreselected(true);
+  }, [visibleGroups, preGroupId, preselected]);
+
+  const canSubmit = title.trim().length > 0 && selectedDates.length > 0 && !createEvent.isPending;
+
+  const toggleGroup = (groupId: number) => {
+    setSelectedGroupIds((prev) =>
+      prev.includes(groupId) ? prev.filter((id) => id !== groupId) : [...prev, groupId]
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+
+    try {
+      await createEvent.mutateAsync({
+        title: title.trim(),
+        dates: selectedDates,
+        target_group_ids: selectedGroupIds.length > 0 ? selectedGroupIds : undefined,
+      });
+      router.replace(`/chinba/team/detail?id=${teamId}&tab=mannaja`);
+    } catch (err: any) {
+      setError(err.response?.data?.detail || '이벤트 생성에 실패했습니다');
+    }
+  };
+
+  return (
+    <FullPageModal isOpen={true} onClose={goBack} title="팀 친바 만들기">
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4">
+        {error && (
+          <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+
+        {/* 전체 팀 대상 안내 (그룹세트 미선택) */}
+        {!preSetId && (
+          <div className="mb-6 rounded-xl bg-gray-50 px-4 py-3">
+            <p className="text-sm text-gray-500">
+              전체 팀 대상으로 생성됩니다
+            </p>
+          </div>
+        )}
+
+        {/* Target group selection */}
+        {hasGroups && (
+          <div className="mb-6">
+            <label className="block text-sm font-bold text-gray-700 mb-2">
+              대상 조 선택
+              {preSetId && groupSets.find((s) => s.id === preSetId) && (
+                <span className="ml-1 text-xs font-normal text-gray-400">
+                  — {groupSets.find((s) => s.id === preSetId)!.name}
+                </span>
+              )}
+            </label>
+            <p className="text-xs text-gray-400 mb-3">
+              여러 조를 선택하면 합동 일정도 잡을 수 있어요
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {visibleGroups.map((group) => {
+                const isSelected = selectedGroupIds.includes(group.id);
+                return (
+                  <button
+                    key={group.id}
+                    onClick={() => toggleGroup(group.id)}
+                    className={`rounded-xl border px-3 py-2.5 text-sm font-medium transition-colors ${
+                      isSelected
+                        ? 'border-gray-900 bg-gray-900 text-white'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    {preSetName ? `${preSetName} - ${group.name}` : group.name}
+                  </button>
+                );
+              })}
+            </div>
+            {selectedGroupIds.length === 0 && (
+              <p className="mt-2 text-[11px] text-gray-400">
+                선택하지 않으면 전체 팀 대상으로 생성됩니다
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Title */}
+        <div className="mb-6">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            모임 이름
+          </label>
+          <div className="relative">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="예: 조별과제 회의, 동아리 정기모임"
+              maxLength={100}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-800 placeholder-gray-400 outline-none focus:border-gray-900 transition-colors"
+            />
+            {title.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setTitle('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-gray-500 transition-colors"
+              >
+                <FiXCircle size={18} />
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-[11px] text-gray-400 text-right">{title.length}/100</p>
+        </div>
+
+        {/* Date selector */}
+        <div className="mb-6">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            날짜 선택
+          </label>
+          <p className="text-xs text-gray-400 mb-3">
+            후보 날짜를 클릭하거나 드래그하여 선택하세요
+          </p>
+          <div className="rounded-xl border border-gray-200 p-4">
+            <DateSelector selectedDates={selectedDates} onChange={setSelectedDates} />
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="mb-2"
+        >
+          {createEvent.isPending ? '만드는 중...' : '만들기'}
+        </Button>
+      </div>
+    </FullPageModal>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamJoinView.tsx
+++ b/app/(main)/chinba/_components/team/TeamJoinView.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { FiUsers } from 'react-icons/fi';
+
+import Button from '@/_components/ui/Button';
+import FullPageModal from '@/_components/layout/FullPageModal';
+import { useToast } from '@/_context/ToastContext';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useJoinTeam } from '@/_lib/hooks/useTeam';
+
+export default function TeamJoinView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const goBack = useSmartBack('/chinba/team');
+  const joinTeam = useJoinTeam();
+  const { showToast } = useToast();
+
+  const initialCode = searchParams.get('code') || '';
+  const [inviteCode, setInviteCode] = useState(initialCode);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSubmit = inviteCode.trim().length > 0 && !joinTeam.isPending;
+
+  const handleJoin = async () => {
+    if (!canSubmit) return;
+    setError(null);
+
+    try {
+      const result = await joinTeam.mutateAsync({
+        invite_code: inviteCode.trim(),
+      });
+      showToast(`${result.team_name}에 가입되었습니다`, 'success');
+      router.replace(`/chinba/team/detail?id=${result.team_id}`);
+    } catch (err: any) {
+      const detail = err.response?.data?.detail || '가입에 실패했습니다';
+      setError(detail);
+      showToast(detail, 'error');
+    }
+  };
+
+  return (
+    <FullPageModal isOpen={true} onClose={goBack} title="팀 가입">
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4">
+        <div className="flex flex-col items-center py-8">
+          <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+            <FiUsers size={28} className="text-gray-400" />
+          </div>
+
+          {error && (
+            <div className="mb-4 w-full rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+              {error}
+            </div>
+          )}
+
+          <div className="w-full mb-6">
+            <label className="block text-sm font-bold text-gray-700 mb-2">
+              초대 코드
+            </label>
+            <input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              placeholder="초대 코드를 입력하세요"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-800 placeholder-gray-400 outline-none focus:border-gray-900 transition-colors text-center font-mono"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleJoin}
+          disabled={!canSubmit}
+        >
+          {joinTeam.isPending ? '가입 중...' : '가입하기'}
+        </Button>
+      </div>
+    </FullPageModal>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamListView.tsx
+++ b/app/(main)/chinba/_components/team/TeamListView.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { FiPlus, FiUsers } from 'react-icons/fi';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import Toast from '@/_components/ui/Toast';
+import { hasAccessToken } from '@/_lib/auth/tokenStore';
+import { useMyTeams } from '@/_lib/hooks/useTeam';
+import { useAuthInitialized } from '@/providers';
+import TeamCard from '@/(main)/teams/_components/TeamCard';
+import TeamStatsBanner from '@/_components/ui/TeamStatsBanner';
+
+export default function TeamListView() {
+  const router = useRouter();
+  const isAuthReady = useAuthInitialized();
+  const isLoggedIn = isAuthReady && hasAccessToken();
+  const { data, isLoading, isError } = useMyTeams();
+  const teams = data?.teams ?? [];
+
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastKey, setToastKey] = useState(0);
+
+  const handleRequireLogin = () => {
+    setToastVisible(true);
+    setToastKey(prev => prev + 1);
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <TeamStatsBanner />
+
+      {/* Header */}
+      <div className="shrink-0 px-4 pb-3">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 flex items-center justify-between">
+          <h1 className="text-lg font-bold text-gray-800">내 팀</h1>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => isLoggedIn ? router.push('/chinba/team/join') : handleRequireLogin()}
+              className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 active:scale-95"
+            >
+              초대 코드 입력
+            </button>
+            <button
+              onClick={() => isLoggedIn ? router.push('/chinba/team/create') : handleRequireLogin()}
+              className="flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+            >
+              <FiPlus size={14} />
+              만들기
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">
+        {!isAuthReady || isLoading ? (
+          <div className="flex items-center justify-center py-20">
+            <LoadingSpinner />
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-center justify-center py-20">
+            <p className="text-sm text-gray-400">팀 목록을 불러오지 못했습니다</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="mt-3 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+            >
+              다시 시도
+            </button>
+          </div>
+        ) : teams.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+              <FiUsers size={28} className="text-gray-300" />
+            </div>
+            <p className="text-sm font-medium text-gray-500 mb-1">팀이 없습니다</p>
+            <p className="text-xs text-gray-400 text-center">
+              새 팀을 만들거나 초대 링크로 가입하세요
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {teams.map((team) => (
+              <TeamCard
+                key={team.id}
+                team={team}
+                onClick={() => router.push(`/chinba/team/detail?id=${team.id}`)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Toast
+        message="로그인이 필요합니다"
+        isVisible={toastVisible}
+        onClose={() => setToastVisible(false)}
+        type="info"
+        triggerKey={toastKey}
+      />
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamSettingsView.tsx
+++ b/app/(main)/chinba/_components/team/TeamSettingsView.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { FiXCircle } from 'react-icons/fi';
+
+import ConfirmModal from '@/_components/ui/ConfirmModal';
+import FullPageModal from '@/_components/layout/FullPageModal';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useToast } from '@/_context/ToastContext';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import {
+  useTeamDetail,
+  useTeamMembers,
+  useUpdateTeam,
+  useDeleteTeam,
+  useChangeRole,
+  useRemoveMember,
+  useRegenerateInviteCode,
+} from '@/_lib/hooks/useTeam';
+import { getCategoryOptions } from '@/_lib/utils/teamDisplay';
+import {
+  canEditTeam,
+  canDeleteTeam,
+  canRegenerateInvitation,
+} from '@/_lib/utils/teamPermissions';
+import type { TeamRole } from '@/_types/team';
+import InviteSection from '@/(main)/teams/_components/InviteSection';
+import MemberList from '@/(main)/teams/_components/MemberList';
+import GroupSettingsSection from '@/(main)/chinba/_components/team/groups/GroupSettingsSection';
+import SubscriptionSection from '@/(main)/chinba/_components/team/SubscriptionSection';
+
+export default function TeamSettingsView() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const teamId = Number(searchParams.get('id'));
+  const goBack = useSmartBack(`/chinba/team/detail?id=${teamId}`);
+  const { showToast } = useToast();
+
+  const { data: team, isLoading: isLoadingTeam } = useTeamDetail(teamId);
+  const { data: membersData, isLoading: isLoadingMembers } = useTeamMembers(teamId);
+  const updateTeam = useUpdateTeam(teamId);
+  const deleteTeam = useDeleteTeam();
+  const changeRole = useChangeRole(teamId);
+  const removeMember = useRemoveMember(teamId);
+  const regenerateCode = useRegenerateInviteCode(teamId);
+
+  const [editName, setEditName] = useState<string | null>(null);
+  const [editCategory, setEditCategory] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState<number | null>(null);
+
+  const categoryOptions = getCategoryOptions();
+  const members = membersData?.members ?? [];
+  const myRole = team?.my_role ?? 'member';
+  const isEditing = editName !== null;
+
+  if (isLoadingTeam) {
+    return (
+      <div className="flex h-full items-center justify-center bg-white">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!team) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-white">
+        <p className="text-sm text-gray-400 mb-3">팀 정보를 불러오지 못했습니다</p>
+        <button
+          onClick={goBack}
+          className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  const handleStartEdit = () => {
+    setEditName(team.name);
+    setEditCategory(team.category || '');
+  };
+
+  const handleCancelEdit = () => {
+    setEditName(null);
+    setEditCategory(null);
+  };
+
+  const handleSaveEdit = async () => {
+    if (editName === null) return;
+    const trimmed = editName.trim();
+    if (!trimmed) {
+      showToast('팀 이름을 입력해주세요', 'error');
+      return;
+    }
+
+    try {
+      await updateTeam.mutateAsync({
+        name: trimmed,
+        category: editCategory || undefined,
+      });
+      showToast('팀 정보가 수정되었습니다', 'success');
+      setEditName(null);
+      setEditCategory(null);
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '수정에 실패했습니다', 'error');
+    }
+  };
+
+  const handleDeleteTeam = async () => {
+    try {
+      await deleteTeam.mutateAsync(teamId);
+      showToast('팀이 삭제되었습니다', 'success');
+      router.replace('/chinba/team');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '삭제에 실패했습니다', 'error');
+    }
+    setShowDeleteConfirm(false);
+  };
+
+  const handleChangeRole = async (memberId: number, role: TeamRole) => {
+    try {
+      await changeRole.mutateAsync({ memberId, role });
+      showToast('역할이 변경되었습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '역할 변경에 실패했습니다', 'error');
+    }
+  };
+
+  const handleRemoveMember = (memberId: number) => {
+    setShowRemoveConfirm(memberId);
+  };
+
+  const confirmRemoveMember = async () => {
+    if (showRemoveConfirm === null) return;
+    try {
+      await removeMember.mutateAsync(showRemoveConfirm);
+      showToast('멤버를 내보냈습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '내보내기에 실패했습니다', 'error');
+    }
+    setShowRemoveConfirm(null);
+  };
+
+  const handleRegenerateCode = async () => {
+    try {
+      await regenerateCode.mutateAsync();
+      showToast('초대 코드가 재생성되었습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '재생성에 실패했습니다', 'error');
+    }
+  };
+
+  return (
+    <FullPageModal isOpen={true} onClose={goBack} title="팀 설정">
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-8">
+        {/* Section 1: Team Info */}
+        <section className="mb-6">
+          <h2 className="text-sm font-bold text-gray-800 mb-3">팀 정보</h2>
+          <div className="rounded-xl border border-gray-100 bg-white p-4 space-y-4">
+            {isEditing ? (
+              <>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1.5">팀 이름</label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      value={editName || ''}
+                      onChange={(e) => setEditName(e.target.value)}
+                      maxLength={50}
+                      className="w-full rounded-xl border border-gray-200 px-4 py-2.5 pr-10 text-sm text-gray-800 outline-none focus:border-gray-900 transition-colors"
+                    />
+                    {(editName?.length ?? 0) > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => setEditName('')}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-gray-500 transition-colors"
+                      >
+                        <FiXCircle size={16} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1.5">카테고리</label>
+                  <div className="flex flex-wrap gap-1.5">
+                    {categoryOptions.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setEditCategory((prev) => (prev === opt.value ? '' : opt.value))}
+                        className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors active:scale-95 ${
+                          editCategory === opt.value
+                            ? 'border-gray-900 bg-gray-900 text-white'
+                            : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleCancelEdit}
+                    className="flex-1 rounded-xl border border-gray-200 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={handleSaveEdit}
+                    disabled={updateTeam.isPending}
+                    className="flex-1 rounded-xl bg-gray-900 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                  >
+                    {updateTeam.isPending ? '저장 중...' : '저장'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-xs text-gray-400 mb-0.5">팀 이름</p>
+                    <p className="text-sm font-medium text-gray-800">{team.name}</p>
+                  </div>
+                  {canEditTeam(myRole) && (
+                    <button
+                      onClick={handleStartEdit}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-50"
+                    >
+                      수정
+                    </button>
+                  )}
+                </div>
+                {team.category && (
+                  <div>
+                    <p className="text-xs text-gray-400 mb-0.5">카테고리</p>
+                    <p className="text-sm text-gray-600">{team.category}</p>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+        </section>
+
+        {/* Section 2: 구독 관리 */}
+        <SubscriptionSection
+          teamId={teamId}
+          canManage={canEditTeam(myRole)}
+        />
+
+        {/* Section 3: Invite */}
+        <section className="mb-6">
+          <h2 className="text-sm font-bold text-gray-800 mb-3">초대 링크</h2>
+          <InviteSection
+            inviteCode={team.invite_code}
+            canRegenerate={canRegenerateInvitation(myRole)}
+            onRegenerate={handleRegenerateCode}
+            isRegenerating={regenerateCode.isPending}
+            onShowToast={showToast}
+          />
+        </section>
+
+        {/* Section 3: Members */}
+        <section className="mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-bold text-gray-800">
+              멤버 관리
+              <span className="ml-1.5 text-xs font-normal text-gray-400">
+                {members.length}명
+              </span>
+            </h2>
+          </div>
+          <div className="rounded-xl border border-gray-100 bg-white">
+            {isLoadingMembers ? (
+              <div className="flex items-center justify-center py-8">
+                <LoadingSpinner size="sm" />
+              </div>
+            ) : members.length === 0 ? (
+              <div className="py-8 text-center text-sm text-gray-400">
+                멤버가 없습니다
+              </div>
+            ) : (
+              <MemberList
+                members={members}
+                myRole={myRole}
+                teamId={teamId}
+                onChangeRole={handleChangeRole}
+                onRemoveMember={handleRemoveMember}
+              />
+            )}
+          </div>
+        </section>
+
+        {/* Section 4: 그룹/조 관리 */}
+        <GroupSettingsSection
+          teamId={teamId}
+          canManage={canEditTeam(myRole)}
+        />
+
+        {/* Section 6: 팀 삭제 (Danger Zone) */}
+        {canDeleteTeam(myRole) && !isEditing && (
+          <section className="mb-6 pt-4 border-t border-gray-100">
+            <button
+              onClick={() => setShowDeleteConfirm(true)}
+              className="w-full rounded-xl border border-red-100 py-2.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-50"
+            >
+              팀 삭제
+            </button>
+          </section>
+        )}
+      </div>
+
+      {/* Delete Confirm Modal */}
+      <ConfirmModal
+        isOpen={showDeleteConfirm}
+        onConfirm={handleDeleteTeam}
+        onCancel={() => setShowDeleteConfirm(false)}
+        title="팀 삭제"
+        confirmLabel="삭제"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>정말 이 팀을 삭제하시겠습니까?</p>
+        <p className="mt-1 text-xs text-gray-400">이 작업은 되돌릴 수 없습니다.</p>
+      </ConfirmModal>
+
+      {/* Remove Member Confirm Modal */}
+      <ConfirmModal
+        isOpen={showRemoveConfirm !== null}
+        onConfirm={confirmRemoveMember}
+        onCancel={() => setShowRemoveConfirm(null)}
+        title="멤버 내보내기"
+        confirmLabel="내보내기"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>이 멤버를 팀에서 내보내시겠습니까?</p>
+      </ConfirmModal>
+    </FullPageModal>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/EditableGroupName.tsx
+++ b/app/(main)/chinba/_components/team/groups/EditableGroupName.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+import { FiEdit2 } from 'react-icons/fi';
+
+interface EditableGroupNameProps {
+  name: string;
+  onChange: (v: string) => void;
+}
+
+export default function EditableGroupName({ name, onChange }: EditableGroupNameProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed) onChange(trimmed);
+    else setDraft(name);
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit();
+          if (e.key === 'Escape') { setDraft(name); setEditing(false); }
+        }}
+        maxLength={30}
+        className="text-sm font-bold text-gray-800 bg-transparent border-b border-gray-300 outline-none py-0 px-0 w-32 focus:border-gray-900"
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => { setDraft(name); setEditing(true); }}
+      className="flex items-center gap-1 text-sm font-bold text-gray-800 hover:text-gray-600 transition-colors"
+    >
+      {name}
+      <FiEdit2 size={12} className="text-gray-400" />
+    </button>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/GroupCurrentView.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupCurrentView.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import Button from '@/_components/ui/Button';
+import { useGroups } from '@/_lib/hooks/useGroups';
+import type { GroupSet } from '@/_types/team';
+
+interface GroupCurrentViewProps {
+  teamId: number;
+  groupSets?: GroupSet[];
+  onRecompose: (setId?: number) => void;
+  onEdit?: (setId?: number) => void;
+}
+
+export default function GroupCurrentView({ teamId, groupSets = [], onRecompose, onEdit }: GroupCurrentViewProps) {
+  const { data, isLoading } = useGroups(teamId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  const groups = data?.groups ?? [];
+  const unassigned = data?.unassigned_members ?? [];
+
+  // 그룹세트가 있으면 세트별로 구분
+  const hasGroupSets = groupSets.length > 0;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        <h3 className="text-sm font-bold text-gray-800">현재 조 편성</h3>
+
+        {hasGroupSets ? (
+          // 그룹세트별로 구분 표시
+          groupSets.map((gs) => (
+            <div key={gs.id} className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-bold text-gray-700">{gs.name}</h4>
+                <div className="flex items-center gap-2">
+                  {onEdit && gs.groups.length > 0 && (
+                    <button
+                      onClick={() => onEdit(gs.id)}
+                      className="text-xs font-medium text-gray-500 hover:text-gray-700 transition-colors"
+                    >
+                      수정
+                    </button>
+                  )}
+                  <button
+                    onClick={() => onRecompose(gs.id)}
+                    className="text-xs font-medium text-gray-500 hover:text-gray-700 transition-colors"
+                  >
+                    재편성
+                  </button>
+                </div>
+              </div>
+              {gs.groups.length === 0 ? (
+                <p className="text-xs text-gray-400 pl-1">아직 조가 없습니다</p>
+              ) : (
+                gs.groups.map((group) => (
+                  <div key={group.id} className="rounded-xl border border-gray-200 p-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <h4 className="text-sm font-bold text-gray-800">{gs.name} - {group.name}</h4>
+                      <span className="text-xs text-gray-400">{group.member_count}명</span>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {group.leader && (
+                        <span className="rounded-full bg-gray-900 text-white px-2.5 py-1 text-xs font-medium">
+                          {group.leader.nickname} (조장)
+                        </span>
+                      )}
+                      {group.members
+                        ?.filter((m) => !m.is_leader)
+                        .map((m) => (
+                          <span
+                            key={m.member_id}
+                            className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700"
+                          >
+                            {m.nickname}
+                          </span>
+                        ))}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          ))
+        ) : (
+          // 기존 flat 표시
+          groups.map((group) => (
+            <div key={group.id} className="rounded-xl border border-gray-200 p-4">
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-sm font-bold text-gray-800">{group.name}</h4>
+                <span className="text-xs text-gray-400">{group.member_count}명</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {group.leader && (
+                  <span className="rounded-full bg-gray-900 text-white px-2.5 py-1 text-xs font-medium">
+                    {group.leader.nickname} (조장)
+                  </span>
+                )}
+                {group.members
+                  ?.filter((m) => !m.is_leader)
+                  .map((m) => (
+                    <span
+                      key={m.member_id}
+                      className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700"
+                    >
+                      {m.nickname}
+                    </span>
+                  ))}
+              </div>
+            </div>
+          ))
+        )}
+
+        {unassigned.length > 0 && (
+          <div className="rounded-xl border border-dashed border-gray-300 p-4">
+            <h4 className="text-xs font-medium text-gray-500 mb-2">미배정 멤버</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {unassigned.map((m) => (
+                <span
+                  key={m.member_id}
+                  className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500"
+                >
+                  {m.nickname}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {!hasGroupSets && (
+        <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100 flex gap-2">
+          {onEdit && groups.length > 0 && (
+            <Button variant="secondary" size="md" onClick={() => onEdit()} className="flex-1">
+              수정하기
+            </Button>
+          )}
+          <Button variant="primary" size="md" onClick={() => onRecompose()} className="flex-1">
+            재편성하기
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
@@ -1,0 +1,507 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+
+import { FiTrash2, FiPlus } from 'react-icons/fi';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import Button from '@/_components/ui/Button';
+import ConfirmModal from '@/_components/ui/ConfirmModal';
+import { useGroups } from '@/_lib/hooks/useGroups';
+import type { GroupInput, Group } from '@/_types/team';
+
+import EditableGroupName from './EditableGroupName';
+import MemberActionBar from './MemberActionBar';
+import MoveTargetSheet from './MoveTargetSheet';
+
+// ── Editable types ──────────────────────────────────────────────
+
+interface EditableMember {
+  member_id: number;
+  nickname: string;
+  is_leader: boolean;
+}
+
+interface EditableGroup {
+  name: string;
+  members: EditableMember[];
+}
+
+interface SelectedMember {
+  groupIdx: number;
+  memberIdx: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function groupsToEditable(groups: Group[]): EditableGroup[] {
+  return groups.map((g) => ({
+    name: g.name,
+    members: (g.members ?? []).map((m) => ({
+      member_id: m.member_id,
+      nickname: m.nickname ?? '이름없음',
+      is_leader: m.is_leader,
+    })),
+  }));
+}
+
+function editableToGroupInputs(groups: EditableGroup[]): GroupInput[] {
+  return groups.map((g, idx) => ({
+    name: g.name,
+    display_order: idx + 1,
+    members: g.members.map((m) => ({
+      member_id: m.member_id,
+      is_leader: m.is_leader,
+    })),
+  }));
+}
+
+function toUnassigned(
+  members: { member_id: number; nickname: string }[],
+): EditableMember[] {
+  return members.map((m) => ({
+    member_id: m.member_id,
+    nickname: m.nickname,
+    is_leader: false,
+  }));
+}
+
+// ── Component ───────────────────────────────────────────────────
+
+interface GroupInlineEditorProps {
+  teamId: number;
+  groupSetId?: number;
+  onSave: (groups: GroupInput[]) => void;
+  onBack: () => void;
+  isSaving: boolean;
+}
+
+export default function GroupInlineEditor({
+  teamId,
+  groupSetId,
+  onSave,
+  onBack,
+  isSaving,
+}: GroupInlineEditorProps) {
+  const { data, isLoading } = useGroups(teamId, groupSetId);
+
+  // Editable state — initialised once when data arrives
+  const [groups, setGroups] = useState<EditableGroup[]>([]);
+  const [unassigned, setUnassigned] = useState<EditableMember[]>([]);
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (data && !initialized) {
+      setGroups(groupsToEditable(data.groups));
+      setUnassigned(toUnassigned(data.unassigned_members));
+      setInitialized(true);
+    }
+  }, [data, initialized]);
+
+  // UI state
+  const [selectedMember, setSelectedMember] = useState<SelectedMember | null>(null);
+  const [showMoveSheet, setShowMoveSheet] = useState(false);
+  const [showAddSheet, setShowAddSheet] = useState<number | null>(null);
+  const [addSelections, setAddSelections] = useState<Set<number>>(new Set());
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<number | null>(null);
+  const [showUnsavedConfirm, setShowUnsavedConfirm] = useState(false);
+
+  // ── Validation ──────────────────────────────────────────────
+
+  const groupsMissingLeader = groups.filter(
+    (g) => g.members.length > 0 && !g.members.some((m) => m.is_leader),
+  );
+
+  const hasChanges = useMemo(() => {
+    if (!data) return false;
+    const initial = groupsToEditable(data.groups);
+    const initialU = data.unassigned_members;
+    if (groups.length !== initial.length) return true;
+    for (let i = 0; i < groups.length; i++) {
+      if (groups[i].name !== initial[i].name) return true;
+      if (groups[i].members.length !== initial[i].members.length) return true;
+      for (let j = 0; j < groups[i].members.length; j++) {
+        const a = groups[i].members[j];
+        const b = initial[i].members[j];
+        if (a.member_id !== b.member_id || a.is_leader !== b.is_leader) return true;
+      }
+    }
+    if (unassigned.length !== initialU.length) return true;
+    return false;
+  }, [groups, unassigned, data]);
+
+  const canSave = groupsMissingLeader.length === 0 && hasChanges;
+
+  // ── Group operations ────────────────────────────────────────
+
+  const handleAddGroup = () => {
+    const nextNum = groups.length + 1;
+    setGroups((prev) => [...prev, { name: `${nextNum}조`, members: [] }]);
+  };
+
+  const handleDeleteGroup = (groupIdx: number) => {
+    const removed = groups[groupIdx];
+    setUnassigned((u) => [...u, ...removed.members.map((m) => ({ ...m, is_leader: false }))]);
+    setGroups((prev) => prev.filter((_, i) => i !== groupIdx));
+    setShowDeleteConfirm(null);
+    setSelectedMember(null);
+  };
+
+  const handleRenameGroup = (groupIdx: number, newName: string) => {
+    setGroups((prev) =>
+      prev.map((g, i) => (i === groupIdx ? { ...g, name: newName } : g)),
+    );
+  };
+
+  // ── Member operations ───────────────────────────────────────
+
+  const handleSetLeader = () => {
+    if (!selectedMember) return;
+    const { groupIdx, memberIdx } = selectedMember;
+    setGroups((prev) =>
+      prev.map((g, gi) => {
+        if (gi !== groupIdx) return g;
+        return {
+          ...g,
+          members: g.members.map((m, mi) => ({
+            ...m,
+            is_leader: mi === memberIdx,
+          })),
+        };
+      }),
+    );
+    setSelectedMember(null);
+  };
+
+  const handleMoveMember = (targetGroupIdx: number) => {
+    if (!selectedMember) return;
+    const { groupIdx, memberIdx } = selectedMember;
+    const member = { ...groups[groupIdx].members[memberIdx], is_leader: false };
+    setGroups((prev) =>
+      prev.map((g, gi) => {
+        if (gi === groupIdx) {
+          return { ...g, members: g.members.filter((_, mi) => mi !== memberIdx) };
+        }
+        if (gi === targetGroupIdx) {
+          return { ...g, members: [...g.members, member] };
+        }
+        return g;
+      }),
+    );
+    setShowMoveSheet(false);
+    setSelectedMember(null);
+  };
+
+  const handleUnassignMember = () => {
+    if (!selectedMember) return;
+    const { groupIdx, memberIdx } = selectedMember;
+    const member = { ...groups[groupIdx].members[memberIdx], is_leader: false };
+    setGroups((prev) =>
+      prev.map((g, gi) => {
+        if (gi !== groupIdx) return g;
+        return { ...g, members: g.members.filter((_, mi) => mi !== memberIdx) };
+      }),
+    );
+    setUnassigned((prev) => [...prev, member]);
+    setSelectedMember(null);
+  };
+
+  const handleAddMembers = (groupIdx: number) => {
+    const selectedIds = Array.from(addSelections);
+    const membersToAdd = unassigned.filter((m) => selectedIds.includes(m.member_id));
+    setGroups((prev) =>
+      prev.map((g, gi) => {
+        if (gi !== groupIdx) return g;
+        return { ...g, members: [...g.members, ...membersToAdd] };
+      }),
+    );
+    setUnassigned((prev) => prev.filter((m) => !selectedIds.includes(m.member_id)));
+    setShowAddSheet(null);
+    setAddSelections(new Set());
+  };
+
+  const handleBack = () => {
+    if (hasChanges) {
+      setShowUnsavedConfirm(true);
+    } else {
+      onBack();
+    }
+  };
+
+  // ── Derived ─────────────────────────────────────────────────
+
+  const selectedMemberData = selectedMember
+    ? groups[selectedMember.groupIdx]?.members[selectedMember.memberIdx]
+    : null;
+
+  // ── Loading ─────────────────────────────────────────────────
+
+  if (isLoading || !initialized) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  // ── Render ──────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col h-full">
+      <div
+        className="flex-1 overflow-y-auto px-4 py-4 space-y-4"
+        style={{ paddingBottom: selectedMember ? 80 : undefined }}
+      >
+        {/* Header */}
+        <div>
+          <h3 className="text-sm font-bold text-gray-800">조 편성 수정</h3>
+          <p className="text-[11px] text-gray-400 mt-0.5">
+            멤버를 눌러 이동하거나 조장을 변경할 수 있습니다
+          </p>
+        </div>
+
+        {/* Add group */}
+        <button
+          type="button"
+          onClick={handleAddGroup}
+          className="w-full rounded-xl border-2 border-dashed border-gray-200 py-3 text-sm font-medium text-gray-400 hover:border-gray-300 hover:text-gray-500 transition-colors active:scale-[0.98]"
+        >
+          <FiPlus className="inline mr-1" size={14} />
+          새 조 추가
+        </button>
+
+        {/* Group cards */}
+        {groups.map((group, gIdx) => {
+          const hasLeader =
+            group.members.length === 0 || group.members.some((m) => m.is_leader);
+          return (
+            <div
+              key={gIdx}
+              className={`rounded-xl border p-4 ${
+                hasLeader ? 'border-gray-200' : 'border-red-200 bg-red-50/30'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-2">
+                <EditableGroupName
+                  name={group.name}
+                  onChange={(v) => handleRenameGroup(gIdx, v)}
+                />
+                <div className="flex items-center gap-2">
+                  {!hasLeader && (
+                    <span className="text-[11px] text-red-400">조장 필요</span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(gIdx)}
+                    className="p-1 text-gray-300 hover:text-red-400 transition-colors"
+                  >
+                    <FiTrash2 size={14} />
+                  </button>
+                </div>
+              </div>
+
+              {/* Member chips */}
+              <div className="flex flex-wrap gap-1.5">
+                {group.members.map((member, mIdx) => {
+                  const isSelected =
+                    selectedMember?.groupIdx === gIdx &&
+                    selectedMember?.memberIdx === mIdx;
+                  return (
+                    <button
+                      key={member.member_id}
+                      type="button"
+                      onClick={() =>
+                        setSelectedMember(
+                          isSelected ? null : { groupIdx: gIdx, memberIdx: mIdx },
+                        )
+                      }
+                      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium transition-all active:scale-95 ${
+                        isSelected
+                          ? 'ring-2 ring-blue-400 bg-blue-50 text-blue-700'
+                          : member.is_leader
+                          ? 'bg-gray-900 text-white'
+                          : 'bg-gray-100 text-gray-700'
+                      }`}
+                    >
+                      {member.nickname}
+                      {member.is_leader && ' ★'}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Add member to this group */}
+              {unassigned.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowAddSheet(gIdx);
+                    setAddSelections(new Set());
+                  }}
+                  className="mt-2 text-xs font-medium text-gray-400 hover:text-gray-600 transition-colors"
+                >
+                  <FiPlus className="inline mr-0.5" size={12} />
+                  멤버 추가
+                </button>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Unassigned members */}
+        {unassigned.length > 0 && (
+          <div className="rounded-xl border border-dashed border-gray-300 p-4">
+            <h4 className="text-xs font-medium text-gray-500 mb-2">미배정 멤버</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {unassigned.map((m) => (
+                <span
+                  key={m.member_id}
+                  className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500"
+                >
+                  {m.nickname}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom bar — action bar or save/back buttons */}
+      {selectedMember && selectedMemberData ? (
+        <MemberActionBar
+          nickname={selectedMemberData.nickname}
+          isLeader={selectedMemberData.is_leader}
+          onSetLeader={handleSetLeader}
+          onMove={() => setShowMoveSheet(true)}
+          onUnassign={handleUnassignMember}
+          onClose={() => setSelectedMember(null)}
+        />
+      ) : (
+        <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100 flex gap-2">
+          <Button variant="secondary" size="md" onClick={handleBack} className="flex-1">
+            돌아가기
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={() => onSave(editableToGroupInputs(groups))}
+            disabled={isSaving || !canSave}
+            className="flex-1"
+          >
+            {isSaving ? '저장 중...' : '저장하기'}
+          </Button>
+        </div>
+      )}
+
+      {/* Move target sheet */}
+      {showMoveSheet && selectedMember && (
+        <MoveTargetSheet
+          memberNickname={selectedMemberData?.nickname ?? ''}
+          groups={groups.map((g, i) => ({
+            name: g.name,
+            isCurrent: i === selectedMember.groupIdx,
+          }))}
+          onSelect={handleMoveMember}
+          onCancel={() => setShowMoveSheet(false)}
+        />
+      )}
+
+      {/* Add members sheet */}
+      {showAddSheet !== null && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40"
+          onClick={() => setShowAddSheet(null)}
+        >
+          <div
+            className="w-[80%] max-w-xs rounded-2xl bg-white p-5 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-center text-base font-semibold text-gray-900 mb-3">
+              {groups[showAddSheet]?.name}에 추가할 멤버 선택
+            </p>
+            <div className="space-y-2 max-h-60 overflow-y-auto">
+              {unassigned.map((m) => (
+                <button
+                  key={m.member_id}
+                  type="button"
+                  onClick={() => {
+                    setAddSelections((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(m.member_id)) next.delete(m.member_id);
+                      else next.add(m.member_id);
+                      return next;
+                    });
+                  }}
+                  className={`w-full text-left rounded-xl border p-3 transition-colors ${
+                    addSelections.has(m.member_id)
+                      ? 'border-gray-900 bg-gray-50'
+                      : 'border-gray-200 hover:border-gray-300'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`w-4 h-4 rounded border flex items-center justify-center text-xs ${
+                        addSelections.has(m.member_id)
+                          ? 'bg-gray-900 border-gray-900 text-white'
+                          : 'border-gray-300'
+                      }`}
+                    >
+                      {addSelections.has(m.member_id) && '✓'}
+                    </span>
+                    <span className="text-sm font-medium text-gray-700">{m.nickname}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowAddSheet(null)}
+                className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 active:scale-95 transition-all"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={() => handleAddMembers(showAddSheet)}
+                disabled={addSelections.size === 0}
+                className="flex-1 rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white hover:bg-gray-800 active:scale-95 transition-all disabled:opacity-50"
+              >
+                추가
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete group confirm */}
+      <ConfirmModal
+        isOpen={showDeleteConfirm !== null}
+        onConfirm={() =>
+          showDeleteConfirm !== null && handleDeleteGroup(showDeleteConfirm)
+        }
+        onCancel={() => setShowDeleteConfirm(null)}
+        title={`${showDeleteConfirm !== null ? groups[showDeleteConfirm]?.name : ''}을(를) 삭제하시겠습니까?`}
+        confirmLabel="삭제"
+        variant="danger"
+      >
+        소속 멤버는 미배정 상태가 됩니다
+      </ConfirmModal>
+
+      {/* Unsaved changes confirm */}
+      <ConfirmModal
+        isOpen={showUnsavedConfirm}
+        onConfirm={() => {
+          setShowUnsavedConfirm(false);
+          onBack();
+        }}
+        onCancel={() => setShowUnsavedConfirm(false)}
+        title="변경사항이 있습니다"
+        confirmLabel="나가기"
+        variant="danger"
+      >
+        저장하지 않은 변경사항이 있습니다. 나가시겠습니까?
+      </ConfirmModal>
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/GroupParsePreview.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupParsePreview.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useState } from 'react';
+
+import { FiAlertTriangle } from 'react-icons/fi';
+
+import Button from '@/_components/ui/Button';
+import type { ParsedGroup, ParsedGroupMember, GroupInput } from '@/_types/team';
+
+import EditableGroupName from './EditableGroupName';
+
+interface GroupParsePreviewProps {
+  parsedGroups: ParsedGroup[];
+  unmatchedNames: string[];
+  unassignedMembers: { member_id: number; nickname: string }[];
+  onConfirm: (groups: GroupInput[]) => void;
+  onBack: () => void;
+  isSaving: boolean;
+}
+
+function toGroupInputs(groups: ParsedGroup[]): GroupInput[] {
+  return groups.map((pg, idx) => ({
+    name: pg.name,
+    display_order: idx + 1,
+    members: pg.members
+      .filter((m) => m.matched_member_id !== null)
+      .map((m) => ({
+        member_id: m.matched_member_id!,
+        is_leader: m.is_leader,
+      })),
+  }));
+}
+
+function deepCloneGroups(groups: ParsedGroup[]): ParsedGroup[] {
+  return groups.map((g) => ({
+    ...g,
+    members: g.members.map((m) => ({ ...m })),
+  }));
+}
+
+interface MemberChipProps {
+  member: ParsedGroupMember;
+  onToggleLeader?: () => void;
+}
+
+function MemberChip({ member, onToggleLeader }: MemberChipProps) {
+  const isLowConfidence = member.matched_member_id !== null && member.confidence < 0.7;
+  const isUnmatched = member.matched_member_id === null;
+  const isClickable = !isUnmatched && onToggleLeader;
+
+  return (
+    <button
+      type="button"
+      disabled={!isClickable}
+      onClick={isClickable ? onToggleLeader : undefined}
+      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+        isUnmatched
+          ? 'bg-red-50 text-red-600 line-through cursor-default'
+          : isLowConfidence
+          ? 'bg-amber-50 text-amber-700 border border-amber-200 active:scale-95'
+          : member.is_leader
+          ? 'bg-gray-900 text-white active:scale-95'
+          : 'bg-gray-100 text-gray-700 active:scale-95'
+      }`}
+    >
+      {member.nickname}
+      {member.is_leader && !isUnmatched && ' ★'}
+    </button>
+  );
+}
+
+// EditableGroupName is now imported from ./EditableGroupName
+
+export default function GroupParsePreview({
+  parsedGroups,
+  unmatchedNames,
+  unassignedMembers,
+  onConfirm,
+  onBack,
+  isSaving,
+}: GroupParsePreviewProps) {
+  const [groups, setGroups] = useState<ParsedGroup[]>(() => deepCloneGroups(parsedGroups));
+
+  const groupsMissingLeader = groups.filter(
+    (g) => !g.members.some((m) => m.is_leader && m.matched_member_id !== null),
+  );
+  const canSave = groupsMissingLeader.length === 0;
+
+  const handleRenameGroup = (groupIdx: number, newName: string) => {
+    setGroups((prev) => {
+      const next = deepCloneGroups(prev);
+      next[groupIdx].name = newName;
+      return next;
+    });
+  };
+
+  const handleToggleLeader = (groupIdx: number, memberIdx: number) => {
+    setGroups((prev) => {
+      const next = deepCloneGroups(prev);
+      const group = next[groupIdx];
+      const target = group.members[memberIdx];
+
+      if (target.matched_member_id === null) return prev;
+
+      if (target.is_leader) {
+        // 조장 해제 시: 그룹에 다른 조장이 있어야 함
+        const otherLeaders = group.members.filter(
+          (m, i) => i !== memberIdx && m.is_leader && m.matched_member_id !== null,
+        );
+        if (otherLeaders.length === 0) return prev; // 최소 1명 유지
+        target.is_leader = false;
+      } else {
+        target.is_leader = true;
+      }
+
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        <div>
+          <h3 className="text-sm font-bold text-gray-800">파싱 결과 확인</h3>
+          <p className="text-[11px] text-gray-400 mt-0.5">멤버를 눌러 조장을 지정/해제할 수 있습니다</p>
+        </div>
+
+        {/* Unmatched names warning */}
+        {unmatchedNames.length > 0 && (
+          <div className="flex items-start gap-2 rounded-xl bg-amber-50 px-3 py-2.5">
+            <FiAlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-600" />
+            <div>
+              <p className="text-xs font-medium text-amber-700">매칭되지 않은 이름</p>
+              <p className="text-xs text-amber-600 mt-0.5">{unmatchedNames.join(', ')}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Parsed groups */}
+        {groups.map((group, gIdx) => {
+          const hasLeader = group.members.some((m) => m.is_leader && m.matched_member_id !== null);
+          return (
+          <div key={gIdx} className={`rounded-xl border p-4 ${hasLeader ? 'border-gray-200' : 'border-red-200 bg-red-50/30'}`}>
+            <div className="flex items-center justify-between mb-2">
+              <EditableGroupName
+                name={group.name}
+                onChange={(v) => handleRenameGroup(gIdx, v)}
+              />
+              {!hasLeader && <span className="text-[11px] text-red-400">조장을 지정해주세요</span>}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {group.members.map((member, mIdx) => (
+                <MemberChip
+                  key={mIdx}
+                  member={member}
+                  onToggleLeader={() => handleToggleLeader(gIdx, mIdx)}
+                />
+              ))}
+            </div>
+          </div>
+          );
+        })}
+
+        {/* Unassigned members */}
+        {unassignedMembers.length > 0 && (
+          <div className="rounded-xl border border-dashed border-gray-300 p-4">
+            <h4 className="text-xs font-medium text-gray-500 mb-2">미배정 멤버</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {unassignedMembers.map((m) => (
+                <span
+                  key={m.member_id}
+                  className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500"
+                >
+                  {m.nickname}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100 flex gap-2">
+        <Button variant="secondary" size="md" onClick={onBack} className="flex-1">
+          다시 입력
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
+          onClick={() => onConfirm(toGroupInputs(groups))}
+          disabled={isSaving || !canSave}
+          className="flex-1"
+        >
+          {isSaving ? '저장 중...' : '저장하기'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/GroupSettingsSection.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupSettingsSection.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { FiPlus } from 'react-icons/fi';
+
+import ConfirmModal from '@/_components/ui/ConfirmModal';
+import { useToast } from '@/_context/ToastContext';
+import { useGroupSets, useUpdateGroupSet, useDeleteGroupSet } from '@/_lib/hooks/useGroups';
+
+interface GroupSettingsSectionProps {
+  teamId: number;
+  canManage: boolean;
+}
+
+export default function GroupSettingsSection({ teamId, canManage }: GroupSettingsSectionProps) {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const { data: groupSetsData } = useGroupSets(teamId);
+  const updateGroupSet = useUpdateGroupSet(teamId);
+  const deleteGroupSetMutation = useDeleteGroupSet(teamId);
+
+  const [editingSetId, setEditingSetId] = useState<number | null>(null);
+  const [editName, setEditName] = useState('');
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
+
+  const groupSets = groupSetsData?.group_sets ?? [];
+  const showActions = canManage;
+  const deleteTarget = groupSets.find((s) => s.id === deleteConfirmId);
+
+  const handleStartEdit = (setId: number, currentName: string) => {
+    setEditingSetId(setId);
+    setEditName(currentName);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingSetId(null);
+    setEditName('');
+  };
+
+  const handleSaveEdit = async () => {
+    if (editingSetId === null) return;
+    const trimmed = editName.trim();
+    if (!trimmed) {
+      showToast('이름을 입력해주세요', 'error');
+      return;
+    }
+    try {
+      await updateGroupSet.mutateAsync({ setId: editingSetId, data: { name: trimmed } });
+      showToast('이름이 변경되었습니다', 'success');
+      handleCancelEdit();
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '이름 변경에 실패했습니다', 'error');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (deleteConfirmId === null) return;
+    try {
+      await deleteGroupSetMutation.mutateAsync(deleteConfirmId);
+      showToast('그룹이 삭제되었습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '삭제에 실패했습니다', 'error');
+    }
+    setDeleteConfirmId(null);
+  };
+
+  const navigateToGroups = () => {
+    router.push(`/chinba/team/groups?id=${teamId}`);
+  };
+
+  return (
+    <section className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-bold text-gray-800">그룹/조 관리</h2>
+        {showActions && groupSets.length > 0 && (
+          <button
+            onClick={navigateToGroups}
+            className="flex items-center gap-1 text-xs font-medium text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            <FiPlus size={14} />
+            새 조 편성
+          </button>
+        )}
+      </div>
+
+      <div className="rounded-xl border border-gray-100 bg-white">
+        {groupSets.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10">
+            <p className="text-sm text-gray-400 mb-3">아직 조가 편성되지 않았습니다</p>
+            {showActions && (
+              <button
+                onClick={navigateToGroups}
+                className="rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+              >
+                조 편성하기
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {groupSets.map((set) => (
+              <div key={set.id} className="p-4">
+                {/* Set header */}
+                {editingSetId === set.id ? (
+                  <div className="flex items-center gap-2 mb-3">
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      maxLength={30}
+                      autoFocus
+                      className="flex-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-800 outline-none focus:border-gray-900 transition-colors"
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleSaveEdit();
+                        if (e.key === 'Escape') handleCancelEdit();
+                      }}
+                    />
+                    <button
+                      onClick={handleCancelEdit}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-50"
+                    >
+                      취소
+                    </button>
+                    <button
+                      onClick={handleSaveEdit}
+                      disabled={updateGroupSet.isPending}
+                      className="rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                    >
+                      저장
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-semibold text-gray-800">{set.name}</span>
+                      <span className="text-xs text-gray-400">{set.group_count}개 조</span>
+                    </div>
+                  </div>
+                )}
+
+                {/* Group chips */}
+                {set.groups.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5 mb-3">
+                    {set.groups.map((group) => (
+                      <span
+                        key={group.id}
+                        className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700"
+                      >
+                        {group.name}({group.member_count})
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-gray-400 mb-3">아직 조가 없습니다</p>
+                )}
+
+                {/* Action buttons */}
+                {showActions && editingSetId !== set.id && (
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleStartEdit(set.id, set.name)}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 border border-gray-200 transition-colors hover:bg-gray-50"
+                    >
+                      이름변경
+                    </button>
+                    {set.groups.length > 0 && (
+                      <button
+                        onClick={() => router.push(`/chinba/team/groups?id=${teamId}&mode=edit&setId=${set.id}`)}
+                        className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 border border-gray-200 transition-colors hover:bg-gray-50"
+                      >
+                        조 수정
+                      </button>
+                    )}
+                    <button
+                      onClick={() => router.push(`/chinba/team/groups?id=${teamId}&mode=recompose&setId=${set.id}`)}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 border border-gray-200 transition-colors hover:bg-gray-50"
+                    >
+                      재편성
+                    </button>
+                    <button
+                      onClick={() => setDeleteConfirmId(set.id)}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-red-400 border border-red-100 transition-colors hover:bg-red-50"
+                    >
+                      삭제
+                    </button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Delete Confirm Modal */}
+      <ConfirmModal
+        isOpen={deleteConfirmId !== null}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteConfirmId(null)}
+        title="그룹 삭제"
+        confirmLabel="삭제"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>&ldquo;{deleteTarget?.name}&rdquo; 그룹을 삭제하시겠습니까?</p>
+        <p className="mt-1 text-xs text-gray-400">소속 조와 편성이 모두 삭제됩니다</p>
+      </ConfirmModal>
+    </section>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/GroupTextInput.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupTextInput.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+
+interface GroupTextInputProps {
+  onParse: (text: string) => void;
+  isParsing: boolean;
+  onBack?: () => void;
+}
+
+export default function GroupTextInput({ onParse, isParsing, onBack }: GroupTextInputProps) {
+  const [text, setText] = useState('');
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 px-4 py-4">
+        <label className="block text-sm font-bold text-gray-700 mb-2">
+          조 편성 텍스트 입력
+        </label>
+        <p className="text-xs text-gray-400 mb-3">
+          엑셀, 카톡, 메모장 등 어떤 형식이든 OK
+        </p>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={`예시:\n1조: 홍길동(조장), 김철수, 이영희\n2조: 박지민(조장), 최수진, 정민호\n\n또는 엑셀에서 복사한 표 형식도 가능합니다.`}
+          className="w-full h-64 rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-800 placeholder-gray-400 outline-none focus:border-gray-900 transition-colors resize-none"
+          autoFocus
+        />
+      </div>
+
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+        <button
+          onClick={() => onParse(text)}
+          disabled={!text.trim() || isParsing}
+          className="w-full rounded-lg bg-gray-900 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-gray-800 disabled:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isParsing ? (
+            <span className="flex items-center justify-center gap-2">
+              <LoadingSpinner size="sm" color="white" />
+              분석 중...
+            </span>
+          ) : (
+            'AI로 분석하기'
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/MemberActionBar.tsx
+++ b/app/(main)/chinba/_components/team/groups/MemberActionBar.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+interface MemberActionBarProps {
+  nickname: string;
+  isLeader: boolean;
+  onSetLeader: () => void;
+  onMove: () => void;
+  onUnassign: () => void;
+  onClose: () => void;
+}
+
+export default function MemberActionBar({
+  nickname,
+  isLeader,
+  onSetLeader,
+  onMove,
+  onUnassign,
+  onClose,
+}: MemberActionBarProps) {
+  return (
+    <div className="shrink-0 border-t border-gray-200 bg-white px-4 py-3 pb-safe">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium text-gray-800">{nickname}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          닫기
+        </button>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onSetLeader}
+          disabled={isLeader}
+          className={`flex-1 rounded-xl py-2.5 text-xs font-medium transition-all active:scale-95 ${
+            isLeader
+              ? 'bg-gray-100 text-gray-400'
+              : 'bg-gray-900 text-white hover:bg-gray-800'
+          }`}
+        >
+          조장 지정
+        </button>
+        <button
+          type="button"
+          onClick={onMove}
+          className="flex-1 rounded-xl border border-gray-200 py-2.5 text-xs font-medium text-gray-700 hover:bg-gray-50 transition-all active:scale-95"
+        >
+          이동
+        </button>
+        <button
+          type="button"
+          onClick={onUnassign}
+          className="flex-1 rounded-xl border border-gray-200 py-2.5 text-xs font-medium text-gray-700 hover:bg-gray-50 transition-all active:scale-95"
+        >
+          미배정으로
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/_components/team/groups/MoveTargetSheet.tsx
+++ b/app/(main)/chinba/_components/team/groups/MoveTargetSheet.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState } from 'react';
+
+interface MoveTargetSheetProps {
+  memberNickname: string;
+  groups: { name: string; isCurrent: boolean }[];
+  onSelect: (groupIdx: number) => void;
+  onCancel: () => void;
+}
+
+export default function MoveTargetSheet({
+  memberNickname,
+  groups,
+  onSelect,
+  onCancel,
+}: MoveTargetSheetProps) {
+  const [selected, setSelected] = useState<number | null>(null);
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        className="w-[80%] max-w-xs rounded-2xl bg-white p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="text-center text-base font-semibold text-gray-900 mb-3">
+          {memberNickname}을(를) 이동할 조 선택
+        </p>
+        <div className="space-y-2 max-h-60 overflow-y-auto">
+          {groups.map((g, idx) => (
+            <button
+              key={idx}
+              type="button"
+              disabled={g.isCurrent}
+              onClick={() => setSelected(idx)}
+              className={`w-full text-left rounded-xl border p-3 transition-colors ${
+                g.isCurrent
+                  ? 'border-gray-100 bg-gray-50 text-gray-300 cursor-default'
+                  : selected === idx
+                  ? 'border-gray-900 bg-gray-50'
+                  : 'border-gray-200 hover:border-gray-300'
+              }`}
+            >
+              <span className="text-sm font-medium">
+                {g.name}
+                {g.isCurrent && (
+                  <span className="text-xs text-gray-300 ml-1">(현재)</span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 active:scale-95 transition-all"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={() => selected !== null && onSelect(selected)}
+            disabled={selected === null}
+            className="flex-1 rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white hover:bg-gray-800 active:scale-95 transition-all disabled:opacity-50"
+          >
+            이동
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/layout.tsx
+++ b/app/(main)/chinba/layout.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import BottomTabBar from './_components/BottomTabBar';
+
+const BOTTOM_TAB_PATHS = new Set(['/chinba', '/chinba/team', '/chinba/my']);
+
+export default function ChinbaLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const normalized = pathname.replace(/\/$/, '') || '/';
+  const showBottomTab = BOTTOM_TAB_PATHS.has(normalized);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
+      {showBottomTab && <BottomTabBar />}
+    </div>
+  );
+}

--- a/app/(main)/chinba/my/page.tsx
+++ b/app/(main)/chinba/my/page.tsx
@@ -1,0 +1,5 @@
+import MyTabContent from '../_components/MyTabContent';
+
+export default function MyPage() {
+  return <MyTabContent />;
+}

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from 'react';
+
 import ChinbaTimetableView from './_components/ChinbaTimetableView';
 
 export default function ChinbaPage() {
-    return (
-        <Suspense fallback={null}>
-            <ChinbaTimetableView />
-        </Suspense>
-    );
+  return (
+    <Suspense fallback={null}>
+      <ChinbaTimetableView />
+    </Suspense>
+  );
 }

--- a/app/(main)/chinba/team/create/page.tsx
+++ b/app/(main)/chinba/team/create/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import TeamCreateView from '../../_components/team/TeamCreateView';
+
+export default function TeamCreatePage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamCreateView />
+    </Suspense>
+  );
+}

--- a/app/(main)/chinba/team/detail/page.tsx
+++ b/app/(main)/chinba/team/detail/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import TeamDetailView from '../../_components/team/TeamDetailView';
+
+export default function TeamDetailPage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamDetailView />
+    </Suspense>
+  );
+}

--- a/app/(main)/chinba/team/event-create/page.tsx
+++ b/app/(main)/chinba/team/event-create/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import TeamEventCreateView from '../../_components/team/TeamEventCreateView';
+
+export default function EventCreatePage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamEventCreateView />
+    </Suspense>
+  );
+}

--- a/app/(main)/chinba/team/groups/page.tsx
+++ b/app/(main)/chinba/team/groups/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import GroupManageView from '../../_components/team/GroupManageView';
+
+export default function GroupsPage() {
+  return (
+    <Suspense fallback={null}>
+      <GroupManageView />
+    </Suspense>
+  );
+}

--- a/app/(main)/chinba/team/join/page.tsx
+++ b/app/(main)/chinba/team/join/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import TeamJoinView from '../../_components/team/TeamJoinView';
+
+export default function TeamJoinPage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamJoinView />
+    </Suspense>
+  );
+}

--- a/app/(main)/chinba/team/page.tsx
+++ b/app/(main)/chinba/team/page.tsx
@@ -1,0 +1,5 @@
+import TeamListView from '../_components/team/TeamListView';
+
+export default function TeamPage() {
+  return <TeamListView />;
+}

--- a/app/(main)/chinba/team/settings/page.tsx
+++ b/app/(main)/chinba/team/settings/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from 'react';
+import TeamSettingsView from '../../_components/team/TeamSettingsView';
+
+export default function TeamSettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamSettingsView />
+    </Suspense>
+  );
+}

--- a/app/(main)/filter/_components/BoardFilterContent.tsx
+++ b/app/(main)/filter/_components/BoardFilterContent.tsx
@@ -460,7 +460,7 @@ export default function BoardFilterContent({
         )}
 
         {/* 버튼 영역 */}
-        <div className="flex gap-3 px-5 py-4">
+        <div className="flex gap-3 px-5 py-4 pb-safe">
           <Button variant="outline" fullWidth onClick={onClose}>
             취소
           </Button>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -41,7 +41,8 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
   };
 
   const normalizedPath = pathname === '/' ? '/' : pathname.replace(/\/$/, '');
-  const showHeader = MAIN_PAGES.has(normalizedPath);
+  const CHINBA_HEADER_PATHS = new Set(['/chinba', '/chinba/team', '/chinba/my']);
+  const showHeader = MAIN_PAGES.has(normalizedPath) || CHINBA_HEADER_PATHS.has(normalizedPath);
 
   const collapsed = desktopCollapsed;
   // sidebar(60 or 260) + content — iPad Pro 12.9" 가로(1366px)까지 꽉 채움

--- a/app/(main)/profile/_components/ProfileClient.tsx
+++ b/app/(main)/profile/_components/ProfileClient.tsx
@@ -12,7 +12,6 @@ import { getAllDepartments, deleteUserAccount, logoutUser } from '@/_lib/api';
 import { useUserStore } from '@/_lib/store/useUserStore';
 import { useToast } from '@/_context/ToastContext';
 import ProfileTabs, { ProfileTabType } from './ProfileTabs';
-import { TimetableTab } from '@/_components/timetable';
 import CareerTab from './career/CareerTab';
 
 function formatAdmissionYear(year: number | null | undefined): string | null {
@@ -36,10 +35,11 @@ export default function ProfileClient() {
   const [isAnimating, setIsAnimating] = useState(false);
   const prevTabRef = useRef<ProfileTabType>(initialTab);
 
-  const TAB_INDEX: Record<ProfileTabType, number> = { basic: 0, timetable: 1, career: 2 };
+  const TAB_INDEX: Record<ProfileTabType, number> = { basic: 0, career: 1 };
 
   const [formData, setFormData] = useState<UserInfoFormData>({
     nickname: '',
+    username: '',
     school: '',
     dept_code: '',
     dept_name: '',
@@ -66,6 +66,7 @@ export default function ProfileClient() {
     if (user) {
       setFormData({
         nickname: user.nickname || '',
+        username: user.username || '',
         school: user.school || '',
         dept_code: user.dept_code || '',
         dept_name: '',
@@ -88,6 +89,7 @@ export default function ProfileClient() {
     if (user) {
       setFormData({
         nickname: user.nickname || '',
+        username: user.username || '',
         school: user.school || '',
         dept_code: user.dept_code || '',
         dept_name: '',
@@ -116,6 +118,7 @@ export default function ProfileClient() {
     try {
       await updateMutation.mutateAsync({
         nickname: formData.nickname,
+        username: formData.username,
         school: formData.school,
         dept_code: formData.dept_code,
         admission_year: formData.admission_year ? parseInt(formData.admission_year) : undefined,
@@ -171,7 +174,9 @@ export default function ProfileClient() {
           <p className="text-lg leading-tight font-bold text-gray-800">
             {user?.nickname || '사용자'}
           </p>
-          <p className="mt-1 text-xs text-gray-400">{user?.email}</p>
+          {user?.username && (
+            <p className="mt-0.5 text-sm text-gray-500">@{user.username}</p>
+          )}
           {(user?.school || deptName || admissionYearText) && (
             <p className="mt-0.5 text-xs text-gray-400">
               {[user?.school, deptName, admissionYearText].filter(Boolean).join(' · ')}
@@ -207,7 +212,8 @@ export default function ProfileClient() {
                     onChange={handleFormChange}
                     email={user?.email}
                     showNickname={true}
-                    isReadonlyNickname={true}
+                    isReadonlyNickname={false}
+                    showUsername={true}
                     isReadonly={!isEditing}
                   />
 
@@ -277,12 +283,6 @@ export default function ProfileClient() {
                     같은 계정으로 다시 가입할 수 있습니다.
                   </p>
                 </ConfirmModal>
-              </div>
-            )}
-
-            {activeTab === 'timetable' && (
-              <div className="h-full">
-                <TimetableTab />
               </div>
             )}
 

--- a/app/(main)/profile/_components/ProfileTabs.tsx
+++ b/app/(main)/profile/_components/ProfileTabs.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useLayoutEffect, useState, useCallback } from 'react';
 
-export type ProfileTabType = 'basic' | 'timetable' | 'career';
+export type ProfileTabType = 'basic' | 'career';
 
 interface ProfileTabsProps {
   activeTab: ProfileTabType;
@@ -11,7 +11,6 @@ interface ProfileTabsProps {
 
 const TABS: { key: ProfileTabType; label: string }[] = [
   { key: 'basic', label: '기본정보' },
-  { key: 'timetable', label: '일정관리' },
   { key: 'career', label: '이력관리' },
 ];
 

--- a/app/(main)/teams/_components/GroupFilterBar.tsx
+++ b/app/(main)/teams/_components/GroupFilterBar.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import type { GroupSet } from '@/_types/team';
+
+interface GroupFilterBarProps {
+  groupSets: GroupSet[];
+  selectedSetId: number | null;
+  selectedGroupId: number | null;
+  onSetChange: (setId: number | null) => void;
+  onGroupChange: (groupId: number | null) => void;
+}
+
+export default function GroupFilterBar({
+  groupSets,
+  selectedSetId,
+  selectedGroupId,
+  onSetChange,
+  onGroupChange,
+}: GroupFilterBarProps) {
+  if (groupSets.length === 0) return null;
+
+  const selectedSet = groupSets.find((s) => s.id === selectedSetId) ?? null;
+  const showSetRow = groupSets.length > 1;
+
+  return (
+    <div className="space-y-2">
+      {/* 1행: 그룹세트 선택 */}
+      {showSetRow && (
+        <div className="flex gap-2 overflow-x-auto no-scrollbar">
+          <button
+            onClick={() => {
+              onSetChange(null);
+              onGroupChange(null);
+            }}
+            className={`shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+              selectedSetId === null
+                ? 'bg-gray-900 text-white'
+                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            전체
+          </button>
+          {groupSets.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => {
+                onSetChange(s.id);
+                onGroupChange(null);
+              }}
+              className={`shrink-0 rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                selectedSetId === s.id
+                  ? 'bg-gray-900 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* 2행: 조 선택 (그룹세트 선택 시) */}
+      {selectedSet && selectedSet.groups.length > 0 && (
+        <div className="flex gap-1.5 overflow-x-auto no-scrollbar">
+          <button
+            onClick={() => onGroupChange(null)}
+            className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+              selectedGroupId === null
+                ? 'bg-gray-700 text-white'
+                : 'bg-gray-50 text-gray-500 hover:bg-gray-100'
+            }`}
+          >
+            전체
+          </button>
+          {selectedSet.groups.map((g) => (
+            <button
+              key={g.id}
+              onClick={() => onGroupChange(g.id)}
+              className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                selectedGroupId === g.id
+                  ? 'bg-gray-700 text-white'
+                  : 'bg-gray-50 text-gray-500 hover:bg-gray-100'
+              }`}
+            >
+              {selectedSet.name} - {g.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(main)/teams/_components/InviteSection.tsx
+++ b/app/(main)/teams/_components/InviteSection.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+
+import { FiCopy, FiShare2, FiRefreshCw } from 'react-icons/fi';
+
+import { formatInviteUrl } from '@/_lib/utils/teamDisplay';
+
+interface InviteSectionProps {
+  inviteCode: string | null;
+  canRegenerate: boolean;
+  onRegenerate: () => void;
+  isRegenerating?: boolean;
+  onShowToast: (message: string, type?: 'success' | 'error' | 'info') => void;
+}
+
+export default function InviteSection({
+  inviteCode,
+  canRegenerate,
+  onRegenerate,
+  isRegenerating = false,
+  onShowToast,
+}: InviteSectionProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (!inviteCode) {
+    return (
+      <div className="rounded-xl border border-gray-100 bg-gray-50 p-4 text-center">
+        <p className="text-sm text-gray-400">초대 링크가 없습니다</p>
+      </div>
+    );
+  }
+
+  const inviteUrl = formatInviteUrl(inviteCode);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      onShowToast('초대 링크가 복사되었습니다', 'success');
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      onShowToast('복사에 실패했습니다', 'error');
+    }
+  };
+
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: '팀 초대',
+          text: '팀에 참여하세요!',
+          url: inviteUrl,
+        });
+      } catch {
+        // User cancelled sharing
+      }
+    } else {
+      handleCopy();
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Invite code display */}
+      <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+        <p className="text-[11px] text-gray-400 mb-1">초대 코드</p>
+        <p className="text-sm font-mono font-medium text-gray-700 break-all">
+          {inviteCode}
+        </p>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <button
+          onClick={handleCopy}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-gray-200 bg-white py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 active:scale-95"
+        >
+          <FiCopy size={14} />
+          {copied ? '복사됨' : '링크 복사'}
+        </button>
+        <button
+          onClick={handleShare}
+          className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gray-900 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+        >
+          <FiShare2 size={14} />
+          공유하기
+        </button>
+      </div>
+
+      {/* Regenerate */}
+      {canRegenerate && (
+        <button
+          onClick={onRegenerate}
+          disabled={isRegenerating}
+          className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-gray-100 py-2.5 text-xs text-gray-400 transition-colors hover:bg-gray-50 disabled:opacity-50"
+        >
+          <FiRefreshCw size={12} className={isRegenerating ? 'animate-spin' : ''} />
+          초대 코드 재생성
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/(main)/teams/_components/MemberList.tsx
+++ b/app/(main)/teams/_components/MemberList.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+
+import { FiUser, FiMoreVertical } from 'react-icons/fi';
+
+import { useGroupSets } from '@/_lib/hooks/useGroups';
+import { getRoleBadgeLabel, getRoleBadgeColor, buildGroupSetNameMap, groupDisplayName } from '@/_lib/utils/teamDisplay';
+import { canRemoveMember, canChangeRole } from '@/_lib/utils/teamPermissions';
+import type { TeamMember, TeamRole } from '@/_types/team';
+
+interface MemberListProps {
+  members: TeamMember[];
+  myRole: TeamRole;
+  teamId?: number;
+  onChangeRole?: (memberId: number, role: TeamRole) => void;
+  onRemoveMember?: (memberId: number) => void;
+}
+
+const ROLE_BADGE_STYLES: Record<string, string> = {
+  red: 'bg-red-100 text-red-700',
+  blue: 'bg-blue-100 text-blue-700',
+  gray: 'bg-gray-100 text-gray-500',
+};
+
+const ROLE_OPTIONS: { value: TeamRole; label: string }[] = [
+  { value: 'captain', label: '팀장' },
+  { value: 'executive', label: '임원' },
+  { value: 'member', label: '팀원' },
+];
+
+export default function MemberList({
+  members,
+  myRole,
+  teamId,
+  onChangeRole,
+  onRemoveMember,
+}: MemberListProps) {
+  const [openMenuId, setOpenMenuId] = useState<number | null>(null);
+  const { data: groupSetsData } = useGroupSets(teamId);
+  const groupSetNameMap = useMemo(() => buildGroupSetNameMap(groupSetsData?.group_sets ?? []), [groupSetsData]);
+
+  const handleMenuToggle = (memberId: number) => {
+    setOpenMenuId((prev) => (prev === memberId ? null : memberId));
+  };
+
+  const showActions = canChangeRole(myRole);
+
+  return (
+    <div className="space-y-1">
+      {members.map((member) => {
+        const roleColor = getRoleBadgeColor(member.role);
+        const roleLabel = getRoleBadgeLabel(member.role);
+        const canRemove = canRemoveMember(myRole, member.role);
+
+        return (
+          <div
+            key={member.id}
+            className="flex items-center gap-3 rounded-lg px-3 py-2.5 hover:bg-gray-50 transition-colors"
+          >
+            {/* Avatar */}
+            {member.profile_image ? (
+              <img
+                src={member.profile_image}
+                alt={member.nickname || ''}
+                className="h-9 w-9 rounded-full border border-gray-100 object-cover"
+              />
+            ) : (
+              <div className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-400">
+                <FiUser size={16} />
+              </div>
+            )}
+
+            {/* Info */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className="text-sm font-medium text-gray-800 truncate">
+                  {member.nickname || '사용자'}
+                </span>
+                <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${ROLE_BADGE_STYLES[roleColor] || ROLE_BADGE_STYLES.gray}`}>
+                  {roleLabel}
+                </span>
+              </div>
+              {member.group && (
+                <p className="text-[11px] text-gray-400 mt-0.5">
+                  {groupDisplayName(member.group.name, member.group.id, groupSetNameMap)}
+                  {member.group.is_leader && ' (조장)'}
+                </p>
+              )}
+            </div>
+
+            {/* Actions */}
+            {showActions && member.role !== 'captain' && (
+              <div className="relative">
+                <button
+                  onClick={() => handleMenuToggle(member.id)}
+                  className="rounded-full p-1.5 text-gray-400 hover:bg-gray-100 transition-colors"
+                >
+                  <FiMoreVertical size={16} />
+                </button>
+
+                {openMenuId === member.id && (
+                  <>
+                    <div
+                      className="fixed inset-0 z-10"
+                      onClick={() => setOpenMenuId(null)}
+                    />
+                    <div className="absolute right-0 top-full z-20 mt-1 w-32 rounded-xl border border-gray-100 bg-white py-1 shadow-lg">
+                      {ROLE_OPTIONS.filter((r) => r.value !== 'captain' && r.value !== member.role).map((role) => (
+                        <button
+                          key={role.value}
+                          onClick={() => {
+                            onChangeRole?.(member.id, role.value);
+                            setOpenMenuId(null);
+                          }}
+                          className="w-full px-3 py-2 text-left text-xs text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          {role.label}으로 변경
+                        </button>
+                      ))}
+                      {canRemove && (
+                        <button
+                          onClick={() => {
+                            onRemoveMember?.(member.id);
+                            setOpenMenuId(null);
+                          }}
+                          className="w-full px-3 py-2 text-left text-xs text-red-500 hover:bg-red-50 transition-colors"
+                        >
+                          내보내기
+                        </button>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(main)/teams/_components/TeamCard.tsx
+++ b/app/(main)/teams/_components/TeamCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { FiUsers } from 'react-icons/fi';
+
+import { getRoleBadgeLabel, getRoleBadgeColor, formatMemberCount } from '@/_lib/utils/teamDisplay';
+import type { TeamListItem } from '@/_types/team';
+
+interface TeamCardProps {
+  team: TeamListItem;
+  onClick: () => void;
+}
+
+export default function TeamCard({ team, onClick }: TeamCardProps) {
+  const roleLabel = getRoleBadgeLabel(team.my_role);
+  const roleColor = getRoleBadgeColor(team.my_role);
+
+  const roleBadgeStyles: Record<string, string> = {
+    red: 'bg-red-100 text-red-700',
+    blue: 'bg-blue-100 text-blue-700',
+    gray: 'bg-gray-100 text-gray-500',
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left rounded-xl border border-gray-100 bg-white p-4 transition-all hover:border-gray-200 active:scale-[0.98] cursor-pointer"
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <h3 className="text-sm font-bold text-gray-800 truncate">
+              {team.name}
+            </h3>
+            {team.is_paid && (
+              <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">
+                프리미엄
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1 text-xs text-gray-400">
+              <FiUsers size={12} />
+              <span>{formatMemberCount(team.member_count)}</span>
+            </div>
+            <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${roleBadgeStyles[roleColor] || roleBadgeStyles.gray}`}>
+              {roleLabel}
+            </span>
+            {team.category && (
+              <span className="text-[10px] text-gray-400">
+                {team.category}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/app/(main)/teams/_components/TeamSegmentTabs.tsx
+++ b/app/(main)/teams/_components/TeamSegmentTabs.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+export type TeamSegment = 'mannaja' | 'mwoheni' | 'jabahbwa';
+
+interface TeamSegmentTabsProps {
+  activeTab: TeamSegment;
+  onTabChange: (tab: TeamSegment) => void;
+}
+
+const TABS: { key: TeamSegment; label: string }[] = [
+  { key: 'mannaja', label: '만나자' },
+  { key: 'mwoheni', label: '뭐했니' },
+  { key: 'jabahbwa', label: '잡아봐' },
+];
+
+export default function TeamSegmentTabs({ activeTab, onTabChange }: TeamSegmentTabsProps) {
+  return (
+    <div className="flex border-b border-gray-100">
+      {TABS.map((tab) => {
+        const isActive = activeTab === tab.key;
+        return (
+          <button
+            key={tab.key}
+            onClick={() => onTabChange(tab.key)}
+            className={`flex-1 py-3 text-center text-sm font-medium transition-colors relative ${
+              isActive
+                ? 'text-gray-900 font-bold'
+                : 'text-gray-400 hover:text-gray-600'
+            }`}
+          >
+            {tab.label}
+            {isActive && (
+              <span className="absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 w-12 rounded-full bg-gray-900" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(main)/teams/_components/UpgradeModal.tsx
+++ b/app/(main)/teams/_components/UpgradeModal.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+interface UpgradeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  teamId: number;
+}
+
+const PREMIUM_FEATURES = [
+  { label: '활동 기록 (뭐했니)', description: '조별 활동을 기록하고 공유' },
+  { label: '조별 기록 비교 (잡아봐)', description: '조별 활동 데이터를 비교·분석·랭킹' },
+];
+
+const PRICING_DISPLAY = [
+  { tier: 'Standard', members: '1~39명', price: '8,900원/월' },
+  { tier: 'Pro', members: '40~79명', price: '17,900원/월' },
+  { tier: 'Business', members: '80명+', price: '34,900원/월' },
+];
+
+export default function UpgradeModal({ isOpen, onClose, teamId }: UpgradeModalProps) {
+  const router = useRouter();
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div
+        className="w-[85%] max-w-sm rounded-2xl bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Title */}
+        <div className="text-center mb-5">
+          <div className="mb-2 flex justify-center">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-xl">
+              &#x2B50;
+            </span>
+          </div>
+          <p className="text-base font-bold text-gray-900">프리미엄 기능입니다</p>
+          <p className="mt-1 text-xs text-gray-500">
+            구독하고 팀 관리 기능을 모두 이용하세요
+          </p>
+        </div>
+
+        {/* Feature list */}
+        <div className="mb-5 space-y-2.5">
+          {PREMIUM_FEATURES.map((feature) => (
+            <div key={feature.label} className="flex items-start gap-2.5">
+              <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-blue-500 text-[10px] text-white">
+                &#x2713;
+              </span>
+              <div>
+                <p className="text-sm font-medium text-gray-800">{feature.label}</p>
+                <p className="text-xs text-gray-400">{feature.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Pricing preview */}
+        <div className="mb-5 rounded-xl bg-gray-50 p-3">
+          <p className="mb-2 text-xs font-semibold text-gray-500">
+            요금제 (월 결제 기준)
+          </p>
+          <div className="flex justify-between text-xs text-gray-600">
+            {PRICING_DISPLAY.map((item) => (
+              <div key={item.tier} className="text-center">
+                <p className="font-semibold text-gray-800">{item.tier}</p>
+                <p className="font-medium text-gray-700">{item.price}</p>
+                <p className="text-gray-400">{item.members}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 active:scale-95 transition-all"
+          >
+            닫기
+          </button>
+          <button
+            onClick={() => {
+              onClose();
+              router.push(`/chinba/team/settings?id=${teamId}`);
+            }}
+            className="flex-1 rounded-xl bg-blue-500 py-3 text-sm font-semibold text-white hover:bg-blue-600 active:scale-95 transition-all"
+          >
+            구독하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/teams/create/page.tsx
+++ b/app/(main)/teams/create/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { FiXCircle } from 'react-icons/fi';
+import { LuChevronLeft } from 'react-icons/lu';
+
+import Button from '@/_components/ui/Button';
+import { useToast } from '@/_context/ToastContext';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useCreateTeam } from '@/_lib/hooks/useTeam';
+import { getCategoryOptions } from '@/_lib/utils/teamDisplay';
+
+export default function TeamCreatePage() {
+  const router = useRouter();
+  const smartBack = useSmartBack('/teams');
+  const createTeam = useCreateTeam();
+  const { showToast } = useToast();
+
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const categoryOptions = getCategoryOptions();
+  const canSubmit = name.trim().length > 0 && !createTeam.isPending;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setError(null);
+
+    try {
+      const result = await createTeam.mutateAsync({
+        name: name.trim(),
+        category: category || undefined,
+      });
+      showToast('팀이 생성되었습니다', 'success');
+      router.replace(`/teams/detail?id=${result.id}`);
+    } catch (err: any) {
+      const detail = err.response?.data?.detail || '팀 생성에 실패했습니다';
+      setError(detail);
+      showToast(detail, 'error');
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      {/* Header */}
+      <div className="shrink-0 px-4 pb-3">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 flex items-center justify-center">
+          <button
+            onClick={smartBack}
+            className="absolute left-0 z-10 group -ml-1 rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+            aria-label="뒤로가기"
+          >
+            <LuChevronLeft size={24} strokeWidth={2.5} className="transition-transform group-hover:-translate-x-0.5" />
+          </button>
+          <h1 className="text-base font-bold text-gray-800">팀 만들기</h1>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4">
+        {error && (
+          <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+
+        <div className="mb-6">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            팀 이름
+          </label>
+          <div className="relative">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 코딩 동아리, 졸업 프로젝트"
+              maxLength={50}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-800 placeholder-gray-400 outline-none focus:border-gray-900 transition-colors"
+            />
+            {name.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setName('')}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-gray-500 transition-colors"
+              >
+                <FiXCircle size={18} />
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-[11px] text-gray-400 text-right">{name.length}/50</p>
+        </div>
+
+        <div className="mb-6">
+          <label className="block text-sm font-bold text-gray-700 mb-2">
+            카테고리
+            <span className="ml-1 text-xs font-normal text-gray-400">(선택)</span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {categoryOptions.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setCategory((prev) => (prev === opt.value ? '' : opt.value))}
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors active:scale-95 ${
+                  category === opt.value
+                    ? 'border-gray-900 bg-gray-900 text-white'
+                    : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          {createTeam.isPending ? '만드는 중...' : '만들기'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -1,0 +1,340 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+
+import { LuPlus, LuClock, LuCalendar, LuTrash2 } from 'react-icons/lu';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useActivities, useCreateActivity, useDeleteActivity } from '@/_lib/hooks/useActivities';
+import { useGroups, useGroupSets } from '@/_lib/hooks/useGroups';
+import { getRoleBadgeLabel, buildGroupSetNameMap, groupDisplayName } from '@/_lib/utils/teamDisplay';
+import type { TeamRole, Activity, ActivityCreateRequest } from '@/_types/team';
+
+interface ActivityTabProps {
+  teamId: number;
+  myRole: TeamRole;
+  selectedSetId?: number | null;
+  selectedGroupId?: number | null;
+}
+
+export default function ActivityTab({ teamId, myRole, selectedSetId, selectedGroupId }: ActivityTabProps) {
+  const { data, isLoading } = useActivities(teamId);
+  const { data: groupsData } = useGroups(teamId);
+  const createMutation = useCreateActivity(teamId);
+  const deleteMutation = useDeleteActivity(teamId);
+
+  const [showForm, setShowForm] = useState(false);
+  const [formData, setFormData] = useState<ActivityCreateRequest>({
+    title: '',
+    activity_date: new Date().toISOString().slice(0, 10),
+  });
+  const [formScores, setFormScores] = useState<{ group_id: number; score: number }[]>([]);
+
+  const hasRole = myRole === 'captain' || myRole === 'executive';
+  const isGroupSelected = selectedGroupId !== null && selectedGroupId !== undefined;
+  const canRecord = hasRole && isGroupSelected;
+  const canDelete = hasRole;
+
+  const { data: groupSetsData } = useGroupSets(teamId);
+  const groupSets = groupSetsData?.group_sets ?? [];
+  const groupSetNameMap = useMemo(() => buildGroupSetNameMap(groupSets), [groupSets]);
+
+  // 선택된 세트의 group_id 집합
+  const selectedGroupIds = useMemo(() => {
+    if (!selectedSetId) return null;
+    const set = groupSets.find((s) => s.id === selectedSetId);
+    if (!set) return null;
+    return new Set(set.groups.map((g) => g.id));
+  }, [selectedSetId, groupSets]);
+
+  // 조별 점수 입력 시 보여줄 그룹 필터링
+  const visibleGroups = useMemo(() => {
+    const allGroups = groupsData?.groups ?? [];
+    if (selectedGroupId) return allGroups.filter((g) => g.id === selectedGroupId);
+    if (selectedGroupIds) return allGroups.filter((g) => selectedGroupIds.has(g.id));
+    return allGroups;
+  }, [groupsData, selectedGroupId, selectedGroupIds]);
+
+  // 조 선택 해제 시 폼 닫기
+  useEffect(() => {
+    setShowForm(false);
+  }, [selectedGroupId]);
+
+  // 활동 필터링
+  const allActivities = data?.activities ?? [];
+  const activities = useMemo(() => {
+    if (!selectedGroupIds && !selectedGroupId) return allActivities;
+    return allActivities.filter((a) => {
+      if (a.scores.length === 0) return true;
+      if (selectedGroupId) return a.scores.some((s) => s.group_id === selectedGroupId);
+      if (selectedGroupIds) return a.scores.some((s) => selectedGroupIds.has(s.group_id));
+      return true;
+    });
+  }, [allActivities, selectedGroupIds, selectedGroupId]);
+
+  const handleSubmit = async () => {
+    if (!formData.title.trim()) return;
+    try {
+      await createMutation.mutateAsync({
+        ...formData,
+        scores: formScores.length > 0 ? formScores : undefined,
+      });
+      setShowForm(false);
+      setFormData({ title: '', activity_date: new Date().toISOString().slice(0, 10) });
+      setFormScores([]);
+    } catch {
+      // error handled by mutation
+    }
+  };
+
+  const handleDelete = async (activityId: number) => {
+    if (!confirm('활동 기록을 삭제하시겠습니까?')) return;
+    try {
+      await deleteMutation.mutateAsync(activityId);
+    } catch {
+      // error handled by mutation
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Create Button */}
+      {canRecord && !showForm && (
+        <button
+          onClick={() => setShowForm(true)}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-3 text-sm font-medium text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-700"
+        >
+          <LuPlus size={16} />
+          활동 기록하기
+        </button>
+      )}
+
+      {/* 조 미선택 안내 */}
+      {hasRole && !isGroupSelected && !showForm && (
+        <p className="text-center text-xs text-gray-400 py-2">
+          조를 선택하면 활동을 기록할 수 있습니다
+        </p>
+      )}
+
+      {/* Create Form */}
+      {showForm && (
+        <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3">
+          <input
+            type="text"
+            placeholder="활동 제목"
+            value={formData.title}
+            onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+            maxLength={100}
+          />
+          <input
+            type="date"
+            value={formData.activity_date}
+            onChange={(e) => setFormData({ ...formData, activity_date: e.target.value })}
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+          />
+          <div className="flex gap-2">
+            <input
+              type="time"
+              placeholder="시작"
+              value={formData.start_time ?? ''}
+              onChange={(e) => setFormData({ ...formData, start_time: e.target.value || undefined })}
+              className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+            />
+            <input
+              type="time"
+              placeholder="종료"
+              value={formData.end_time ?? ''}
+              onChange={(e) => setFormData({ ...formData, end_time: e.target.value || undefined })}
+              className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+            />
+          </div>
+          <textarea
+            placeholder="활동 설명 (선택)"
+            value={formData.description ?? ''}
+            onChange={(e) => setFormData({ ...formData, description: e.target.value || undefined })}
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none resize-none"
+            rows={2}
+          />
+          <input
+            type="text"
+            placeholder="하이라이트 (선택)"
+            value={formData.highlight ?? ''}
+            onChange={(e) => setFormData({ ...formData, highlight: e.target.value || undefined })}
+            className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
+          />
+
+          {/* Group Scores */}
+          {visibleGroups.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-gray-500">조별 점수</p>
+              {visibleGroups.map((group) => {
+                const existing = formScores.find((s) => s.group_id === group.id);
+                return (
+                  <div key={group.id} className="flex items-center gap-2">
+                    <span className="text-xs text-gray-600 shrink-0">{groupDisplayName(group.name, group.id, groupSetNameMap)}</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={existing?.score ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        if (val === '') {
+                          setFormScores(formScores.filter((s) => s.group_id !== group.id));
+                        } else {
+                          const score = parseInt(val, 10);
+                          setFormScores(
+                            existing
+                              ? formScores.map((s) =>
+                                  s.group_id === group.id ? { ...s, score } : s,
+                                )
+                              : [...formScores, { group_id: group.id, score }],
+                          );
+                        }
+                      }}
+                      className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm focus:border-gray-400 focus:outline-none"
+                      placeholder="점수"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="flex gap-2 pt-1">
+            <button
+              onClick={() => {
+                setShowForm(false);
+                setFormScores([]);
+              }}
+              className="flex-1 rounded-lg bg-gray-200 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-300"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!formData.title.trim() || createMutation.isPending}
+              className="flex-1 rounded-lg bg-gray-900 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+            >
+              {createMutation.isPending ? '기록 중...' : '기록하기'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Activity List */}
+      {activities.length === 0 && !showForm ? (
+        <div className="flex flex-col items-center justify-center py-16">
+          <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-gray-50">
+            <span className="text-2xl">{'\uD83D\uDCDD'}</span>
+          </div>
+          <p className="text-sm font-medium text-gray-500 mb-1">아직 활동 기록이 없습니다</p>
+          <p className="text-xs text-gray-400 text-center">
+            팀 활동을 기록하고 공유하세요
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {activities.map((activity: Activity) => (
+            <ActivityCard
+              key={activity.id}
+              activity={activity}
+              canDelete={canDelete}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+function ActivityCard({
+  activity,
+  canDelete,
+  onDelete,
+}: {
+  activity: Activity;
+  canDelete: boolean;
+  onDelete: (id: number) => void;
+}) {
+  const timeStr =
+    activity.start_time && activity.end_time
+      ? `${activity.start_time} - ${activity.end_time}`
+      : activity.start_time ?? '';
+
+  return (
+    <div className="rounded-xl border border-gray-100 bg-white p-4 transition-shadow hover:shadow-sm">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-gray-800 truncate">{activity.title}</h3>
+          <div className="mt-1 flex items-center gap-3 text-xs text-gray-400">
+            <span className="flex items-center gap-1">
+              <LuCalendar size={12} />
+              {activity.activity_date}
+            </span>
+            {timeStr && (
+              <span className="flex items-center gap-1">
+                <LuClock size={12} />
+                {timeStr}
+              </span>
+            )}
+          </div>
+        </div>
+        {canDelete && (
+          <button
+            onClick={() => onDelete(activity.id)}
+            className="ml-2 rounded-lg p-1.5 text-gray-300 transition-colors hover:bg-red-50 hover:text-red-400"
+            aria-label="삭제"
+          >
+            <LuTrash2 size={14} />
+          </button>
+        )}
+      </div>
+
+      {/* Highlight */}
+      {activity.highlight && (
+        <p className="mt-2 text-xs text-gray-500 bg-yellow-50 rounded-lg px-2.5 py-1.5 border border-yellow-100">
+          {activity.highlight}
+        </p>
+      )}
+
+      {/* Description */}
+      {activity.description && (
+        <p className="mt-2 text-xs text-gray-500 line-clamp-2">{activity.description}</p>
+      )}
+
+      {/* Scores */}
+      {activity.scores.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {activity.scores.map((score) => (
+            <span
+              key={score.group_id}
+              className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2.5 py-1 text-xs"
+            >
+              <span className="font-medium text-gray-600">{score.group_name}</span>
+              <span className="text-gray-900 font-bold">{score.score}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Recorder */}
+      <div className="mt-3 flex items-center gap-1.5 text-xs text-gray-400">
+        <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+          {getRoleBadgeLabel(activity.recorder.role_badge)}
+        </span>
+        <span>{activity.recorder.nickname ?? '알 수 없음'}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/teams/detail/_components/JababwaTab.tsx
+++ b/app/(main)/teams/detail/_components/JababwaTab.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { LuTrophy, LuUser, LuCalendar } from 'react-icons/lu';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useActivities } from '@/_lib/hooks/useActivities';
+import { useGroupSets } from '@/_lib/hooks/useGroups';
+import { useRankings, useMyRanking } from '@/_lib/hooks/useRankings';
+import { buildGroupSetNameMap, groupDisplayName } from '@/_lib/utils/teamDisplay';
+import type { TeamRole, RankingItem, Activity } from '@/_types/team';
+
+interface JababwaTabProps {
+  teamId: number;
+  myRole: TeamRole;
+  selectedSetId?: number | null;
+  selectedGroupId?: number | null;
+}
+
+export default function JababwaTab({ teamId, selectedSetId, selectedGroupId }: JababwaTabProps) {
+  const { data: rankingsData, isLoading: rankingsLoading } = useRankings(teamId, {
+    period: 'semester',
+    group_set_id: selectedSetId ?? undefined,
+  });
+  const { data: myRanking, isLoading: myRankingLoading } = useMyRanking(teamId, {
+    group_set_id: selectedSetId ?? undefined,
+  });
+  const { data: activitiesData } = useActivities(teamId, { limit: 5 });
+  const { data: groupSetsData } = useGroupSets(teamId);
+  const groupSetNameMap = useMemo(() => buildGroupSetNameMap(groupSetsData?.group_sets ?? []), [groupSetsData]);
+
+  if (rankingsLoading || myRankingLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  const rankings = rankingsData?.rankings ?? [];
+  const activities = activitiesData?.activities ?? [];
+  const maxScore = rankings.length > 0 ? Math.max(...rankings.map((r) => r.total_score), 1) : 1;
+
+  return (
+    <div className="space-y-6">
+      {/* Section 1: Ranking Board */}
+      <section>
+        <div className="flex items-center gap-2 mb-3">
+          <LuTrophy size={16} className="text-yellow-500" />
+          <h2 className="text-sm font-bold text-gray-800">
+            조별 랭킹
+          </h2>
+        </div>
+
+        {rankings.length === 0 ? (
+          <div className="rounded-xl bg-gray-50 p-6 text-center">
+            <p className="text-xs text-gray-400">아직 점수 데이터가 없습니다</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {rankings.map((item) => (
+              <RankingBar
+                key={item.group_id}
+                item={item}
+                maxScore={maxScore}
+                isSelected={selectedGroupId === item.group_id}
+                groupSetNameMap={groupSetNameMap}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Section 2: Recent Activities Timeline */}
+      <section>
+        <div className="flex items-center gap-2 mb-3">
+          <LuCalendar size={16} className="text-blue-500" />
+          <h2 className="text-sm font-bold text-gray-800">
+            최근 활동
+          </h2>
+        </div>
+
+        {activities.length === 0 ? (
+          <div className="rounded-xl bg-gray-50 p-6 text-center">
+            <p className="text-xs text-gray-400">아직 활동 기록이 없습니다</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {activities.map((activity: Activity) => (
+              <div
+                key={activity.id}
+                className="flex items-start gap-3 rounded-lg border border-gray-100 bg-white p-3"
+              >
+                <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-gray-300" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs font-medium text-gray-700 truncate">{activity.title}</p>
+                  <p className="text-[10px] text-gray-400 mt-0.5">{activity.activity_date}</p>
+                  {activity.scores.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {activity.scores.map((score) => (
+                        <span
+                          key={score.group_id}
+                          className="inline-flex items-center gap-0.5 rounded-full bg-gray-50 px-2 py-0.5 text-[10px]"
+                        >
+                          <span className="text-gray-500">{groupDisplayName(score.group_name, score.group_id, groupSetNameMap)}</span>
+                          <span className="font-bold text-gray-700">{score.score}</span>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Section 3: My Stats */}
+      {myRanking && (
+        <section>
+          <div className="flex items-center gap-2 mb-3">
+            <LuUser size={16} className="text-green-500" />
+            <h2 className="text-sm font-bold text-gray-800">
+              내 참여 현황
+            </h2>
+          </div>
+
+          <div className="rounded-xl border border-gray-100 bg-white p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-500">닉네임</span>
+              <span className="text-sm font-medium text-gray-800">
+                {myRanking.nickname ?? '미설정'}
+              </span>
+            </div>
+
+            {myRanking.group ? (
+              <>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-gray-500">소속 조</span>
+                  <span className="text-sm font-medium text-gray-800">{groupDisplayName(myRanking.group.name, myRanking.group.id, groupSetNameMap)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-gray-500">조 순위</span>
+                  <span className="text-sm font-bold text-gray-800">
+                    {myRanking.group.current_rank}위
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-gray-500">조 총 점수</span>
+                  <span className="text-sm font-bold text-gray-800">
+                    {myRanking.group.total_score}점
+                  </span>
+                </div>
+              </>
+            ) : (
+              <div className="text-center py-2">
+                <p className="text-xs text-gray-400">아직 조에 배정되지 않았습니다</p>
+              </div>
+            )}
+
+            <div className="border-t border-gray-100 pt-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-gray-500">내 참여 횟수</span>
+                <span className="text-sm font-medium text-gray-800">
+                  {myRanking.my_participation_count} / {myRanking.total_activities}
+                </span>
+              </div>
+              {myRanking.total_activities > 0 && (
+                <div className="mt-2">
+                  <div className="h-1.5 w-full rounded-full bg-gray-100 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-green-400 transition-all"
+                      style={{
+                        width: `${Math.min(
+                          (myRanking.my_participation_count / myRanking.total_activities) * 100,
+                          100,
+                        )}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+
+function RankingBar({ item, maxScore, isSelected, groupSetNameMap }: { item: RankingItem; maxScore: number; isSelected?: boolean; groupSetNameMap: Map<number, string> }) {
+  const barWidth = maxScore > 0 ? Math.max((item.total_score / maxScore) * 100, 2) : 2;
+
+  const rankColors: Record<number, string> = {
+    1: 'bg-yellow-400',
+    2: 'bg-gray-400',
+    3: 'bg-amber-600',
+  };
+  const barColor = rankColors[item.rank] ?? 'bg-gray-300';
+
+  const rankChangeIndicator = () => {
+    if (item.rank_change > 0) return <span className="text-[10px] text-green-500 font-medium ml-1">{'\u2191'}{item.rank_change}</span>;
+    if (item.rank_change < 0) return <span className="text-[10px] text-red-500 font-medium ml-1">{'\u2193'}{Math.abs(item.rank_change)}</span>;
+    return null;
+  };
+
+  return (
+    <div className={`rounded-lg border bg-white p-3 ${isSelected ? 'border-gray-900 ring-2 ring-gray-900' : 'border-gray-100'}`}>
+      <div className="flex items-center justify-between mb-1.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-bold text-gray-400 w-5 text-center">{item.rank}</span>
+          <span className="text-sm font-semibold text-gray-800">{groupDisplayName(item.group_name, item.group_id, groupSetNameMap)}</span>
+          {rankChangeIndicator()}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-400">{item.activity_count}회</span>
+          <span className="text-sm font-bold text-gray-800">{item.total_score}점</span>
+        </div>
+      </div>
+      <div className="h-2 w-full rounded-full bg-gray-100 overflow-hidden">
+        <div
+          className={`h-full rounded-full ${barColor} transition-all duration-500`}
+          style={{ width: `${barWidth}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useMemo } from 'react';
+
+import type { IconType } from 'react-icons';
+import { FiPlus, FiCalendar, FiUsers, FiLayers } from 'react-icons/fi';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useGroupSets } from '@/_lib/hooks/useGroups';
+import { useTeamEvents } from '@/_lib/hooks/useTeamEvents';
+import { buildGroupSetNameMap, groupDisplayName } from '@/_lib/utils/teamDisplay';
+import type { TeamRole, TeamEvent } from '@/_types/team';
+
+import TeamSetupGuide from './TeamSetupGuide';
+interface MannajaTabProps {
+  teamId: number;
+  myRole: TeamRole;
+  memberCount: number;
+  inviteCode: string | null;
+  selectedSetId?: number | null;
+  selectedGroupId?: number | null;
+}
+
+export default function MannajaTab({ teamId, myRole, memberCount, inviteCode, selectedSetId, selectedGroupId }: MannajaTabProps) {
+  const router = useRouter();
+  const { data, isLoading } = useTeamEvents(teamId);
+  const { data: groupSetsData } = useGroupSets(teamId);
+
+  const canCreate = myRole === 'captain' || myRole === 'executive';
+  const groupSets = groupSetsData?.group_sets ?? [];
+  const groupSetNameMap = useMemo(() => buildGroupSetNameMap(groupSets), [groupSets]);
+
+  // 선택된 세트에 속하는 group_id 집합
+  const selectedGroupIds = useMemo(() => {
+    if (!selectedSetId) return null;
+    const set = groupSets.find((s) => s.id === selectedSetId);
+    if (!set) return null;
+    return new Set(set.groups.map((g) => g.id));
+  }, [selectedSetId, groupSets]);
+
+  // 이벤트 필터링
+  const allEvents = data?.events ?? [];
+  const events = useMemo(() => {
+    if (!selectedGroupIds && !selectedGroupId) return allEvents;
+    return allEvents.filter((event) => {
+      if (event.target_groups.length === 0) return false;
+      if (selectedGroupId) {
+        return event.target_groups.some((g) => g.id === selectedGroupId);
+      }
+      if (selectedGroupIds) {
+        return event.target_groups.some((g) => selectedGroupIds.has(g.id));
+      }
+      return true;
+    });
+  }, [allEvents, selectedGroupIds, selectedGroupId]);
+
+  // 팀 전체 / 조별 이벤트 분리
+  const { teamWideEvents, groupEvents } = useMemo(() => {
+    const teamWide: TeamEvent[] = [];
+    const group: TeamEvent[] = [];
+    for (const event of events) {
+      if (event.target_groups.length === 0) {
+        teamWide.push(event);
+      } else {
+        group.push(event);
+      }
+    }
+    return { teamWideEvents: teamWide, groupEvents: group };
+  }, [events]);
+
+  const hasGroups = groupSets.length > 0;
+  const isFilterActive = !!selectedSetId || !!selectedGroupId;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 팀 셋업 가이드 (captain/executive만) */}
+      {canCreate && (!hasGroups || memberCount <= 1) && (
+        <TeamSetupGuide teamId={teamId} memberCount={memberCount} inviteCode={inviteCode} hasGroups={hasGroups} />
+      )}
+
+      {/* Create button for captain/executive */}
+      {canCreate && (
+        <button
+          onClick={() => {
+            const params = new URLSearchParams({ id: String(teamId) });
+            if (selectedSetId) params.set('setId', String(selectedSetId));
+            if (selectedGroupId) params.set('groupId', String(selectedGroupId));
+            router.push(`/chinba/team/event-create?${params.toString()}`);
+          }}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-4 text-sm font-medium text-gray-400 transition-colors hover:border-gray-300 hover:text-gray-500 active:scale-[0.98]"
+        >
+          <FiPlus size={18} />
+          <span>팀 친바 만들기</span>
+        </button>
+      )}
+
+      {hasGroups ? (
+        /* 섹션 분리 레이아웃 */
+        <>
+          {!isFilterActive && (
+            <>
+              <SectionHeader icon={FiUsers} label="팀 전체 일정" />
+              {teamWideEvents.length > 0 ? (
+                teamWideEvents.map((event) => (
+                  <EventCard
+                    key={event.event_id}
+                    event={event}
+                    groupSetNameMap={groupSetNameMap}
+                    onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                  />
+                ))
+              ) : (
+                <SectionEmptyState message="팀 전체 일정이 없습니다" />
+              )}
+            </>
+          )}
+
+          {!isFilterActive && <SectionHeader icon={FiLayers} label="조별 일정" />}
+          {groupEvents.length > 0 ? (
+            groupEvents.map((event) => (
+              <EventCard
+                key={event.event_id}
+                event={event}
+                groupSetNameMap={groupSetNameMap}
+                onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+              />
+            ))
+          ) : (
+            <SectionEmptyState
+              message="아직 조별 일정이 없습니다"
+              submessage={canCreate ? '조별 일정을 만들어 보세요' : undefined}
+            />
+          )}
+        </>
+      ) : events.length === 0 ? (
+        /* 기존 빈 상태 유지 */
+        <div className="flex flex-col items-center justify-center py-16">
+          <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-gray-50">
+            <FiCalendar size={24} className="text-gray-300" />
+          </div>
+          <p className="text-sm font-medium text-gray-500 mb-1">아직 일정이 없습니다</p>
+          <p className="text-xs text-gray-400 text-center">
+            {canCreate
+              ? '위의 버튼을 눌러 일정 조율을 시작하세요'
+              : '팀장 또는 임원이 일정 조율을 생성할 수 있습니다'}
+          </p>
+        </div>
+      ) : (
+        /* 플랫 리스트 (조 없을 때) */
+        events.map((event) => (
+          <EventCard
+            key={event.event_id}
+            event={event}
+            groupSetNameMap={groupSetNameMap}
+            onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function EventCard({ event, groupSetNameMap, onClick }: { event: TeamEvent; groupSetNameMap: Map<number, string>; onClick: () => void }) {
+  const progressPercent =
+    event.total_participants > 0
+      ? Math.round((event.submitted_count / event.total_participants) * 100)
+      : 0;
+
+  return (
+    <div
+      onClick={onClick}
+      className="cursor-pointer rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-shadow hover:shadow-md active:scale-[0.98]"
+    >
+      <div className="flex items-start justify-between mb-2">
+        <h3 className="text-sm font-bold text-gray-800 truncate flex-1">{event.title}</h3>
+        <span
+          className={`ml-2 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${
+            event.status === 'active'
+              ? 'bg-green-50 text-green-600'
+              : event.status === 'completed'
+                ? 'bg-blue-50 text-blue-600'
+                : 'bg-gray-50 text-gray-400'
+          }`}
+        >
+          {event.status === 'active' ? '진행 중' : event.status === 'completed' ? '완료' : '만료'}
+        </span>
+      </div>
+
+      {/* Dates */}
+      <div className="flex items-center gap-1.5 mb-2">
+        <FiCalendar size={12} className="text-gray-400" />
+        <p className="text-xs text-gray-500 truncate">
+          {event.dates.join(', ')}
+        </p>
+      </div>
+
+      {/* Target groups - 항상 표시 */}
+      <div className="flex flex-wrap gap-1 mb-2">
+        {event.target_groups.length > 0 ? (
+          event.target_groups.map((g) => (
+            <span
+              key={g.id}
+              className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600"
+            >
+              {groupDisplayName(g.name, g.id, groupSetNameMap)}
+            </span>
+          ))
+        ) : (
+          <span className="rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-medium text-blue-600">
+            전체
+          </span>
+        )}
+      </div>
+
+      {/* Participant progress */}
+      <div className="flex items-center gap-2">
+        <FiUsers size={12} className="text-gray-400" />
+        <div className="flex-1 h-1.5 rounded-full bg-gray-100 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-gray-800 transition-all"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+        <span className="text-[10px] font-medium text-gray-500">
+          {event.submitted_count}/{event.total_participants}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({ icon: Icon, label }: { icon: IconType; label: string }) {
+  return (
+    <div className="flex items-center gap-2 pt-2">
+      <Icon size={14} className="text-gray-500" />
+      <span className="text-xs font-semibold text-gray-500">{label}</span>
+      <div className="flex-1 border-t border-gray-100" />
+    </div>
+  );
+}
+
+function SectionEmptyState({ message, submessage }: { message: string; submessage?: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-10">
+      <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-gray-50">
+        <FiCalendar size={18} className="text-gray-300" />
+      </div>
+      <p className="text-xs font-medium text-gray-400">{message}</p>
+      {submessage && (
+        <p className="text-[11px] text-gray-300 mt-0.5">{submessage}</p>
+      )}
+    </div>
+  );
+}
+

--- a/app/(main)/teams/detail/_components/TeamDetailClient.tsx
+++ b/app/(main)/teams/detail/_components/TeamDetailClient.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FiSettings } from 'react-icons/fi';
+import { LuChevronLeft } from 'react-icons/lu';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useGroupSets } from '@/_lib/hooks/useGroups';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useTeamDetail } from '@/_lib/hooks/useTeam';
+
+import GroupFilterBar from '../../_components/GroupFilterBar';
+import TeamSegmentTabs, { type TeamSegment } from '../../_components/TeamSegmentTabs';
+import UpgradeModal from '../../_components/UpgradeModal';
+import ActivityTab from './ActivityTab';
+import JababwaTab from './JababwaTab';
+import MannajaTab from './MannajaTab';
+
+export default function TeamDetailClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const smartBack = useSmartBack('/teams');
+  const teamId = searchParams.get('id') ? Number(searchParams.get('id')) : undefined;
+  const { data: team, isLoading, isError } = useTeamDetail(teamId);
+  const { data: groupSetsData } = useGroupSets(teamId);
+
+  const [activeTab, setActiveTab] = useState<TeamSegment>('mannaja');
+  const [showUpgrade, setShowUpgrade] = useState(false);
+  const [selectedSetId, setSelectedSetId] = useState<number | null>(null);
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
+
+  const groupSets = groupSetsData?.group_sets ?? [];
+  // 세트 1개일 때 자동 선택
+  const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
+
+  // 뭐했니/잡아봐 탭은 유료 기능 (구독 필요)
+  const isPaidTab = (tab: TeamSegment) => tab === 'mwoheni' || tab === 'jabahbwa';
+  const needsSubscription = team && !team.is_paid;
+
+  const handleTabChange = (tab: TeamSegment) => {
+    if (isPaidTab(tab) && needsSubscription) {
+      setShowUpgrade(true);
+      return;
+    }
+    setActiveTab(tab);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center bg-white">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (isError || !team) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-white">
+        <p className="text-sm text-gray-400 mb-3">팀 정보를 불러오지 못했습니다</p>
+        <button
+          onClick={smartBack}
+          className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  const renderTabContent = () => {
+    if (activeTab === 'mannaja') {
+      return <MannajaTab teamId={teamId!} myRole={team.my_role} memberCount={team.member_count} inviteCode={team.invite_code} selectedSetId={effectiveSetId} selectedGroupId={selectedGroupId} />;
+    }
+
+    if (activeTab === 'mwoheni') {
+      return <ActivityTab teamId={teamId!} myRole={team.my_role} selectedSetId={effectiveSetId} selectedGroupId={selectedGroupId} />;
+    }
+
+    if (activeTab === 'jabahbwa') {
+      return <JababwaTab teamId={teamId!} myRole={team.my_role} selectedSetId={effectiveSetId} selectedGroupId={selectedGroupId} />;
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      {/* Header */}
+      <div className="shrink-0 px-4 pb-0">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 mb-3 flex items-center justify-center">
+          <button
+            onClick={smartBack}
+            className="absolute left-0 z-10 group -ml-1 rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+            aria-label="뒤로가기"
+          >
+            <LuChevronLeft size={24} strokeWidth={2.5} className="transition-transform group-hover:-translate-x-0.5" />
+          </button>
+          <h1 className="text-base font-bold text-gray-800 truncate max-w-[60%]">
+            {team.name}
+          </h1>
+          <button
+            onClick={() => router.push(`/teams/settings?id=${teamId}`)}
+            className="absolute right-0 z-10 rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+            aria-label="설정"
+          >
+            <FiSettings size={20} />
+          </button>
+        </div>
+      </div>
+
+      {/* Segment Tabs */}
+      <div className="shrink-0">
+        <TeamSegmentTabs activeTab={activeTab} onTabChange={handleTabChange} />
+      </div>
+
+      {/* Group Filter */}
+      {groupSets.length > 0 && (
+        <div className="shrink-0 px-4 pt-3">
+          <GroupFilterBar
+            groupSets={groupSets}
+            selectedSetId={effectiveSetId}
+            selectedGroupId={selectedGroupId}
+            onSetChange={setSelectedSetId}
+            onGroupChange={setSelectedGroupId}
+          />
+        </div>
+      )}
+
+      {/* Tab Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-6">
+        {renderTabContent()}
+      </div>
+
+      {/* Upgrade Modal */}
+      {teamId && (
+        <UpgradeModal
+          isOpen={showUpgrade}
+          onClose={() => setShowUpgrade(false)}
+          teamId={teamId}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(main)/teams/detail/_components/TeamSetupGuide.tsx
+++ b/app/(main)/teams/detail/_components/TeamSetupGuide.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { FiCheck, FiCopy, FiShare2, FiUsers } from 'react-icons/fi';
+
+import { formatInviteUrl } from '@/_lib/utils/teamDisplay';
+
+interface TeamSetupGuideProps {
+  teamId: number;
+  memberCount: number;
+  inviteCode: string | null;
+  hasGroups: boolean;
+}
+
+export default function TeamSetupGuide({ teamId, memberCount, inviteCode, hasGroups }: TeamSetupGuideProps) {
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+
+  if (hasGroups) return null;
+
+  const isStep1Done = memberCount > 1;
+  const inviteUrl = inviteCode ? formatInviteUrl(inviteCode) : null;
+
+  const handleCopy = async () => {
+    if (!inviteUrl) return;
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // silent fail
+    }
+  };
+
+  const handleShare = async () => {
+    if (!inviteUrl) return;
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: '팀 초대',
+          text: '팀에 참여하세요!',
+          url: inviteUrl,
+        });
+      } catch {
+        // User cancelled
+      }
+    } else {
+      handleCopy();
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 p-4 space-y-3">
+      {/* Step 1 */}
+      {!isStep1Done ? (
+        <div className="flex items-start gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100">
+            <span className="text-xs font-bold text-blue-600">①</span>
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-700">팀원을 초대하세요</p>
+            <p className="text-xs text-gray-500 mt-0.5">초대 링크를 공유해서 팀원을 모아보세요</p>
+            {inviteUrl && (
+              <div className="flex gap-2 mt-2.5">
+                <button
+                  onClick={handleCopy}
+                  className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 active:scale-95"
+                >
+                  <FiCopy size={12} />
+                  {copied ? '복사됨' : '링크 복사'}
+                </button>
+                <button
+                  onClick={handleShare}
+                  className="flex items-center gap-1.5 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+                >
+                  <FiShare2 size={12} />
+                  공유하기
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-green-100">
+            <FiCheck size={12} className="text-green-600" />
+          </div>
+          <p className="text-sm font-medium text-gray-500">팀원 초대 완료 ({memberCount}명)</p>
+        </div>
+      )}
+
+      {/* Step 2 */}
+      {!isStep1Done ? (
+        <div className="flex items-center gap-3 pl-11">
+          <p className="text-xs text-gray-400">② 조 편성하기 (팀원 초대 후 가능)</p>
+        </div>
+      ) : (
+        <div className="flex items-start gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100">
+            <FiUsers size={14} className="text-blue-600" />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-700">조를 편성해보세요</p>
+            <p className="text-xs text-gray-500 mt-0.5">팀원을 바탕으로 조를 나누면 조별 일정 관리가 가능해요</p>
+            <button
+              onClick={() => router.push(`/chinba/team/groups?id=${teamId}`)}
+              className="mt-1.5 text-xs font-semibold text-blue-600 hover:text-blue-700"
+            >
+              조 편성하러 가기 →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(main)/teams/detail/page.tsx
+++ b/app/(main)/teams/detail/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { Suspense } from 'react';
+
+import TeamDetailClient from './_components/TeamDetailClient';
+
+export default function TeamDetailPage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamDetailClient />
+    </Suspense>
+  );
+}

--- a/app/(main)/teams/join/page.tsx
+++ b/app/(main)/teams/join/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Suspense } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FiUsers } from 'react-icons/fi';
+import { LuChevronLeft } from 'react-icons/lu';
+
+import Button from '@/_components/ui/Button';
+import { useToast } from '@/_context/ToastContext';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useJoinTeam } from '@/_lib/hooks/useTeam';
+
+function JoinTeamContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const smartBack = useSmartBack('/teams');
+  const joinTeam = useJoinTeam();
+  const { showToast } = useToast();
+
+  const [inviteCode, setInviteCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  // Auto-fill from URL params
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (code) {
+      setInviteCode(code);
+    }
+  }, [searchParams]);
+
+  const canSubmit = inviteCode.trim().length > 0 && !joinTeam.isPending;
+
+  const handleJoin = async () => {
+    if (!canSubmit) return;
+    setError(null);
+
+    try {
+      const result = await joinTeam.mutateAsync({
+        invite_code: inviteCode.trim(),
+      });
+      showToast(`${result.team_name}에 가입되었습니다`, 'success');
+      router.replace(`/teams/${result.team_id}`);
+    } catch (err: any) {
+      const detail = err.response?.data?.detail || '가입에 실패했습니다';
+      setError(detail);
+      showToast(detail, 'error');
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      {/* Header */}
+      <div className="shrink-0 px-4 pb-3">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 flex items-center justify-center">
+          <button
+            onClick={smartBack}
+            className="absolute left-0 z-10 group -ml-1 rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+            aria-label="뒤로가기"
+          >
+            <LuChevronLeft size={24} strokeWidth={2.5} className="transition-transform group-hover:-translate-x-0.5" />
+          </button>
+          <h1 className="text-base font-bold text-gray-800">팀 가입</h1>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4">
+        <div className="flex flex-col items-center py-8">
+          <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+            <FiUsers size={28} className="text-gray-400" />
+          </div>
+
+          {error && (
+            <div className="mb-4 w-full rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+              {error}
+            </div>
+          )}
+
+          <div className="w-full mb-6">
+            <label className="block text-sm font-bold text-gray-700 mb-2">
+              초대 코드
+            </label>
+            <input
+              type="text"
+              value={inviteCode}
+              onChange={(e) => setInviteCode(e.target.value)}
+              placeholder="초대 코드를 입력하세요"
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-800 placeholder-gray-400 outline-none focus:border-gray-900 transition-colors text-center font-mono"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleJoin}
+          disabled={!canSubmit}
+        >
+          {joinTeam.isPending ? '가입 중...' : '가입하기'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function JoinTeamPage() {
+  return (
+    <Suspense fallback={null}>
+      <JoinTeamContent />
+    </Suspense>
+  );
+}

--- a/app/(main)/teams/page.tsx
+++ b/app/(main)/teams/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FiPlus, FiUsers } from 'react-icons/fi';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useMyTeams } from '@/_lib/hooks/useTeam';
+
+import TeamCard from './_components/TeamCard';
+
+export default function TeamsPage() {
+  const router = useRouter();
+  const { data, isLoading, isError } = useMyTeams();
+
+  const teams = data?.teams ?? [];
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      {/* Header */}
+      <div className="shrink-0 px-4 pb-3">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 flex items-center justify-between">
+          <h1 className="text-lg font-bold text-gray-800">내 팀</h1>
+          <button
+            onClick={() => router.push('/teams/create')}
+            className="flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+          >
+            <FiPlus size={14} />
+            만들기
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20">
+            <LoadingSpinner />
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-center justify-center py-20">
+            <p className="text-sm text-gray-400">팀 목록을 불러오지 못했습니다</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="mt-3 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+            >
+              다시 시도
+            </button>
+          </div>
+        ) : teams.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+              <FiUsers size={28} className="text-gray-300" />
+            </div>
+            <p className="text-sm font-medium text-gray-500 mb-1">팀이 없습니다</p>
+            <p className="text-xs text-gray-400 text-center">
+              새 팀을 만들거나 초대 링크로 가입하세요
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {teams.map((team) => (
+              <TeamCard
+                key={team.id}
+                team={team}
+                onClick={() => router.push(`/teams/detail?id=${team.id}`)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
+++ b/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FiXCircle } from 'react-icons/fi';
+import { LuChevronLeft } from 'react-icons/lu';
+
+import ConfirmModal from '@/_components/ui/ConfirmModal';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useToast } from '@/_context/ToastContext';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import {
+  useTeamDetail,
+  useTeamMembers,
+  useUpdateTeam,
+  useDeleteTeam,
+  useChangeRole,
+  useRemoveMember,
+  useRegenerateInviteCode,
+} from '@/_lib/hooks/useTeam';
+import { getCategoryOptions } from '@/_lib/utils/teamDisplay';
+import {
+  canEditTeam,
+  canDeleteTeam,
+  canRegenerateInvitation,
+} from '@/_lib/utils/teamPermissions';
+import type { TeamRole } from '@/_types/team';
+
+import InviteSection from '../../_components/InviteSection';
+import MemberList from '../../_components/MemberList';
+import GroupSettingsSection from '@/(main)/chinba/_components/team/groups/GroupSettingsSection';
+import SubscriptionSection from '@/(main)/chinba/_components/team/SubscriptionSection';
+
+export default function TeamSettingsClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const teamId = searchParams.get('id') ? Number(searchParams.get('id')) : undefined;
+  const smartBack = useSmartBack(`/teams/detail?id=${teamId}`);
+  const { showToast } = useToast();
+
+  const { data: team, isLoading: isLoadingTeam } = useTeamDetail(teamId);
+  const { data: membersData, isLoading: isLoadingMembers } = useTeamMembers(teamId);
+  const updateTeam = useUpdateTeam(teamId!);
+  const deleteTeam = useDeleteTeam();
+  const changeRole = useChangeRole(teamId!);
+  const removeMember = useRemoveMember(teamId!);
+  const regenerateCode = useRegenerateInviteCode(teamId!);
+
+  const [editName, setEditName] = useState<string | null>(null);
+  const [editCategory, setEditCategory] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState<number | null>(null);
+
+  const categoryOptions = getCategoryOptions();
+  const members = membersData?.members ?? [];
+  const myRole = team?.my_role ?? 'member';
+  const isEditing = editName !== null;
+
+  if (isLoadingTeam) {
+    return (
+      <div className="flex h-full items-center justify-center bg-white">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!team || !teamId) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center bg-white">
+        <p className="text-sm text-gray-400 mb-3">팀 정보를 불러오지 못했습니다</p>
+        <button
+          onClick={smartBack}
+          className="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
+        >
+          돌아가기
+        </button>
+      </div>
+    );
+  }
+
+  const handleStartEdit = () => {
+    setEditName(team.name);
+    setEditCategory(team.category || '');
+  };
+
+  const handleCancelEdit = () => {
+    setEditName(null);
+    setEditCategory(null);
+  };
+
+  const handleSaveEdit = async () => {
+    if (editName === null) return;
+    const trimmed = editName.trim();
+    if (!trimmed) {
+      showToast('팀 이름을 입력해주세요', 'error');
+      return;
+    }
+
+    try {
+      await updateTeam.mutateAsync({
+        name: trimmed,
+        category: editCategory || undefined,
+      });
+      showToast('팀 정보가 수정되었습니다', 'success');
+      setEditName(null);
+      setEditCategory(null);
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '수정에 실패했습니다', 'error');
+    }
+  };
+
+  const handleDeleteTeam = async () => {
+    try {
+      await deleteTeam.mutateAsync(teamId);
+      showToast('팀이 삭제되었습니다', 'success');
+      router.replace('/teams');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '삭제에 실패했습니다', 'error');
+    }
+    setShowDeleteConfirm(false);
+  };
+
+  const handleChangeRole = async (memberId: number, role: TeamRole) => {
+    try {
+      await changeRole.mutateAsync({ memberId, role });
+      showToast('역할이 변경되었습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '역할 변경에 실패했습니다', 'error');
+    }
+  };
+
+  const handleRemoveMember = (memberId: number) => {
+    setShowRemoveConfirm(memberId);
+  };
+
+  const confirmRemoveMember = async () => {
+    if (showRemoveConfirm === null) return;
+    try {
+      await removeMember.mutateAsync(showRemoveConfirm);
+      showToast('멤버를 내보냈습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '내보내기에 실패했습니다', 'error');
+    }
+    setShowRemoveConfirm(null);
+  };
+
+  const handleRegenerateCode = async () => {
+    try {
+      await regenerateCode.mutateAsync();
+      showToast('초대 코드가 재생성되었습니다', 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '재생성에 실패했습니다', 'error');
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      {/* Header */}
+      <div className="shrink-0 px-4 pb-3">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 flex items-center justify-center">
+          <button
+            onClick={smartBack}
+            className="absolute left-0 z-10 group -ml-1 rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+            aria-label="뒤로가기"
+          >
+            <LuChevronLeft size={24} strokeWidth={2.5} className="transition-transform group-hover:-translate-x-0.5" />
+          </button>
+          <h1 className="text-base font-bold text-gray-800">팀 설정</h1>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-8">
+        {/* Section 1: Team Info */}
+        <section className="mb-6">
+          <h2 className="text-sm font-bold text-gray-800 mb-3">팀 정보</h2>
+          <div className="rounded-xl border border-gray-100 bg-white p-4 space-y-4">
+            {isEditing ? (
+              <>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1.5">팀 이름</label>
+                  <div className="relative">
+                    <input
+                      type="text"
+                      value={editName || ''}
+                      onChange={(e) => setEditName(e.target.value)}
+                      maxLength={50}
+                      className="w-full rounded-xl border border-gray-200 px-4 py-2.5 pr-10 text-sm text-gray-800 outline-none focus:border-gray-900 transition-colors"
+                    />
+                    {(editName?.length ?? 0) > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => setEditName('')}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-gray-500 transition-colors"
+                      >
+                        <FiXCircle size={16} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-xs font-medium text-gray-500 mb-1.5">카테고리</label>
+                  <div className="flex flex-wrap gap-1.5">
+                    {categoryOptions.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => setEditCategory((prev) => (prev === opt.value ? '' : opt.value))}
+                        className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors active:scale-95 ${
+                          editCategory === opt.value
+                            ? 'border-gray-900 bg-gray-900 text-white'
+                            : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleCancelEdit}
+                    className="flex-1 rounded-xl border border-gray-200 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50"
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={handleSaveEdit}
+                    disabled={updateTeam.isPending}
+                    className="flex-1 rounded-xl bg-gray-900 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
+                  >
+                    {updateTeam.isPending ? '저장 중...' : '저장'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-xs text-gray-400 mb-0.5">팀 이름</p>
+                    <p className="text-sm font-medium text-gray-800">{team.name}</p>
+                  </div>
+                  {canEditTeam(myRole) && (
+                    <button
+                      onClick={handleStartEdit}
+                      className="rounded-lg px-3 py-1.5 text-xs font-medium text-gray-500 transition-colors hover:bg-gray-50"
+                    >
+                      수정
+                    </button>
+                  )}
+                </div>
+                {team.category && (
+                  <div>
+                    <p className="text-xs text-gray-400 mb-0.5">카테고리</p>
+                    <p className="text-sm text-gray-600">{team.category}</p>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {canDeleteTeam(myRole) && !isEditing && (
+            <button
+              onClick={() => setShowDeleteConfirm(true)}
+              className="mt-3 w-full rounded-xl border border-red-100 py-2.5 text-sm font-medium text-red-500 transition-colors hover:bg-red-50"
+            >
+              팀 삭제
+            </button>
+          )}
+        </section>
+
+        {/* Section 2: Invite */}
+        <section className="mb-6">
+          <h2 className="text-sm font-bold text-gray-800 mb-3">초대 링크</h2>
+          <InviteSection
+            inviteCode={team.invite_code}
+            canRegenerate={canRegenerateInvitation(myRole)}
+            onRegenerate={handleRegenerateCode}
+            isRegenerating={regenerateCode.isPending}
+            onShowToast={showToast}
+          />
+        </section>
+
+        {/* Section 3: Members */}
+        <section className="mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-bold text-gray-800">
+              멤버 관리
+              <span className="ml-1.5 text-xs font-normal text-gray-400">
+                {members.length}명
+              </span>
+            </h2>
+          </div>
+          <div className="rounded-xl border border-gray-100 bg-white">
+            {isLoadingMembers ? (
+              <div className="flex items-center justify-center py-8">
+                <LoadingSpinner size="sm" />
+              </div>
+            ) : members.length === 0 ? (
+              <div className="py-8 text-center text-sm text-gray-400">
+                멤버가 없습니다
+              </div>
+            ) : (
+              <MemberList
+                members={members}
+                myRole={myRole}
+                teamId={teamId}
+                onChangeRole={handleChangeRole}
+                onRemoveMember={handleRemoveMember}
+              />
+            )}
+          </div>
+        </section>
+
+        {/* Section 4: 그룹/조 관리 */}
+        <GroupSettingsSection
+          teamId={teamId}
+          canManage={canEditTeam(myRole)}
+        />
+
+        {/* Section 5: 구독 관리 */}
+        <SubscriptionSection
+          teamId={teamId}
+          canManage={canEditTeam(myRole)}
+        />
+      </div>
+
+      {/* Delete Confirm Modal */}
+      <ConfirmModal
+        isOpen={showDeleteConfirm}
+        onConfirm={handleDeleteTeam}
+        onCancel={() => setShowDeleteConfirm(false)}
+        title="팀 삭제"
+        confirmLabel="삭제"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>정말 이 팀을 삭제하시겠습니까?</p>
+        <p className="mt-1 text-xs text-gray-400">이 작업은 되돌릴 수 없습니다.</p>
+      </ConfirmModal>
+
+      {/* Remove Member Confirm Modal */}
+      <ConfirmModal
+        isOpen={showRemoveConfirm !== null}
+        onConfirm={confirmRemoveMember}
+        onCancel={() => setShowRemoveConfirm(null)}
+        title="멤버 내보내기"
+        confirmLabel="내보내기"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>이 멤버를 팀에서 내보내시겠습니까?</p>
+      </ConfirmModal>
+    </div>
+  );
+}

--- a/app/(main)/teams/settings/page.tsx
+++ b/app/(main)/teams/settings/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { Suspense } from 'react';
+
+import TeamSettingsClient from './_components/TeamSettingsClient';
+
+export default function TeamSettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <TeamSettingsClient />
+    </Suspense>
+  );
+}

--- a/app/_components/auth/UserInfoForm.tsx
+++ b/app/_components/auth/UserInfoForm.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { FiUser, FiHome, FiBook, FiHash, FiMail } from 'react-icons/fi';
+import { FiUser, FiHome, FiBook, FiHash, FiMail, FiAtSign } from 'react-icons/fi';
 
 import DepartmentSearch from '@/_components/ui/DepartmentSearch';
 import type { Department } from '@/_types/department';
 
 export interface UserInfoFormData {
     nickname: string;
+    username: string;
     school: string;
     dept_code: string;
     dept_name: string;
@@ -19,6 +20,8 @@ interface UserInfoFormProps {
     email?: string;
     showNickname?: boolean;
     isReadonlyNickname?: boolean;
+    showUsername?: boolean;
+    isReadonlyUsername?: boolean;
     isReadonlySchool?: boolean;
     isReadonly?: boolean;
     showRequirementBadges?: boolean;
@@ -27,6 +30,7 @@ interface UserInfoFormProps {
         school?: boolean;
         dept_code?: boolean;
         admission_year?: boolean;
+        username?: boolean;
     };
 }
 
@@ -36,6 +40,8 @@ export default function UserInfoForm({
     email,
     showNickname = true,
     isReadonlyNickname = false,
+    showUsername = false,
+    isReadonlyUsername = false,
     isReadonlySchool = false,
     isReadonly = false,
     showRequirementBadges = false,
@@ -67,12 +73,12 @@ export default function UserInfoForm({
 
     return (
         <div className="space-y-6">
-            {/* 닉네임 */}
+            {/* 이름 */}
             {showNickname && (
                 <div className="space-y-2">
                     <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
                         <FiUser className="text-gray-400" />
-                        닉네임
+                        이름
                         {renderBadge('nickname')}
                     </label>
                     <input
@@ -81,12 +87,42 @@ export default function UserInfoForm({
                         value={formData.nickname}
                         onChange={handleInputChange}
                         readOnly={isReadonlyNickname || isReadonly}
-                        placeholder="닉네임을 입력하세요"
+                        placeholder="이름을 입력하세요"
                         className={`w-full rounded-xl border border-gray-200 px-4 py-3 outline-none transition-all ${(isReadonlyNickname || isReadonly)
                             ? 'bg-gray-100 text-gray-500 cursor-not-allowed'
                             : 'bg-gray-50 focus:border-gray-900 focus:bg-white'
                             }`}
                     />
+                </div>
+            )}
+
+            {/* @아이디 */}
+            {showUsername && (
+                <div className="space-y-2">
+                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700">
+                        <FiAtSign className="text-gray-400" />
+                        아이디
+                    </label>
+                    <div className="relative">
+                        <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 text-sm">@</span>
+                        <input
+                            type="text"
+                            name="username"
+                            value={formData.username}
+                            onChange={handleInputChange}
+                            readOnly={isReadonlyUsername || isReadonly}
+                            placeholder="아이디를 입력하세요"
+                            className={`w-full rounded-xl border px-4 py-3 pl-8 outline-none transition-all ${(isReadonlyUsername || isReadonly)
+                                ? 'border-gray-200 bg-gray-100 text-gray-500 cursor-not-allowed'
+                                : invalidFields.username
+                                    ? 'border-red-300 bg-red-50 focus:border-red-500'
+                                    : 'border-gray-200 bg-gray-50 focus:border-gray-900 focus:bg-white'
+                                }`}
+                        />
+                    </div>
+                    {!isReadonly && !isReadonlyUsername && (
+                        <p className="text-xs text-gray-400">영문 소문자, 숫자, 밑줄만 사용 가능 (3자 이상)</p>
+                    )}
                 </div>
             )}
 

--- a/app/_components/layout/FullPageModal.tsx
+++ b/app/_components/layout/FullPageModal.tsx
@@ -11,6 +11,7 @@ interface FullPageModalProps {
   children: ReactNode;
   mode?: 'inline' | 'overlay';
   showBackButton?: boolean;
+  headerRight?: ReactNode;
 }
 
 export default function FullPageModal({
@@ -20,6 +21,7 @@ export default function FullPageModal({
   children,
   mode = 'inline',
   showBackButton = true,
+  headerRight,
 }: FullPageModalProps) {
   const [isMounted, setIsMounted] = useState(false);
 
@@ -66,6 +68,9 @@ export default function FullPageModal({
             </button>
           )}
           <h1 className="text-base font-bold text-gray-800">{title}</h1>
+          {headerRight && (
+            <div className="absolute right-0 z-10">{headerRight}</div>
+          )}
         </div>
       </div>
       {/* 컨텐츠 영역 */}

--- a/app/_components/ui/TeamStatsBanner.tsx
+++ b/app/_components/ui/TeamStatsBanner.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTeamStats } from '@/_lib/hooks/useTeamStats';
+import { FiUsers } from 'react-icons/fi';
+
+// 각 자릿수를 아래에서 위로 슬라이드하는 컴포넌트
+function RollingDigit({ digit, delay }: { digit: string; delay: number }) {
+    const [prevDigit, setPrevDigit] = useState(digit);
+    const [isRolling, setIsRolling] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (digit !== prevDigit) {
+            setIsRolling(true);
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+            timeoutRef.current = setTimeout(() => {
+                setPrevDigit(digit);
+                setIsRolling(false);
+            }, 600 + delay);
+        }
+    }, [digit, delay]);
+
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+            }
+        };
+    }, []);
+
+    if (!/\d/.test(digit)) {
+        return <span>{digit}</span>;
+    }
+
+    return (
+        <span
+            className="inline-block overflow-hidden relative"
+            style={{ width: '1ch', height: '1em', lineHeight: '1', textAlign: 'center' }}
+        >
+            <span
+                className="block"
+                style={{
+                    transition: `transform ${0.6 + delay}s cubic-bezier(0.16, 1, 0.3, 1), opacity ${0.4 + delay}s ease`,
+                    transform: isRolling ? 'translateY(-100%)' : 'translateY(0)',
+                    opacity: isRolling ? 0 : 1,
+                }}
+            >
+                {prevDigit}
+            </span>
+            <span
+                className="block absolute top-0 left-0 right-0"
+                style={{
+                    transition: `transform ${0.6 + delay}s cubic-bezier(0.16, 1, 0.3, 1), opacity ${0.4 + delay}s ease`,
+                    transform: isRolling ? 'translateY(0)' : 'translateY(100%)',
+                    opacity: isRolling ? 1 : 0,
+                }}
+            >
+                {digit}
+            </span>
+        </span>
+    );
+}
+
+// 숫자 카운트업 + 롤링 애니메이션 결합
+function AnimatedCount({ value }: { value: number }) {
+    const [displayValue, setDisplayValue] = useState(0);
+    const prevTargetRef = useRef(0);
+    const startTimeRef = useRef<number | null>(null);
+    const rafRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (value === 0) return;
+
+        const startValue = prevTargetRef.current;
+        prevTargetRef.current = value;
+        startTimeRef.current = null;
+        const duration = startValue === 0 ? 3500 : 1500;
+
+        const animate = (currentTime: number) => {
+            if (startTimeRef.current === null) {
+                startTimeRef.current = currentTime;
+            }
+
+            const elapsed = currentTime - startTimeRef.current;
+            const progress = Math.min(elapsed / duration, 1);
+            const easeProgress = 1 - Math.pow(1 - progress, 3);
+
+            const current = Math.round(startValue + (value - startValue) * easeProgress);
+            setDisplayValue(current);
+
+            if (progress < 1) {
+                rafRef.current = requestAnimationFrame(animate);
+            } else {
+                setDisplayValue(value);
+            }
+        };
+
+        rafRef.current = requestAnimationFrame(animate);
+
+        return () => {
+            if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        };
+    }, [value]);
+
+    const formatted = displayValue.toLocaleString('ko-KR');
+    const chars = formatted.split('');
+
+    return (
+        <span className="inline-flex items-baseline font-bold text-blue-600" style={{ fontVariantNumeric: 'tabular-nums' }} aria-label={`${displayValue}개`}>
+            {chars.map((char, i) => (
+                <RollingDigit
+                    key={`${chars.length}-${i}`}
+                    digit={char}
+                    delay={i * 0.03}
+                />
+            ))}
+            <span>개</span>
+        </span>
+    );
+}
+
+export default function TeamStatsBanner() {
+    const { data: stats, isLoading } = useTeamStats();
+
+    if (isLoading || !stats) return null;
+
+    return (
+        <div className="mx-4 mb-3 px-4 py-4 rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 animate-slideDown">
+            <div className="flex items-start gap-3">
+                <FiUsers size={20} className="text-blue-600 mt-0.5 shrink-0" />
+                <p className="text-sm text-gray-700">
+                    친해지기 바래는 <AnimatedCount value={stats.total_teams} />의 동아리와 함께하고 있어요
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/app/_lib/api/activities.ts
+++ b/app/_lib/api/activities.ts
@@ -1,0 +1,38 @@
+import api from './client'
+import type {
+  Activity,
+  ActivityCreateRequest,
+  ActivityUpdateRequest,
+  ActivityListResponse,
+} from '@/_types/team'
+
+export async function createActivity(teamId: number, data: ActivityCreateRequest): Promise<Activity> {
+  const res = await api.post(`/chinba/teams/${teamId}/activities`, data)
+  return res.data
+}
+
+export async function getActivities(
+  teamId: number,
+  params?: { group_id?: number; month?: string; skip?: number; limit?: number },
+): Promise<ActivityListResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/activities`, { params })
+  return res.data
+}
+
+export async function getActivityDetail(teamId: number, activityId: number): Promise<Activity> {
+  const res = await api.get(`/chinba/teams/${teamId}/activities/${activityId}`)
+  return res.data
+}
+
+export async function updateActivity(
+  teamId: number,
+  activityId: number,
+  data: ActivityUpdateRequest,
+): Promise<Activity> {
+  const res = await api.patch(`/chinba/teams/${teamId}/activities/${activityId}`, data)
+  return res.data
+}
+
+export async function deleteActivity(teamId: number, activityId: number): Promise<void> {
+  await api.delete(`/chinba/teams/${teamId}/activities/${activityId}`)
+}

--- a/app/_lib/api/groups.test.ts
+++ b/app/_lib/api/groups.test.ts
@@ -1,0 +1,51 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+vi.mock('./client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import api from './client'
+import { parseGroups, saveGroups, getGroups, changeGroupLeader } from './groups'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('parseGroups', () => {
+  it('sends POST /chinba/teams/:teamId/groups/parse', async () => {
+    vi.mocked(api.post).mockResolvedValue({ data: { parsed_groups: [], unmatched_names: [], unassigned_members: [] } })
+    await parseGroups(1, { text: '1조\n조장: 홍길동' })
+    expect(api.post).toHaveBeenCalledWith('/chinba/teams/1/groups/parse', { text: '1조\n조장: 홍길동' })
+  })
+})
+
+describe('saveGroups', () => {
+  it('sends PUT /chinba/teams/:teamId/groups', async () => {
+    vi.mocked(api.put).mockResolvedValue({ data: { groups: [] } })
+    await saveGroups(1, { groups: [{ name: '1조', display_order: 1, members: [] }] })
+    expect(api.put).toHaveBeenCalledWith('/chinba/teams/1/groups', { groups: [{ name: '1조', display_order: 1, members: [] }] })
+  })
+})
+
+describe('getGroups', () => {
+  it('sends GET /chinba/teams/:teamId/groups', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { groups: [], unassigned_members: [] } })
+    const result = await getGroups(1)
+    expect(api.get).toHaveBeenCalledWith('/chinba/teams/1/groups')
+    expect(result.groups).toEqual([])
+  })
+})
+
+describe('changeGroupLeader', () => {
+  it('sends PATCH /chinba/teams/:teamId/groups/:groupId/leader', async () => {
+    vi.mocked(api.patch).mockResolvedValue({ data: {} })
+    await changeGroupLeader(1, 2, 5)
+    expect(api.patch).toHaveBeenCalledWith('/chinba/teams/1/groups/2/leader', { member_id: 5 })
+  })
+})

--- a/app/_lib/api/groups.ts
+++ b/app/_lib/api/groups.ts
@@ -1,0 +1,51 @@
+import api from './client'
+import type {
+  GroupsListResponse,
+  GroupsSaveRequest,
+  GroupParseRequest,
+  GroupParseResponse,
+  Group,
+  GroupSet,
+  GroupSetsListResponse,
+  GroupSetCreateRequest,
+} from '@/_types/team'
+
+export async function parseGroups(teamId: number, data: GroupParseRequest): Promise<GroupParseResponse> {
+  const res = await api.post(`/chinba/teams/${teamId}/groups/parse`, data, { timeout: 30000 })
+  return res.data
+}
+
+export async function saveGroups(teamId: number, data: GroupsSaveRequest): Promise<{ groups: Group[] }> {
+  const res = await api.put(`/chinba/teams/${teamId}/groups`, data)
+  return res.data
+}
+
+export async function getGroups(teamId: number, groupSetId?: number): Promise<GroupsListResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/groups`, {
+    params: groupSetId != null ? { group_set_id: groupSetId } : undefined,
+  })
+  return res.data
+}
+
+export async function changeGroupLeader(teamId: number, groupId: number, memberId: number): Promise<void> {
+  await api.patch(`/chinba/teams/${teamId}/groups/${groupId}/leader`, { member_id: memberId })
+}
+
+export async function getGroupSets(teamId: number): Promise<GroupSetsListResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/group-sets`)
+  return res.data
+}
+
+export async function createGroupSet(teamId: number, data: GroupSetCreateRequest): Promise<GroupSet> {
+  const res = await api.post(`/chinba/teams/${teamId}/group-sets`, data)
+  return res.data
+}
+
+export async function updateGroupSet(teamId: number, setId: number, data: GroupSetCreateRequest): Promise<GroupSet> {
+  const res = await api.put(`/chinba/teams/${teamId}/group-sets/${setId}`, data)
+  return res.data
+}
+
+export async function deleteGroupSet(teamId: number, setId: number): Promise<void> {
+  await api.delete(`/chinba/teams/${teamId}/group-sets/${setId}`)
+}

--- a/app/_lib/api/index.ts
+++ b/app/_lib/api/index.ts
@@ -31,6 +31,12 @@ export * from './career';
 // Chinba
 export * from './chinba';
 
+// Subscriptions
+export * from './subscriptions';
+
+// Activities
+export * from './activities';
+
 // Types re-export for convenience
 export type { Notice, NoticeListResponse } from '@/_types/notice';
 export type { Keyword } from '@/_types/keyword';

--- a/app/_lib/api/rankings.ts
+++ b/app/_lib/api/rankings.ts
@@ -1,0 +1,43 @@
+import type {
+  RankingsResponse,
+  TrendResponse,
+  GroupRankingDetail,
+  MyRanking,
+  MembersRankingResponse,
+} from '@/_types/team'
+
+import api from './client'
+
+export async function getRankings(
+  teamId: number,
+  params?: { period?: string; group_set_id?: number },
+): Promise<RankingsResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/rankings`, { params })
+  return res.data
+}
+
+export async function getRankingsTrend(
+  teamId: number,
+  params?: { period?: string; interval?: string; group_set_id?: number },
+): Promise<TrendResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/rankings/trend`, { params })
+  return res.data
+}
+
+export async function getGroupDetail(
+  teamId: number,
+  groupId: number,
+): Promise<GroupRankingDetail> {
+  const res = await api.get(`/chinba/teams/${teamId}/rankings/groups/${groupId}`)
+  return res.data
+}
+
+export async function getMyRanking(teamId: number, params?: { group_set_id?: number }): Promise<MyRanking> {
+  const res = await api.get(`/chinba/teams/${teamId}/rankings/me`, { params })
+  return res.data
+}
+
+export async function getMembersRanking(teamId: number): Promise<MembersRankingResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/rankings/members`)
+  return res.data
+}

--- a/app/_lib/api/stats.ts
+++ b/app/_lib/api/stats.ts
@@ -10,3 +10,13 @@ export const getUserStats = async () => {
     const response = await api.get<UserStats>('/stats/users');
     return response.data;
 };
+
+export interface TeamStats {
+    total_teams: number;
+    updated_at: string;
+}
+
+export const getTeamStats = async () => {
+    const response = await api.get<TeamStats>('/stats/teams');
+    return response.data;
+};

--- a/app/_lib/api/subscriptions.ts
+++ b/app/_lib/api/subscriptions.ts
@@ -1,0 +1,26 @@
+import api from './client';
+import type {
+  SubscriptionDetail,
+  SubscriptionCreateRequest,
+  SubscriptionCreateResponse,
+} from '@/_types/team';
+
+export async function getSubscription(teamId: number): Promise<SubscriptionDetail> {
+  const res = await api.get(`/chinba/teams/${teamId}/subscription`);
+  return res.data;
+}
+
+export async function createSubscription(
+  teamId: number,
+  data: SubscriptionCreateRequest,
+): Promise<SubscriptionCreateResponse> {
+  const res = await api.post(`/chinba/teams/${teamId}/subscription`, data);
+  return res.data;
+}
+
+export async function cancelSubscription(
+  teamId: number,
+): Promise<{ message: string; expires_at: string | null }> {
+  const res = await api.delete(`/chinba/teams/${teamId}/subscription`);
+  return res.data;
+}

--- a/app/_lib/api/teamEvents.ts
+++ b/app/_lib/api/teamEvents.ts
@@ -1,0 +1,47 @@
+import api from './client';
+import type {
+  TeamEvent,
+  TeamEventCreateRequest,
+  TeamEventListResponse,
+  TeamEventDetail,
+  TimetableEntry,
+} from '@/_types/team';
+
+export async function createTeamEvent(
+  teamId: number,
+  data: TeamEventCreateRequest,
+): Promise<{ event_id: string; title: string; team_id: number; target_groups: { id: number; name: string }[]; participant_count: number; created_at: string }> {
+  const res = await api.post(`/chinba/teams/${teamId}/events`, data);
+  return res.data;
+}
+
+export async function getTeamEvents(
+  teamId: number,
+  params?: { status?: string; skip?: number; limit?: number },
+): Promise<TeamEventListResponse> {
+  const res = await api.get(`/chinba/teams/${teamId}/events`, {
+    params: {
+      event_status: params?.status,
+      skip: params?.skip,
+      limit: params?.limit,
+    },
+  });
+  return res.data;
+}
+
+export async function getTeamEventDetail(
+  teamId: number,
+  eventId: string,
+): Promise<TeamEventDetail> {
+  const res = await api.get(`/chinba/teams/${teamId}/events/${eventId}`);
+  return res.data;
+}
+
+export async function getTeamTimetables(
+  teamId: number,
+  groupId?: number,
+): Promise<{ timetables: TimetableEntry[] }> {
+  const params = groupId ? { group_id: groupId } : undefined;
+  const res = await api.get(`/chinba/teams/${teamId}/timetables`, { params });
+  return res.data;
+}

--- a/app/_lib/api/teams.test.ts
+++ b/app/_lib/api/teams.test.ts
@@ -1,0 +1,223 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('./client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import api from './client';
+import {
+  createTeam,
+  getMyTeams,
+  getTeamDetail,
+  updateTeam,
+  deleteTeam,
+  getTeamMembers,
+  changeRole,
+  transferCaptain,
+  removeMember,
+  leaveTeam,
+  joinTeam,
+  getInvitations,
+  regenerateInviteCode,
+} from './teams';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createTeam', () => {
+  it('sends POST /chinba/teams with body', async () => {
+    const mockTeam = {
+      id: 1,
+      name: '테스트팀',
+      description: null,
+      category: null,
+      invite_code: 'abc12345',
+      member_count: 1,
+      my_role: 'captain',
+      status: 'active',
+      created_at: '2026-03-15',
+    };
+    vi.mocked(api.post).mockResolvedValue({ data: mockTeam });
+
+    const result = await createTeam({ name: '테스트팀' });
+
+    expect(api.post).toHaveBeenCalledWith('/chinba/teams', { name: '테스트팀' });
+    expect(result.id).toBe(1);
+    expect(result.my_role).toBe('captain');
+  });
+});
+
+describe('getMyTeams', () => {
+  it('sends GET /chinba/teams', async () => {
+    const mockResponse = { teams: [{ id: 1, name: '팀1', member_count: 5 }] };
+    vi.mocked(api.get).mockResolvedValue({ data: mockResponse });
+
+    const result = await getMyTeams();
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/teams');
+    expect(result.teams).toHaveLength(1);
+  });
+});
+
+describe('getTeamDetail', () => {
+  it('sends GET /chinba/teams/:teamId', async () => {
+    const mockDetail = { id: 1, name: '팀1', my_role: 'captain' };
+    vi.mocked(api.get).mockResolvedValue({ data: mockDetail });
+
+    const result = await getTeamDetail(1);
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/teams/1');
+    expect(result.id).toBe(1);
+  });
+});
+
+describe('updateTeam', () => {
+  it('sends PATCH /chinba/teams/:teamId with body', async () => {
+    const mockDetail = { id: 1, name: '수정된팀', my_role: 'captain' };
+    vi.mocked(api.patch).mockResolvedValue({ data: mockDetail });
+
+    const result = await updateTeam(1, { name: '수정된팀' });
+
+    expect(api.patch).toHaveBeenCalledWith('/chinba/teams/1', { name: '수정된팀' });
+    expect(result.name).toBe('수정된팀');
+  });
+});
+
+describe('deleteTeam', () => {
+  it('sends DELETE /chinba/teams/:teamId', async () => {
+    vi.mocked(api.delete).mockResolvedValue({ data: { message: '삭제 완료' } });
+
+    const result = await deleteTeam(1);
+
+    expect(api.delete).toHaveBeenCalledWith('/chinba/teams/1');
+    expect(result.message).toBe('삭제 완료');
+  });
+});
+
+describe('getTeamMembers', () => {
+  it('sends GET /chinba/teams/:teamId/members without role filter', async () => {
+    const mockResponse = { members: [], total: 0 };
+    vi.mocked(api.get).mockResolvedValue({ data: mockResponse });
+
+    const result = await getTeamMembers(1);
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/teams/1/members', { params: undefined });
+    expect(result.total).toBe(0);
+  });
+
+  it('sends GET /chinba/teams/:teamId/members with role filter', async () => {
+    const mockResponse = { members: [], total: 0 };
+    vi.mocked(api.get).mockResolvedValue({ data: mockResponse });
+
+    await getTeamMembers(1, 'captain');
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/teams/1/members', { params: { role: 'captain' } });
+  });
+});
+
+describe('changeRole', () => {
+  it('sends PATCH /chinba/teams/:teamId/members/:memberId/role', async () => {
+    const mockMember = { id: 2, user_id: 10, role: 'executive' };
+    vi.mocked(api.patch).mockResolvedValue({ data: mockMember });
+
+    const result = await changeRole(1, 2, 'executive');
+
+    expect(api.patch).toHaveBeenCalledWith('/chinba/teams/1/members/2/role', { role: 'executive' });
+    expect(result.role).toBe('executive');
+  });
+});
+
+describe('transferCaptain', () => {
+  it('sends POST /chinba/teams/:teamId/captain-transfer', async () => {
+    vi.mocked(api.post).mockResolvedValue({ data: { message: '이양 완료' } });
+
+    const result = await transferCaptain(1, { new_captain_member_id: 5 });
+
+    expect(api.post).toHaveBeenCalledWith('/chinba/teams/1/captain-transfer', { new_captain_member_id: 5 });
+    expect(result.message).toBe('이양 완료');
+  });
+});
+
+describe('removeMember', () => {
+  it('sends DELETE /chinba/teams/:teamId/members/:memberId', async () => {
+    vi.mocked(api.delete).mockResolvedValue({ data: { message: '추방 완료' } });
+
+    const result = await removeMember(1, 3);
+
+    expect(api.delete).toHaveBeenCalledWith('/chinba/teams/1/members/3');
+    expect(result.message).toBe('추방 완료');
+  });
+});
+
+describe('leaveTeam', () => {
+  it('sends DELETE /chinba/teams/:teamId/members/me', async () => {
+    vi.mocked(api.delete).mockResolvedValue({ data: { message: '탈퇴 완료' } });
+
+    const result = await leaveTeam(1);
+
+    expect(api.delete).toHaveBeenCalledWith('/chinba/teams/1/members/me');
+    expect(result.message).toBe('탈퇴 완료');
+  });
+});
+
+describe('joinTeam', () => {
+  it('sends POST /chinba/teams/join with invite_code', async () => {
+    const mockResponse = {
+      team_id: 1,
+      team_name: '테스트팀',
+      my_role: 'member',
+      message: '가입 완료',
+    };
+    vi.mocked(api.post).mockResolvedValue({ data: mockResponse });
+
+    const result = await joinTeam({ invite_code: 'abc12345' });
+
+    expect(api.post).toHaveBeenCalledWith('/chinba/teams/join', { invite_code: 'abc12345' });
+    expect(result.team_id).toBe(1);
+    expect(result.my_role).toBe('member');
+  });
+});
+
+describe('getInvitations', () => {
+  it('sends GET /chinba/teams/:teamId/invitation', async () => {
+    const mockInvitation = {
+      invite_code: 'abc12345',
+      invite_url: 'https://chinba.app/invite/abc12345',
+      is_active: true,
+      created_at: '2026-03-15',
+      expires_at: null,
+    };
+    vi.mocked(api.get).mockResolvedValue({ data: mockInvitation });
+
+    const result = await getInvitations(1);
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/teams/1/invitations');
+    expect(result.invite_code).toBe('abc12345');
+    expect(result.is_active).toBe(true);
+  });
+});
+
+describe('regenerateInviteCode', () => {
+  it('sends POST /chinba/teams/:teamId/invitation/regenerate', async () => {
+    const mockInvitation = {
+      invite_code: 'new12345',
+      invite_url: 'https://chinba.app/invite/new12345',
+      is_active: true,
+      created_at: '2026-03-15',
+      expires_at: null,
+    };
+    vi.mocked(api.post).mockResolvedValue({ data: mockInvitation });
+
+    const result = await regenerateInviteCode(1);
+
+    expect(api.post).toHaveBeenCalledWith('/chinba/teams/1/invitations/regenerate');
+    expect(result.invite_code).toBe('new12345');
+  });
+});

--- a/app/_lib/api/teams.ts
+++ b/app/_lib/api/teams.ts
@@ -1,0 +1,80 @@
+import api from './client';
+import type {
+  Team,
+  TeamListItem,
+  TeamDetail,
+  TeamMember,
+  TeamMemberListResponse,
+  TeamCreateRequest,
+  TeamUpdateRequest,
+  JoinTeamRequest,
+  JoinTeamResponse,
+  InvitationInfo,
+  CaptainTransferRequest,
+} from '@/_types/team';
+
+export async function createTeam(data: TeamCreateRequest): Promise<Team> {
+  const res = await api.post('/chinba/teams', data);
+  return res.data;
+}
+
+export async function getMyTeams(): Promise<{ teams: TeamListItem[] }> {
+  const res = await api.get('/chinba/teams');
+  return res.data;
+}
+
+export async function getTeamDetail(teamId: number): Promise<TeamDetail> {
+  const res = await api.get(`/chinba/teams/${teamId}`);
+  return res.data;
+}
+
+export async function updateTeam(teamId: number, data: TeamUpdateRequest): Promise<TeamDetail> {
+  const res = await api.patch(`/chinba/teams/${teamId}`, data);
+  return res.data;
+}
+
+export async function deleteTeam(teamId: number): Promise<{ message: string }> {
+  const res = await api.delete(`/chinba/teams/${teamId}`);
+  return res.data;
+}
+
+export async function getTeamMembers(teamId: number, role?: string): Promise<TeamMemberListResponse> {
+  const params = role ? { role } : undefined;
+  const res = await api.get(`/chinba/teams/${teamId}/members`, { params });
+  return res.data;
+}
+
+export async function changeRole(teamId: number, memberId: number, role: string): Promise<TeamMember> {
+  const res = await api.patch(`/chinba/teams/${teamId}/members/${memberId}/role`, { role });
+  return res.data;
+}
+
+export async function transferCaptain(teamId: number, data: CaptainTransferRequest): Promise<any> {
+  const res = await api.post(`/chinba/teams/${teamId}/captain-transfer`, data);
+  return res.data;
+}
+
+export async function removeMember(teamId: number, memberId: number): Promise<{ message: string }> {
+  const res = await api.delete(`/chinba/teams/${teamId}/members/${memberId}`);
+  return res.data;
+}
+
+export async function leaveTeam(teamId: number): Promise<{ message: string }> {
+  const res = await api.delete(`/chinba/teams/${teamId}/members/me`);
+  return res.data;
+}
+
+export async function joinTeam(data: JoinTeamRequest): Promise<JoinTeamResponse> {
+  const res = await api.post('/chinba/teams/join', data);
+  return res.data;
+}
+
+export async function getInvitations(teamId: number): Promise<InvitationInfo> {
+  const res = await api.get(`/chinba/teams/${teamId}/invitations`);
+  return res.data;
+}
+
+export async function regenerateInviteCode(teamId: number): Promise<InvitationInfo> {
+  const res = await api.post(`/chinba/teams/${teamId}/invitations/regenerate`);
+  return res.data;
+}

--- a/app/_lib/hooks/useActivities.ts
+++ b/app/_lib/hooks/useActivities.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  getActivities,
+  getActivityDetail,
+  createActivity,
+  updateActivity,
+  deleteActivity,
+} from '@/_lib/api/activities'
+import type { ActivityCreateRequest, ActivityUpdateRequest } from '@/_types/team'
+
+export function useActivities(
+  teamId: number | undefined,
+  params?: { group_id?: number; month?: string; skip?: number; limit?: number },
+) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'activities', params],
+    queryFn: () => getActivities(teamId!, params),
+    enabled: !!teamId,
+  })
+}
+
+export function useActivityDetail(teamId: number | undefined, activityId: number | undefined) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'activities', activityId],
+    queryFn: () => getActivityDetail(teamId!, activityId!),
+    enabled: !!teamId && !!activityId,
+  })
+}
+
+export function useCreateActivity(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: ActivityCreateRequest) => createActivity(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'activities'] })
+    },
+  })
+}
+
+export function useUpdateActivity(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ activityId, data }: { activityId: number; data: ActivityUpdateRequest }) =>
+      updateActivity(teamId, activityId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'activities'] })
+    },
+  })
+}
+
+export function useDeleteActivity(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (activityId: number) => deleteActivity(teamId, activityId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'activities'] })
+    },
+  })
+}

--- a/app/_lib/hooks/useGroups.ts
+++ b/app/_lib/hooks/useGroups.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getGroups, saveGroups, parseGroups, changeGroupLeader, getGroupSets, createGroupSet, updateGroupSet, deleteGroupSet } from '@/_lib/api/groups'
+import { hasAccessToken } from '@/_lib/auth/tokenStore'
+import type { GroupsSaveRequest, GroupParseRequest, GroupSetCreateRequest } from '@/_types/team'
+
+export function useGroups(teamId: number | undefined, groupSetId?: number) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'groups', groupSetId],
+    queryFn: () => getGroups(teamId!, groupSetId),
+    enabled: !!teamId && hasAccessToken(),
+  })
+}
+
+export function useParseGroups(teamId: number) {
+  return useMutation({
+    mutationFn: (data: GroupParseRequest) => parseGroups(teamId, data),
+  })
+}
+
+export function useSaveGroups(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: GroupsSaveRequest) => saveGroups(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'groups'] })
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'group-sets'] })
+      qc.invalidateQueries({ queryKey: ['teams', teamId] })
+    },
+  })
+}
+
+export function useChangeGroupLeader(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ groupId, memberId }: { groupId: number; memberId: number }) =>
+      changeGroupLeader(teamId, groupId, memberId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'groups'] })
+    },
+  })
+}
+
+export function useGroupSets(teamId: number | undefined) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'group-sets'],
+    queryFn: () => getGroupSets(teamId!),
+    enabled: !!teamId && hasAccessToken(),
+  })
+}
+
+export function useCreateGroupSet(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: GroupSetCreateRequest) => createGroupSet(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'group-sets'] })
+    },
+  })
+}
+
+export function useUpdateGroupSet(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ setId, data }: { setId: number; data: GroupSetCreateRequest }) =>
+      updateGroupSet(teamId, setId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'group-sets'] })
+    },
+  })
+}
+
+export function useDeleteGroupSet(teamId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (setId: number) => deleteGroupSet(teamId, setId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'group-sets'] })
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'groups'] })
+    },
+  })
+}

--- a/app/_lib/hooks/useRankings.ts
+++ b/app/_lib/hooks/useRankings.ts
@@ -1,0 +1,60 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+
+import {
+  getRankings,
+  getRankingsTrend,
+  getGroupDetail,
+  getMyRanking,
+  getMembersRanking,
+} from '@/_lib/api/rankings'
+
+export function useRankings(
+  teamId: number | undefined,
+  params?: { period?: string; group_set_id?: number },
+) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'rankings', params],
+    queryFn: () => getRankings(teamId!, params),
+    enabled: !!teamId,
+  })
+}
+
+export function useRankingsTrend(
+  teamId: number | undefined,
+  params?: { period?: string; interval?: string; group_set_id?: number },
+) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'rankings', 'trend', params],
+    queryFn: () => getRankingsTrend(teamId!, params),
+    enabled: !!teamId,
+  })
+}
+
+export function useGroupDetail(
+  teamId: number | undefined,
+  groupId: number | undefined,
+) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'rankings', 'groups', groupId],
+    queryFn: () => getGroupDetail(teamId!, groupId!),
+    enabled: !!teamId && !!groupId,
+  })
+}
+
+export function useMyRanking(teamId: number | undefined, params?: { group_set_id?: number }) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'rankings', 'me', params],
+    queryFn: () => getMyRanking(teamId!, params),
+    enabled: !!teamId,
+  })
+}
+
+export function useMembersRanking(teamId: number | undefined) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'rankings', 'members'],
+    queryFn: () => getMembersRanking(teamId!),
+    enabled: !!teamId,
+  })
+}

--- a/app/_lib/hooks/useSubscription.ts
+++ b/app/_lib/hooks/useSubscription.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getSubscription,
+  createSubscription,
+  cancelSubscription,
+} from '@/_lib/api/subscriptions';
+import type { SubscriptionCreateRequest } from '@/_types/team';
+
+export function useSubscription(teamId: number | undefined) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'subscription'],
+    queryFn: () => getSubscription(teamId!),
+    enabled: !!teamId,
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useCreateSubscription(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: SubscriptionCreateRequest) => createSubscription(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'subscription'] });
+      qc.invalidateQueries({ queryKey: ['teams', teamId] });
+      qc.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}
+
+export function useCancelSubscription(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => cancelSubscription(teamId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'subscription'] });
+      qc.invalidateQueries({ queryKey: ['teams', teamId] });
+      qc.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}

--- a/app/_lib/hooks/useTeam.ts
+++ b/app/_lib/hooks/useTeam.ts
@@ -1,0 +1,145 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getMyTeams,
+  getTeamDetail,
+  getTeamMembers,
+  createTeam,
+  updateTeam,
+  deleteTeam,
+  joinTeam,
+  leaveTeam,
+  removeMember,
+  changeRole,
+  transferCaptain,
+  regenerateInviteCode,
+} from '@/_lib/api/teams';
+import { hasAccessToken } from '@/_lib/auth/tokenStore';
+import type {
+  TeamCreateRequest,
+  TeamUpdateRequest,
+  JoinTeamRequest,
+  CaptainTransferRequest,
+} from '@/_types/team';
+
+export function useMyTeams() {
+  return useQuery({
+    queryKey: ['teams'],
+    queryFn: getMyTeams,
+    staleTime: 1000 * 60 * 5,
+    enabled: hasAccessToken(),
+  });
+}
+
+export function useTeamDetail(teamId: number | undefined) {
+  return useQuery({
+    queryKey: ['teams', teamId],
+    queryFn: () => getTeamDetail(teamId!),
+    enabled: !!teamId && hasAccessToken(),
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useTeamMembers(teamId: number | undefined, role?: string) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'members', role],
+    queryFn: () => getTeamMembers(teamId!, role),
+    enabled: !!teamId && hasAccessToken(),
+  });
+}
+
+export function useCreateTeam() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: TeamCreateRequest) => createTeam(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}
+
+export function useUpdateTeam(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: TeamUpdateRequest) => updateTeam(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams'] });
+      qc.invalidateQueries({ queryKey: ['teams', teamId] });
+    },
+  });
+}
+
+export function useDeleteTeam() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (teamId: number) => deleteTeam(teamId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}
+
+export function useJoinTeam() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: JoinTeamRequest) => joinTeam(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}
+
+export function useLeaveTeam() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (teamId: number) => leaveTeam(teamId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams'] });
+    },
+  });
+}
+
+export function useRemoveMember(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (memberId: number) => removeMember(teamId, memberId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'members'] });
+      qc.invalidateQueries({ queryKey: ['teams', teamId] });
+    },
+  });
+}
+
+export function useChangeRole(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ memberId, role }: { memberId: number; role: string }) =>
+      changeRole(teamId, memberId, role),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'members'] });
+    },
+  });
+}
+
+export function useTransferCaptain(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CaptainTransferRequest) => transferCaptain(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams'] });
+      qc.invalidateQueries({ queryKey: ['teams', teamId] });
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'members'] });
+    },
+  });
+}
+
+export function useRegenerateInviteCode(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => regenerateInviteCode(teamId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId] });
+    },
+  });
+}

--- a/app/_lib/hooks/useTeamEvents.ts
+++ b/app/_lib/hooks/useTeamEvents.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  createTeamEvent,
+  getTeamEvents,
+  getTeamEventDetail,
+  getTeamTimetables,
+} from '@/_lib/api/teamEvents';
+import type { TeamEventCreateRequest } from '@/_types/team';
+
+export function useTeamEvents(teamId: number | undefined, status?: string) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'events', status],
+    queryFn: () => getTeamEvents(teamId!, { status }),
+    enabled: !!teamId,
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useTeamEventDetail(teamId: number | undefined, eventId: string | undefined) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'events', eventId],
+    queryFn: () => getTeamEventDetail(teamId!, eventId!),
+    enabled: !!teamId && !!eventId,
+    staleTime: 1000 * 30,
+  });
+}
+
+export function useCreateTeamEvent(teamId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: TeamEventCreateRequest) => createTeamEvent(teamId, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['teams', teamId, 'events'] });
+    },
+  });
+}
+
+export function useTeamTimetables(teamId: number | undefined, groupId?: number) {
+  return useQuery({
+    queryKey: ['teams', teamId, 'timetables', groupId],
+    queryFn: () => getTeamTimetables(teamId!, groupId),
+    enabled: !!teamId,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/app/_lib/hooks/useTeamStats.ts
+++ b/app/_lib/hooks/useTeamStats.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getTeamStats } from '@/_lib/api/stats';
+
+export function useTeamStats() {
+    return useQuery({
+        queryKey: ['stats', 'teams'],
+        queryFn: getTeamStats,
+        staleTime: 1000 * 60 * 60, // 1시간 캐시
+        refetchOnMount: false,
+    });
+}

--- a/app/_lib/utils/teamDisplay.test.ts
+++ b/app/_lib/utils/teamDisplay.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRoleBadgeLabel,
+  getRoleBadgeColor,
+  formatInviteUrl,
+  getTeamStatusLabel,
+  formatMemberCount,
+  getCategoryOptions,
+} from './teamDisplay';
+
+describe('getRoleBadgeLabel', () => {
+  it('returns 팀장 for captain', () => {
+    expect(getRoleBadgeLabel('captain')).toBe('팀장');
+  });
+
+  it('returns 임원 for executive', () => {
+    expect(getRoleBadgeLabel('executive')).toBe('임원');
+  });
+
+  it('returns 팀원 for member', () => {
+    expect(getRoleBadgeLabel('member')).toBe('팀원');
+  });
+
+  it('returns 팀원 for undefined', () => {
+    expect(getRoleBadgeLabel(undefined)).toBe('팀원');
+  });
+
+  it('returns 팀원 for unknown role', () => {
+    expect(getRoleBadgeLabel('unknown')).toBe('팀원');
+  });
+});
+
+describe('getRoleBadgeColor', () => {
+  it('returns red for captain', () => {
+    expect(getRoleBadgeColor('captain')).toBe('red');
+  });
+
+  it('returns blue for executive', () => {
+    expect(getRoleBadgeColor('executive')).toBe('blue');
+  });
+
+  it('returns gray for member', () => {
+    expect(getRoleBadgeColor('member')).toBe('gray');
+  });
+
+  it('returns gray for undefined', () => {
+    expect(getRoleBadgeColor(undefined)).toBe('gray');
+  });
+
+  it('returns gray for unknown role', () => {
+    expect(getRoleBadgeColor('unknown')).toBe('gray');
+  });
+});
+
+describe('formatInviteUrl', () => {
+  it('formats invite code into full URL', () => {
+    expect(formatInviteUrl('abc12345')).toBe('https://chinba.app/invite?code=abc12345');
+  });
+
+  it('handles empty string', () => {
+    expect(formatInviteUrl('')).toBe('https://chinba.app/invite?code=');
+  });
+});
+
+describe('getTeamStatusLabel', () => {
+  it('returns 프리미엄 when isPaid is true', () => {
+    expect(getTeamStatusLabel(true, 5)).toBe('프리미엄');
+  });
+
+  it('returns 프리미엄 when isPaid is true regardless of member count', () => {
+    expect(getTeamStatusLabel(true, 25)).toBe('프리미엄');
+  });
+
+  it('returns 구독 필요 when not paid regardless of member count', () => {
+    expect(getTeamStatusLabel(false, 20)).toBe('구독 필요');
+    expect(getTeamStatusLabel(false, 50)).toBe('구독 필요');
+    expect(getTeamStatusLabel(false, 5)).toBe('구독 필요');
+    expect(getTeamStatusLabel(false, 0)).toBe('구독 필요');
+  });
+});
+
+describe('formatMemberCount', () => {
+  it('formats count with 명 suffix', () => {
+    expect(formatMemberCount(5)).toBe('5명');
+  });
+
+  it('formats zero', () => {
+    expect(formatMemberCount(0)).toBe('0명');
+  });
+
+  it('formats large numbers', () => {
+    expect(formatMemberCount(100)).toBe('100명');
+  });
+});
+
+describe('getCategoryOptions', () => {
+  it('returns 6 category options', () => {
+    const options = getCategoryOptions();
+    expect(options).toHaveLength(6);
+  });
+
+  it('each option has label and value', () => {
+    const options = getCategoryOptions();
+    options.forEach((option) => {
+      expect(option).toHaveProperty('label');
+      expect(option).toHaveProperty('value');
+      expect(typeof option.label).toBe('string');
+      expect(typeof option.value).toBe('string');
+    });
+  });
+
+  it('includes expected categories', () => {
+    const options = getCategoryOptions();
+    const values = options.map((o) => o.value);
+    expect(values).toContain('동아리');
+    expect(values).toContain('학과');
+    expect(values).toContain('스터디');
+    expect(values).toContain('연구실');
+    expect(values).toContain('학회');
+    expect(values).toContain('기타');
+  });
+});

--- a/app/_lib/utils/teamDisplay.ts
+++ b/app/_lib/utils/teamDisplay.ts
@@ -1,0 +1,63 @@
+export function getRoleBadgeLabel(role?: string): string {
+  switch (role) {
+    case 'captain': return '팀장';
+    case 'executive': return '임원';
+    case 'member': return '팀원';
+    default: return '팀원';
+  }
+}
+
+export function getRoleBadgeColor(role?: string): string {
+  switch (role) {
+    case 'captain': return 'red';
+    case 'executive': return 'blue';
+    case 'member': return 'gray';
+    default: return 'gray';
+  }
+}
+
+export function formatInviteUrl(inviteCode: string): string {
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://chinba.app';
+  return `${origin}/invite?code=${inviteCode}`;
+}
+
+export function getTeamStatusLabel(isPaid: boolean, _memberCount: number): string {
+  if (isPaid) return '프리미엄';
+  return '구독 필요';
+}
+
+export function formatMemberCount(count: number): string {
+  return `${count}명`;
+}
+
+export function getCategoryOptions(): { label: string; value: string }[] {
+  return [
+    { label: '동아리', value: '동아리' },
+    { label: '학과', value: '학과' },
+    { label: '스터디', value: '스터디' },
+    { label: '연구실', value: '연구실' },
+    { label: '학회', value: '학회' },
+    { label: '기타', value: '기타' },
+  ];
+}
+
+/**
+ * groupId → setName 조회맵 생성
+ */
+export function buildGroupSetNameMap(groupSets: { id: number; name: string; groups: { id: number }[] }[]): Map<number, string> {
+  const map = new Map<number, string>();
+  for (const gs of groupSets) {
+    for (const g of gs.groups) {
+      map.set(g.id, gs.name);
+    }
+  }
+  return map;
+}
+
+/**
+ * 그룹 표시명에 세트명 접두어를 붙임 (예: "친바 - 1조")
+ */
+export function groupDisplayName(groupName: string, groupId: number, setNameMap: Map<number, string>): string {
+  const setName = setNameMap.get(groupId);
+  return setName ? `${setName} - ${groupName}` : groupName;
+}

--- a/app/_lib/utils/teamPermissions.test.ts
+++ b/app/_lib/utils/teamPermissions.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canEditTeam,
+  canDeleteTeam,
+  canRemoveMember,
+  canChangeRole,
+  canViewInvitation,
+  canRegenerateInvitation,
+  canTransferCaptain,
+} from './teamPermissions';
+
+describe('canEditTeam', () => {
+  it('captain can edit team', () => {
+    expect(canEditTeam('captain')).toBe(true);
+  });
+
+  it('executive can edit team', () => {
+    expect(canEditTeam('executive')).toBe(true);
+  });
+
+  it('member cannot edit team', () => {
+    expect(canEditTeam('member')).toBe(false);
+  });
+});
+
+describe('canDeleteTeam', () => {
+  it('captain can delete team', () => {
+    expect(canDeleteTeam('captain')).toBe(true);
+  });
+
+  it('executive cannot delete team', () => {
+    expect(canDeleteTeam('executive')).toBe(false);
+  });
+
+  it('member cannot delete team', () => {
+    expect(canDeleteTeam('member')).toBe(false);
+  });
+});
+
+describe('canRemoveMember', () => {
+  it('captain can remove executive', () => {
+    expect(canRemoveMember('captain', 'executive')).toBe(true);
+  });
+
+  it('captain can remove member', () => {
+    expect(canRemoveMember('captain', 'member')).toBe(true);
+  });
+
+  it('captain cannot remove captain', () => {
+    expect(canRemoveMember('captain', 'captain')).toBe(false);
+  });
+
+  it('executive can remove member', () => {
+    expect(canRemoveMember('executive', 'member')).toBe(true);
+  });
+
+  it('executive cannot remove executive', () => {
+    expect(canRemoveMember('executive', 'executive')).toBe(false);
+  });
+
+  it('executive cannot remove captain', () => {
+    expect(canRemoveMember('executive', 'captain')).toBe(false);
+  });
+
+  it('member cannot remove anyone', () => {
+    expect(canRemoveMember('member', 'member')).toBe(false);
+    expect(canRemoveMember('member', 'executive')).toBe(false);
+    expect(canRemoveMember('member', 'captain')).toBe(false);
+  });
+});
+
+describe('canChangeRole', () => {
+  it('captain can change role', () => {
+    expect(canChangeRole('captain')).toBe(true);
+  });
+
+  it('executive cannot change role', () => {
+    expect(canChangeRole('executive')).toBe(false);
+  });
+
+  it('member cannot change role', () => {
+    expect(canChangeRole('member')).toBe(false);
+  });
+});
+
+describe('canViewInvitation', () => {
+  it('captain can view invitation', () => {
+    expect(canViewInvitation('captain')).toBe(true);
+  });
+
+  it('executive can view invitation', () => {
+    expect(canViewInvitation('executive')).toBe(true);
+  });
+
+  it('member cannot view invitation', () => {
+    expect(canViewInvitation('member')).toBe(false);
+  });
+});
+
+describe('canRegenerateInvitation', () => {
+  it('captain can regenerate invitation', () => {
+    expect(canRegenerateInvitation('captain')).toBe(true);
+  });
+
+  it('executive cannot regenerate invitation', () => {
+    expect(canRegenerateInvitation('executive')).toBe(false);
+  });
+
+  it('member cannot regenerate invitation', () => {
+    expect(canRegenerateInvitation('member')).toBe(false);
+  });
+});
+
+describe('canTransferCaptain', () => {
+  it('captain can transfer captain', () => {
+    expect(canTransferCaptain('captain')).toBe(true);
+  });
+
+  it('executive cannot transfer captain', () => {
+    expect(canTransferCaptain('executive')).toBe(false);
+  });
+
+  it('member cannot transfer captain', () => {
+    expect(canTransferCaptain('member')).toBe(false);
+  });
+});

--- a/app/_lib/utils/teamPermissions.ts
+++ b/app/_lib/utils/teamPermissions.ts
@@ -1,0 +1,31 @@
+import type { TeamRole } from '@/_types/team';
+
+export function canEditTeam(role: TeamRole): boolean {
+  return role === 'captain' || role === 'executive';
+}
+
+export function canDeleteTeam(role: TeamRole): boolean {
+  return role === 'captain';
+}
+
+export function canRemoveMember(currentRole: TeamRole, targetRole: TeamRole): boolean {
+  if (currentRole === 'captain') return targetRole !== 'captain';
+  if (currentRole === 'executive') return targetRole === 'member';
+  return false;
+}
+
+export function canChangeRole(role: TeamRole): boolean {
+  return role === 'captain';
+}
+
+export function canViewInvitation(role: TeamRole): boolean {
+  return role === 'captain' || role === 'executive';
+}
+
+export function canRegenerateInvitation(role: TeamRole): boolean {
+  return role === 'captain';
+}
+
+export function canTransferCaptain(role: TeamRole): boolean {
+  return role === 'captain';
+}

--- a/app/_types/team.ts
+++ b/app/_types/team.ts
@@ -1,0 +1,408 @@
+export type TeamRole = 'captain' | 'executive' | 'member'
+export type TeamStatus = 'active' | 'archived'
+
+export interface Team {
+  id: number
+  name: string
+  description: string | null
+  category: string | null
+  invite_code: string | null
+  member_count: number
+  my_role: TeamRole
+  status: TeamStatus
+  created_at: string
+}
+
+export interface TeamListItem {
+  id: number
+  name: string
+  category: string | null
+  member_count: number
+  my_role: TeamRole
+  status: TeamStatus
+  is_paid: boolean
+  created_at: string
+}
+
+export interface TeamDetail {
+  id: number
+  name: string
+  description: string | null
+  category: string | null
+  member_count: number
+  my_role: TeamRole
+  my_group: { id: number; name: string; is_leader: boolean } | null
+  invite_code: string | null
+  status: TeamStatus
+  is_paid: boolean
+  trial_used: boolean
+  subscription: {
+    tier: string
+    billing_cycle: string
+    status: string
+    expires_at: string
+  } | null
+  created_at: string
+}
+
+export interface TeamMember {
+  id: number
+  user_id: number
+  nickname: string | null
+  profile_image: string | null
+  role: TeamRole
+  group: { id: number; name: string; is_leader: boolean } | null
+  joined_at: string
+}
+
+export interface TeamMemberListResponse {
+  members: TeamMember[]
+  total: number
+}
+
+export interface TeamCreateRequest {
+  name: string
+  description?: string
+  category?: string
+}
+
+export interface TeamUpdateRequest {
+  name?: string
+  description?: string
+  category?: string
+}
+
+export interface JoinTeamRequest {
+  invite_code: string
+}
+
+export interface JoinTeamResponse {
+  team_id: number
+  team_name: string
+  my_role: TeamRole
+  message: string
+}
+
+export interface InvitationInfo {
+  invite_code: string
+  invite_url: string
+  is_active: boolean
+  created_at: string
+  expires_at: string | null
+}
+
+export interface CaptainTransferRequest {
+  new_captain_member_id: number
+}
+
+// ==================== Group Types ====================
+
+export interface GroupMember {
+  member_id: number
+  user_id: number
+  nickname: string | null
+  profile_image: string | null
+  is_leader: boolean
+}
+
+export interface Group {
+  id: number
+  name: string
+  display_order: number
+  member_count: number
+  leader: { member_id: number; nickname: string } | null
+  members?: GroupMember[]
+  group_set_id: number | null
+}
+
+export interface GroupsListResponse {
+  groups: Group[]
+  unassigned_members: { member_id: number; nickname: string }[]
+}
+
+export interface GroupMemberInput {
+  member_id: number
+  is_leader: boolean
+}
+
+export interface GroupInput {
+  name: string
+  display_order: number
+  members: GroupMemberInput[]
+}
+
+export interface GroupsSaveRequest {
+  groups: GroupInput[]
+  group_set_id?: number
+}
+
+export interface GroupParseRequest {
+  text: string
+  group_set_id?: number
+}
+
+export interface ParsedGroupMember {
+  nickname: string
+  matched_member_id: number | null
+  is_leader: boolean
+  confidence: number
+}
+
+export interface ParsedGroup {
+  name: string
+  members: ParsedGroupMember[]
+}
+
+export interface GroupParseResponse {
+  parsed_groups: ParsedGroup[]
+  unmatched_names: string[]
+  unassigned_members: { member_id: number; nickname: string }[]
+}
+
+// ==================== GroupSet Types ====================
+
+export interface GroupSet {
+  id: number
+  name: string
+  display_order: number
+  group_count: number
+  groups: Group[]
+}
+
+export interface GroupSetsListResponse {
+  group_sets: GroupSet[]
+}
+
+export interface GroupSetCreateRequest {
+  name: string
+}
+
+// ==================== Subscription Types ====================
+
+export interface TierInfo {
+  tier: string
+  member_range: string
+  monthly_price: number
+  semester_price: number
+  annual_price: number
+}
+
+export interface SubscriptionDetail {
+  team_id: number
+  member_count: number
+  tier: string | null
+  tier_label: string | null
+  billing_cycle: string | null
+  amount: number | null
+  status: string | null
+  started_at: string | null
+  expires_at: string | null
+  trial_used: boolean
+  available_tiers: TierInfo[]
+}
+
+export interface SubscriptionCreateRequest {
+  billing_cycle: 'monthly' | 'semester' | 'annual'
+}
+
+export interface SubscriptionCreateResponse {
+  subscription_id: number
+  tier: string
+  billing_cycle: string
+  amount: number
+  status: string
+  started_at: string
+  expires_at: string
+}
+
+// ==================== Team Events Types ====================
+
+export interface TeamEvent {
+  event_id: string
+  title: string
+  dates: string[]
+  status: string
+  team_id: number
+  target_groups: { id: number; name: string }[]
+  total_participants: number
+  submitted_count: number
+  created_at: string
+}
+
+export interface TeamEventCreateRequest {
+  title: string
+  dates: string[]
+  target_group_ids?: number[]
+}
+
+export interface TeamEventListResponse {
+  events: TeamEvent[]
+  total: number
+}
+
+export interface TeamEventDetail {
+  event_id: string
+  title: string
+  dates: string[]
+  start_hour: number
+  end_hour: number
+  status: string
+  creator_id: number
+  creator_nickname: string | null
+  team_id: number
+  target_groups: { id: number; name: string }[]
+  participants: {
+    user_id: number
+    nickname: string | null
+    has_submitted: boolean
+  }[]
+  heatmap: {
+    dt: string
+    unavailable_count: number
+    unavailable_members: string[]
+  }[]
+  recommended_times: {
+    date: string
+    start_time: string
+    end_time: string
+    available_count: number
+    all_available: boolean
+  }[]
+  my_role: string
+  created_at: string
+}
+
+export interface TimetableEntry {
+  user_id: number
+  nickname: string | null
+  group_name: string | null
+  is_leader: boolean
+  semester: string
+  classes: {
+    name: string
+    professor: string | null
+    location: string | null
+    day: number
+    start_time: string
+    end_time: string
+  }[]
+}
+
+// ==================== Activity Types ====================
+
+export interface ActivityScore {
+  group_id: number
+  group_name: string
+  score: number
+}
+
+export interface ActivityRecorder {
+  user_id: number
+  nickname: string | null
+  role_badge: string
+}
+
+export interface Activity {
+  id: number
+  title: string
+  description: string | null
+  highlight: string | null
+  activity_date: string
+  start_time: string | null
+  end_time: string | null
+  photo_urls: string[] | null
+  recorder: ActivityRecorder
+  scores: ActivityScore[]
+  created_at: string
+}
+
+export interface ActivityCreateRequest {
+  title: string
+  description?: string
+  highlight?: string
+  activity_date: string
+  start_time?: string
+  end_time?: string
+  photo_urls?: string[]
+  scores?: { group_id: number; score: number }[]
+}
+
+export interface ActivityUpdateRequest {
+  title?: string
+  description?: string
+  highlight?: string
+  activity_date?: string
+  start_time?: string
+  end_time?: string
+  photo_urls?: string[]
+  scores?: { group_id: number; score: number }[]
+}
+
+export interface ActivityListResponse {
+  activities: Activity[]
+  total: number
+}
+
+// ==================== Rankings Types ====================
+
+export interface RankingItem {
+  rank: number
+  group_id: number
+  group_name: string
+  total_score: number
+  activity_count: number
+  rank_change: number
+}
+
+export interface RankingsResponse {
+  period: string
+  rankings: RankingItem[]
+}
+
+export interface TrendDataPoint {
+  label: string
+  cumulative_score: number
+}
+
+export interface TrendSeries {
+  group_id: number
+  group_name: string
+  data_points: TrendDataPoint[]
+}
+
+export interface TrendResponse {
+  period: string
+  interval: string
+  series: TrendSeries[]
+}
+
+export interface GroupRankingDetail {
+  group_id: number
+  group_name: string
+  total_score: number
+  activity_count: number
+  current_rank: number
+  score_history: { activity_id: number; title: string; activity_date: string; score: number }[]
+  member_participation: { member_id: number; nickname: string; is_leader: boolean; participation_count: number; total_activities: number }[]
+}
+
+export interface MyRanking {
+  user_id: number
+  nickname: string | null
+  group: { id: number; name: string; current_rank: number; total_score: number } | null
+  my_participation_count: number
+  total_activities: number
+}
+
+export interface MemberRankingItem {
+  member_id: number
+  nickname: string | null
+  group_name: string | null
+  participation_count: number
+  total_activities: number
+  participation_rate: number
+}
+
+export interface MembersRankingResponse {
+  members: MemberRankingItem[]
+}

--- a/app/_types/user.ts
+++ b/app/_types/user.ts
@@ -18,6 +18,7 @@ export interface UserProfile {
 // 사용자 정보 업데이트 요청
 export interface UserProfileUpdate {
     nickname?: string;
+    username?: string;
     school?: string;
     dept_code?: string;
     admission_year?: number;

--- a/app/globals.css
+++ b/app/globals.css
@@ -40,8 +40,6 @@ body {
 }
 
 body {
-  position: fixed;
-  width: 100%;
   overflow: hidden;
 }
 

--- a/app/invite/_components/InviteClient.tsx
+++ b/app/invite/_components/InviteClient.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { joinTeam } from '@/_lib/api/teams';
+import { hasAccessToken } from '@/_lib/auth/tokenStore';
+import { getLoginUrl } from '@/_lib/utils/requireLogin';
+import { useAuthInitialized } from '@/providers';
+
+type JoinState = 'loading' | 'joining' | 'success' | 'already' | 'error';
+
+export default function InviteClient() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const isAuthReady = useAuthInitialized();
+  const code = searchParams.get('code');
+
+  const [state, setState] = useState<JoinState>('loading');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [teamId, setTeamId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isAuthReady) return;
+
+    if (!code) {
+      setErrorMsg('초대 코드가 없습니다');
+      setState('error');
+      return;
+    }
+
+    if (!hasAccessToken()) {
+      router.replace(getLoginUrl(`/invite?code=${code}`));
+      return;
+    }
+
+    setState('joining');
+
+    joinTeam({ invite_code: code })
+      .then((res) => {
+        setTeamId(res.team_id);
+        setState('success');
+      })
+      .catch((err) => {
+        const status = err?.response?.status;
+        const detail = err?.response?.data?.detail;
+
+        if (status === 409 || detail?.includes('이미')) {
+          const id = err?.response?.data?.team_id;
+          if (id) setTeamId(id);
+          setState('already');
+        } else {
+          setErrorMsg(
+            detail || '초대 링크가 유효하지 않거나 만료되었습니다'
+          );
+          setState('error');
+        }
+      });
+  }, [isAuthReady, code, router]);
+
+  const goToTeam = () => {
+    if (teamId) {
+      router.replace(`/chinba/team/detail?id=${teamId}`);
+    } else {
+      router.replace('/chinba/team');
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-screen items-center justify-center bg-white px-6">
+      <div className="w-full max-w-sm text-center">
+        {(state === 'loading' || state === 'joining') && (
+          <div className="flex flex-col items-center gap-3">
+            <LoadingSpinner />
+            <p className="text-sm text-gray-500">팀에 참여하는 중...</p>
+          </div>
+        )}
+
+        {state === 'success' && (
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
+              <span className="text-3xl">🎉</span>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-800">팀 참여 완료!</p>
+              <p className="mt-1 text-sm text-gray-500">환영합니다</p>
+            </div>
+            <button
+              onClick={goToTeam}
+              className="w-full rounded-xl bg-gray-900 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:scale-[0.98]"
+            >
+              팀으로 이동
+            </button>
+          </div>
+        )}
+
+        {state === 'already' && (
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-50">
+              <span className="text-3xl">👋</span>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-800">이미 참여한 팀이에요</p>
+              <p className="mt-1 text-sm text-gray-500">바로 팀 페이지로 이동할게요</p>
+            </div>
+            <button
+              onClick={goToTeam}
+              className="w-full rounded-xl bg-gray-900 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:scale-[0.98]"
+            >
+              팀으로 이동
+            </button>
+          </div>
+        )}
+
+        {state === 'error' && (
+          <div className="flex flex-col items-center gap-4">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+              <span className="text-3xl">😢</span>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-800">참여할 수 없습니다</p>
+              <p className="mt-1 text-sm text-gray-500">{errorMsg}</p>
+            </div>
+            <button
+              onClick={() => router.replace('/')}
+              className="w-full rounded-xl bg-gray-100 py-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 active:scale-[0.98]"
+            >
+              홈으로 돌아가기
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/invite/page.tsx
+++ b/app/invite/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react';
+
+import InviteClient from './_components/InviteClient';
+
+export default function InvitePage() {
+  return (
+    <Suspense fallback={null}>
+      <InviteClient />
+    </Suspense>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -67,7 +67,7 @@ gtag('js', new Date());
 gtag('config', 'G-SMF31V39T9');`}
         </Script>
       </head>
-      <body className={`${inter.className} flex h-screen flex-col bg-gray-50 text-gray-900`}>
+      <body className={`${inter.className} flex h-dvh flex-col bg-gray-50 text-gray-900`}>
         <ServiceWorkerRegistration />
         <Providers>
           <NavigationTracker />

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -14,7 +14,7 @@ test.describe('프로필 페이지 - 로그인 사용자', () => {
     // 프로필 탭이 표시되면 프로필 페이지 로드 완료
     await expect(asLoggedInUser.getByRole('button', { name: '기본정보' })).toBeVisible({ timeout: 10_000 });
     // 닉네임 입력 필드에 유저 이름이 있는지 확인
-    await expect(asLoggedInUser.getByPlaceholder('닉네임을 입력하세요')).toHaveValue('테스트유저');
+    await expect(asLoggedInUser.getByPlaceholder('이름을 입력하세요')).toHaveValue('테스트유저');
   });
 
   test('수정하기 버튼이 있다', async ({ asLoggedInUser }) => {
@@ -56,6 +56,6 @@ test.describe('프로필 페이지 - 반응형', () => {
     // 프로필 탭이 표시되면 로드 완료
     await expect(asLoggedInUser.getByRole('button', { name: '기본정보' })).toBeVisible({ timeout: 10_000 });
     // 닉네임 입력 필드 확인
-    await expect(asLoggedInUser.getByPlaceholder('닉네임을 입력하세요')).toHaveValue('테스트유저');
+    await expect(asLoggedInUser.getByPlaceholder('이름을 입력하세요')).toHaveValue('테스트유저');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,22 +31,34 @@
         "@capacitor/assets": "^3.0.5",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
         "@typescript-eslint/parser": "^8.51.0",
+        "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.23",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
+        "jsdom": "^29.0.0",
         "postcss": "^8.5.6",
         "prettier": "^3.7.4",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.1.18",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -60,6 +72,67 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -89,7 +162,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1496,6 +1568,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@capacitor/android": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.0.2.tgz",
@@ -2037,7 +2122,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.0.2.tgz",
       "integrity": "sha512-EXZfxkL6GFJS2cb7TIBR7RiHA5iz6ufDcl1VmUpI2pga3lJ5Ck2+iqbx7N+osL3XYem9ad4XCidJEMm64DX6UQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2091,6 +2175,146 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@ducanh2912/next-pwa": {
@@ -2326,6 +2550,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -3262,6 +3504,26 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -3278,7 +3540,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -3299,6 +3560,285 @@
         "@xml-tools/parser": "^1.0.11",
         "prettier": ">=2.4.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -3458,6 +3998,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3788,6 +4335,93 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trapezedev/gradle-parse": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@trapezedev/gradle-parse/-/gradle-parse-7.1.3.tgz",
@@ -4065,11 +4699,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4080,6 +4741,7 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -4125,7 +4787,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4143,7 +4804,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4221,7 +4881,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4728,11 +5387,161 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -4742,25 +5551,29 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4771,13 +5584,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4790,6 +5605,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -4799,6 +5615,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -4807,13 +5624,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4830,6 +5649,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -4843,6 +5663,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4855,6 +5676,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4869,6 +5691,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -4897,20 +5720,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4923,6 +5747,7 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -4996,6 +5821,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5013,6 +5839,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5028,7 +5855,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -5269,6 +6097,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
@@ -5585,6 +6423,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -5676,7 +6524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5836,6 +6683,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5877,6 +6734,7 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -6321,6 +7179,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -6333,6 +7205,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -6356,6 +7235,58 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -6478,6 +7409,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -6613,6 +7551,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -6679,6 +7628,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
@@ -7073,7 +8030,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7275,7 +8231,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7517,6 +8472,7 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -7539,6 +8495,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -8245,7 +9211,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -8506,6 +9473,19 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/idb": {
       "version": "7.1.1",
@@ -8951,6 +9931,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9185,6 +10172,7 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -9199,6 +10187,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9236,6 +10225,95 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -9744,6 +10822,7 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -9822,6 +10901,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9860,6 +10950,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -10063,7 +11160,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10342,7 +11440,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
@@ -10677,6 +11774,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10829,6 +11937,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10910,6 +12044,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -11016,9 +12157,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -11035,7 +12176,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11132,7 +12272,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11233,6 +12372,44 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -11390,7 +12567,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11400,7 +12576,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12122,12 +13297,52 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "2.79.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12239,6 +13454,19 @@
       "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
       "license": "ISC"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -12250,6 +13478,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -12286,6 +13515,7 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -12297,7 +13527,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -12520,6 +13751,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -12758,6 +13996,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13053,6 +14305,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -13175,6 +14434,7 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -13240,6 +14500,23 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -13281,13 +14558,42 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
+      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.25"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
+      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -13309,6 +14615,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -13502,7 +14821,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13565,6 +14883,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -13762,11 +15090,473 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.9",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.0.tgz",
       "integrity": "sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -13786,6 +15576,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13834,6 +15625,7 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -13843,6 +15635,7 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -13856,8 +15649,19 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/whatwg-url": {
@@ -13978,6 +15782,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -14084,7 +15905,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14270,7 +16090,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14429,6 +16248,16 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -14459,6 +16288,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xpath": {
       "version": "0.0.32",
@@ -14574,7 +16410,6 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed"
@@ -35,20 +38,25 @@
     "@capacitor/assets": "^3.0.5",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.23",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
+    "jsdom": "^29.0.0",
     "postcss": "^8.5.6",
     "prettier": "^3.7.4",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['app/**/*.test.ts', 'app/**/*.test.tsx'],
+    exclude: ['e2e/**'],
+    coverage: {
+      provider: 'v8',
+      include: ['app/_lib/**', 'app/_components/**'],
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './app'),
+      '@/_lib': path.resolve(__dirname, './app/_lib'),
+      '@/_types': path.resolve(__dirname, './app/_types'),
+      '@/_components': path.resolve(__dirname, './app/_components'),
+    },
+  },
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'


### PR DESCRIPTION
## Summary
- 팀 생성/목록/상세/설정/초대/가입 페이지 전체 구현
- 만나자/뭐했니/잡아봐 세그먼트 탭 및 조별 필터 구현
- 조편성 관리 UI (텍스트 파싱, 인라인 편집, 멤버 이동)
- 구독 섹션, 이벤트 생성 플로우, 초대 링크 페이지 구현
- 팀 API 레이어, React Query hooks, 유틸 및 단위 테스트 추가
- 친바 탭 레이아웃, BottomTabBar, 프로필 탭, 온보딩 수정
- 잡아봐 기간필터 제거 (semester 고정으로 단순화)

## Test plan
- [ ] 팀 생성/가입/초대 플로우 동작 확인
- [ ] 조편성 UI (텍스트 입력 → 파싱 → 편집) 동작 확인
- [ ] 만나자/뭐했니/잡아봐 탭 전환 및 데이터 표시 확인
- [ ] 그룹 필터 동작 확인
- [ ] 구독 모달 및 결제 플로우 확인
- [ ] vitest 단위 테스트 통과 확인
- [ ] 기존 E2E 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive team management system: create, join, and manage teams with invitations
  * Introduced AI-powered group organization for team members
  * Added team subscription and premium tier support
  * Implemented activity tracking, ranking boards, and team statistics
  * Added username field to user profiles for identity display
  * Introduced team event scheduling and member participation tracking
  * Added mobile bottom navigation for improved app navigation

* **UI Improvements**
  * Enhanced team detail pages with activity, ranking, and event tabs
  * Streamlined team setup guide for new users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->