### PR TITLE
test(chinba): 24시 시간 범위 및 시간표 import E2E 테스트 추가

### DIFF
--- a/e2e/chinba-schedule.spec.ts
+++ b/e2e/chinba-schedule.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from './fixtures/auth.fixture';
+
+test.describe('친바 시간 범위 확대 (24시)', () => {
+  test('이벤트 상세에서 23:00, 23:30 시간 슬롯이 표시된다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/chinba/event?id=evt-001&tab=my');
+    await expect(asLoggedInUser.locator('.animate-spin')).toHaveCount(0, { timeout: 10_000 });
+    await expect(asLoggedInUser.getByText('23:00')).toBeVisible({ timeout: 10_000 });
+    await expect(asLoggedInUser.getByText('23:30')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('히트맵에서도 23시대 슬롯이 표시된다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/chinba/event?id=evt-001&tab=team');
+    await expect(asLoggedInUser.locator('.animate-spin')).toHaveCount(0, { timeout: 10_000 });
+    await expect(asLoggedInUser.getByText('23:00')).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+test.describe('시간표 불러오기 병합', () => {
+  test('내 일정 탭에서 시간표 불러오기 버튼이 있다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/chinba/event?id=evt-001&tab=my');
+    await expect(asLoggedInUser.getByText('내 시간표 불러오기')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('시간표 불러오기 성공 시 토스트 메시지가 표시된다', async ({ asLoggedInUser }) => {
+    await asLoggedInUser.goto('/chinba/event?id=evt-001&tab=my');
+    await asLoggedInUser.getByText('내 시간표 불러오기').click();
+    await expect(asLoggedInUser.getByText(/슬롯을 불러왔습니다/)).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -260,7 +260,7 @@ export async function mockAuthenticatedAPIs(page: Page, options?: {
     if (url.includes('/my-participation')) return json(route, MOCK_CHINBA_MY_PARTICIPATION);
     if (url.includes('/my-unavailability')) return json(route, { message: 'ok' });
     if (url.includes('/complete')) return json(route, { message: 'ok' });
-    if (url.includes('/import-timetable')) return json(route, { message: 'ok', imported_count: 0 });
+    if (url.includes('/import-timetable')) return json(route, { message: '시간표에서 6개 슬롯을 불러왔습니다', imported_count: 6 });
     if (method === 'GET') return json(route, MOCK_CHINBA_EVENT_DETAIL);
     if (method === 'DELETE') return json(route, { message: 'deleted' });
     return route.continue();

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -168,7 +168,7 @@ export const MOCK_CHINBA_EVENT_DETAIL = {
   title: '조별과제 회의',
   dates: ['2024-07-10', '2024-07-11', '2024-07-12'],
   start_hour: 9,
-  end_hour: 21,
+  end_hour: 24,
   status: 'active' as const,
   creator_id: 1,
   creator_nickname: '테스트유저',


### PR DESCRIPTION
## Summary
- 친바 이벤트 24시 확대에 맞춰 E2E 테스트 데이터 및 테스트 추가
- `MOCK_CHINBA_EVENT_DETAIL`의 `end_hour` 21 → 24 변경
- `import-timetable` API mock 응답 실제 메시지/카운트 반영
- `chinba-schedule.spec.ts` 신규 테스트 4건

## Changes
- `e2e/fixtures/test-data.ts`: end_hour 24
- `e2e/fixtures/api-mocks.ts`: import-timetable 응답 개선
- `e2e/chinba-schedule.spec.ts`: 23시대 슬롯 표시 + 시간표 불러오기 테스트

## Test plan
- [ ] npx playwright test e2e/chinba-schedule.spec.ts 통과 확인
- [ ] 기존 chinba E2E 테스트 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added E2E test suites for extended 24-hour schedule format, verifying late evening time slots display correctly
  * Added E2E tests validating schedule import functionality with proper user confirmation messaging
  * Updated test data to support expanded schedule operating hours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->