### PR TITLE
feat(search): 공지사항 검색 페이지 및 UI 구현

### DIFF
--- a/app/(main)/search/_components/DateRangePresets.tsx
+++ b/app/(main)/search/_components/DateRangePresets.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { DateRange } from '../_hooks/useSearchState';
+
+interface DateRangePresetsProps {
+  value: DateRange;
+  onChange: (value: DateRange) => void;
+}
+
+const PRESETS: { label: string; value: DateRange }[] = [
+  { label: '1주', value: '1w' },
+  { label: '1달', value: '1m' },
+  { label: '3달', value: '3m' },
+  { label: '전체', value: 'all' },
+];
+
+export default function DateRangePresets({ value, onChange }: DateRangePresetsProps) {
+  return (
+    <>
+      {PRESETS.map((preset) => (
+        <button
+          key={preset.value}
+          type="button"
+          onClick={() => onChange(preset.value)}
+          className={`shrink-0 whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-all active:scale-95 ${
+            value === preset.value
+              ? 'bg-gray-900 text-white shadow-md'
+              : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+          }`}
+        >
+          {preset.label}
+        </button>
+      ))}
+    </>
+  );
+}

--- a/app/(main)/search/_components/HighlightedTitle.tsx
+++ b/app/(main)/search/_components/HighlightedTitle.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+interface HighlightedTitleProps {
+  title: string;
+  query: string;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export default function HighlightedTitle({ title, query }: HighlightedTitleProps) {
+  if (!query.trim()) {
+    return <span>{title}</span>;
+  }
+
+  const regex = new RegExp(`(${escapeRegex(query.trim())})`, 'gi');
+  const parts = title.split(regex);
+
+  return (
+    <span>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <mark key={i} className="bg-yellow-200 rounded-sm px-0.5">
+            {part}
+          </mark>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </span>
+  );
+}

--- a/app/(main)/search/_components/SearchBoardFilter.tsx
+++ b/app/(main)/search/_components/SearchBoardFilter.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState, lazy, Suspense } from 'react';
+
+import { FiX } from 'react-icons/fi';
+
+import FullPageModal from '@/_components/layout/FullPageModal';
+
+const BoardFilterContent = lazy(
+  () => import('../../filter/_components/BoardFilterContent'),
+);
+
+interface SearchBoardFilterProps {
+  selectedBoards: string[];
+  onChange: (boards: string[]) => void;
+}
+
+export default function SearchBoardFilter({ selectedBoards, onChange }: SearchBoardFilterProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleApply = (boards: string[]) => {
+    onChange(boards);
+    setIsOpen(false);
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onChange([]);
+  };
+
+  const hasSelection = selectedBoards.length > 0;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={`flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-all active:scale-95 ${
+          hasSelection
+            ? 'bg-gray-900 text-white shadow-md'
+            : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+        }`}
+      >
+        <span>{hasSelection ? `${selectedBoards.length}개 게시판` : '게시판'}</span>
+        {hasSelection && (
+          <span
+            role="button"
+            onClick={handleClear}
+            className="ml-0.5 rounded-full p-0.5 hover:bg-white/20"
+            aria-label="게시판 필터 초기화"
+          >
+            <FiX size={13} />
+          </span>
+        )}
+      </button>
+
+      <FullPageModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="게시판 선택"
+        mode="overlay"
+      >
+        <Suspense
+          fallback={
+            <div className="flex flex-1 items-center justify-center">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-gray-200 border-t-gray-900" />
+            </div>
+          }
+        >
+          <BoardFilterContent
+            selectedBoards={selectedBoards}
+            onApply={handleApply}
+            onClose={() => setIsOpen(false)}
+          />
+        </Suspense>
+      </FullPageModal>
+    </>
+  );
+}

--- a/app/(main)/search/_components/SearchContent.tsx
+++ b/app/(main)/search/_components/SearchContent.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { Capacitor } from '@capacitor/core';
+import dayjs from 'dayjs';
+import { FiArrowLeft } from 'react-icons/fi';
+import { useInView } from 'react-intersection-observer';
+
+import CategoryBadge from '@/_components/ui/CategoryBadge';
+import { incrementNoticeView } from '@/_lib/api/notices';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useUser } from '@/_lib/hooks/useUser';
+import type { Notice } from '@/_types/notice';
+
+import HighlightedTitle from './HighlightedTitle';
+import SearchFilters from './SearchFilters';
+import SearchHistory from './SearchHistory';
+import SearchInput from './SearchInput';
+import SearchResultHeader from './SearchResultHeader';
+import { useSearchNotices } from '../_hooks/useSearchNotices';
+import { useSearchState } from '../_hooks/useSearchState';
+
+import { openUrl } from '@/_lib/utils/openUrl';
+
+export default function SearchContent() {
+  const goBack = useSmartBack('/');
+  const { isLoggedIn } = useUser();
+
+  const {
+    query,
+    setQuery,
+    submittedQuery,
+    submitQuery,
+    dateRange,
+    setDateRange,
+    selectedBoards,
+    setSelectedBoards,
+    searchHistory,
+    removeFromHistory,
+  } = useSearchState();
+
+  const {
+    notices,
+    totalCount,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useSearchNotices({
+    submittedQuery,
+    dateRange,
+    boardCodes: selectedBoards,
+  });
+
+  const { ref: loadMoreRef, inView } = useInView({
+    rootMargin: '0px 0px 400px 0px',
+    threshold: 0,
+  });
+
+  useEffect(() => {
+    if (!inView || !hasNextPage || isFetchingNextPage) return;
+    fetchNextPage();
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const handleSelectHistory = (term: string) => {
+    submitQuery(term);
+  };
+
+  const handleNoticeClick = async (
+    e: React.MouseEvent<HTMLAnchorElement>,
+    notice: Notice,
+  ) => {
+    if (isLoggedIn) {
+      incrementNoticeView(notice.id).catch(() => {});
+    }
+    if (Capacitor.isNativePlatform()) {
+      e.preventDefault();
+      try {
+        await openUrl(notice.link);
+      } catch {
+        window.open(notice.link, '_blank', 'noreferrer');
+      }
+    }
+  };
+
+  const showHistory = submittedQuery.length === 0 && query.length === 0;
+  const showResults = submittedQuery.length >= 1;
+
+  return (
+    <div className="flex h-full flex-col bg-white">
+      {/* 헤더 */}
+      <div className="shrink-0 px-4 pb-1">
+        <div className="pt-safe md:pt-0" />
+        <div className="relative mt-4 flex items-center justify-center md:mt-4">
+          <button
+            onClick={goBack}
+            className="absolute left-0 z-10 group -ml-1 rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100 hover:text-gray-900 active:scale-95"
+            aria-label="뒤로가기"
+          >
+            <FiArrowLeft size={22} className="transition-transform group-hover:-translate-x-0.5" />
+          </button>
+          <h1 className="text-base font-bold text-gray-800">공지 검색</h1>
+        </div>
+      </div>
+
+      {/* 검색 입력 */}
+      <div className="shrink-0">
+        <SearchInput
+          value={query}
+          onChange={setQuery}
+          onSubmit={submitQuery}
+        />
+      </div>
+
+      {/* 필터 */}
+      <div className="shrink-0">
+        <SearchFilters
+          dateRange={dateRange}
+          onDateRangeChange={setDateRange}
+          selectedBoards={selectedBoards}
+          onBoardsChange={setSelectedBoards}
+        />
+      </div>
+
+      {/* 컨텐츠 영역 */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {showHistory && (
+          <SearchHistory
+            history={searchHistory}
+            onSelect={handleSelectHistory}
+            onRemove={removeFromHistory}
+          />
+        )}
+
+        {showResults && (
+          <>
+            {/* 로딩 */}
+            {isLoading && (
+              <div className="flex items-center justify-center py-12">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-gray-200 border-t-gray-900" />
+              </div>
+            )}
+
+            {/* 결과 헤더 */}
+            {!isLoading && (
+              <SearchResultHeader totalCount={totalCount} />
+            )}
+
+            {/* 결과 없음 */}
+            {!isLoading && notices.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-16 text-center">
+                <p className="text-sm font-medium text-gray-500">검색 결과가 없어요</p>
+                <p className="mt-1 text-xs text-gray-400">다른 검색어나 필터를 시도해보세요</p>
+              </div>
+            )}
+
+            {/* 검색 결과 목록 */}
+            {!isLoading && notices.length > 0 && (
+              <div role="list" className="divide-y divide-gray-100 md:space-y-2 md:divide-y-0 md:px-4 md:py-2">
+                {notices.map((notice) => (
+                  <div
+                    key={notice.id}
+                    role="listitem"
+                    className="bg-white transition-all hover:bg-gray-50 md:rounded-xl md:border md:border-gray-100 md:shadow-sm md:hover:-translate-y-0.5 md:hover:shadow-md"
+                  >
+                    <a
+                      href={notice.link}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="block p-5"
+                      onClick={(e) => handleNoticeClick(e, notice)}
+                    >
+                      <div className="mb-2 flex items-center gap-2">
+                        <CategoryBadge boardCode={notice.board_code} />
+                        <span className="flex items-center gap-1 text-xs text-gray-400">
+                          {dayjs(notice.date).format('YYYY-MM-DD')}
+                        </span>
+                      </div>
+                      <h3 className="text-[15px] font-medium leading-snug text-gray-900">
+                        <HighlightedTitle title={notice.title} query={submittedQuery} />
+                      </h3>
+                    </a>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* 무한 스크롤 트리거 */}
+            {hasNextPage && (
+              <div ref={loadMoreRef} className="py-4 text-center">
+                {isFetchingNextPage ? (
+                  <div className="flex items-center justify-center gap-2 text-sm text-gray-400">
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+                    <span>불러오는 중...</span>
+                  </div>
+                ) : null}
+              </div>
+            )}
+
+            {!hasNextPage && notices.length > 0 && !isLoading && (
+              <div className="py-8 text-center text-sm text-gray-400">
+                모든 검색 결과를 불러왔어요
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/search/_components/SearchFilters.tsx
+++ b/app/(main)/search/_components/SearchFilters.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import DateRangePresets from './DateRangePresets';
+import SearchBoardFilter from './SearchBoardFilter';
+import type { DateRange } from '../_hooks/useSearchState';
+
+interface SearchFiltersProps {
+  dateRange: DateRange;
+  onDateRangeChange: (value: DateRange) => void;
+  selectedBoards: string[];
+  onBoardsChange: (boards: string[]) => void;
+}
+
+export default function SearchFilters({
+  dateRange,
+  onDateRangeChange,
+  selectedBoards,
+  onBoardsChange,
+}: SearchFiltersProps) {
+  return (
+    <div className="flex flex-row items-center gap-2 overflow-x-auto px-4 py-1.5 no-scrollbar">
+      <DateRangePresets value={dateRange} onChange={onDateRangeChange} />
+      <SearchBoardFilter selectedBoards={selectedBoards} onChange={onBoardsChange} />
+    </div>
+  );
+}

--- a/app/(main)/search/_components/SearchHistory.tsx
+++ b/app/(main)/search/_components/SearchHistory.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { FiClock, FiX } from 'react-icons/fi';
+
+interface SearchHistoryProps {
+  history: string[];
+  onSelect: (term: string) => void;
+  onRemove: (term: string) => void;
+}
+
+export default function SearchHistory({ history, onSelect, onRemove }: SearchHistoryProps) {
+  if (history.length === 0) return null;
+
+  return (
+    <div className="px-4 py-2">
+      <h3 className="mb-2 text-xs font-bold text-gray-500">최근 검색</h3>
+      <ul className="flex flex-col">
+        {history.map((term) => (
+          <li key={term} className="flex items-center gap-2 py-2.5">
+            <FiClock size={15} className="shrink-0 text-gray-400" />
+            <button
+              type="button"
+              onClick={() => onSelect(term)}
+              className="flex-1 text-left text-sm text-gray-700 hover:text-gray-900"
+            >
+              {term}
+            </button>
+            <button
+              type="button"
+              onClick={() => onRemove(term)}
+              className="shrink-0 rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+              aria-label={`"${term}" 삭제`}
+            >
+              <FiX size={14} />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(main)/search/_components/SearchInput.tsx
+++ b/app/(main)/search/_components/SearchInput.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { FiSearch, FiX } from 'react-icons/fi';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+}
+
+export default function SearchInput({ value, onChange, onSubmit }: SearchInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onSubmit(value);
+      inputRef.current?.blur();
+    }
+  };
+
+  const handleClear = () => {
+    onChange('');
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="relative flex items-center px-4 py-2">
+      <div className="relative flex w-full items-center rounded-xl bg-gray-100 px-3 py-2.5">
+        <FiSearch size={18} className="shrink-0 text-gray-400" />
+        <input
+          ref={inputRef}
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="검색어를 입력하세요"
+          enterKeyHint="search"
+          className="ml-2 flex-1 bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        {value.length > 0 && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="ml-2 shrink-0 rounded-full p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600"
+            aria-label="검색어 지우기"
+          >
+            <FiX size={16} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/search/_components/SearchResultHeader.tsx
+++ b/app/(main)/search/_components/SearchResultHeader.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+interface SearchResultHeaderProps {
+  totalCount: number;
+}
+
+export default function SearchResultHeader({ totalCount }: SearchResultHeaderProps) {
+  return (
+    <div className="px-4 py-2">
+      <span className="text-sm text-gray-500">
+        검색 결과 <span className="font-semibold text-gray-700">{totalCount.toLocaleString()}</span>건
+      </span>
+    </div>
+  );
+}

--- a/app/(main)/search/_hooks/useSearchNotices.ts
+++ b/app/(main)/search/_hooks/useSearchNotices.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { searchNotices } from '@/_lib/api/notices';
+import type { Notice } from '@/_types/notice';
+
+import type { DateRange } from './useSearchState';
+
+interface UseSearchNoticesParams {
+  submittedQuery: string;
+  dateRange: DateRange;
+  boardCodes: string[];
+}
+
+export function useSearchNotices({
+  submittedQuery,
+  dateRange,
+  boardCodes,
+}: UseSearchNoticesParams) {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isFetching,
+  } = useInfiniteQuery({
+    queryKey: ['notices', 'search', { query: submittedQuery, dateRange, boardCodes }],
+    queryFn: ({ pageParam }) =>
+      searchNotices(
+        submittedQuery,
+        pageParam as string | null,
+        20,
+        dateRange,
+        boardCodes.length > 0 ? boardCodes : undefined,
+      ),
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    initialPageParam: null as string | null,
+    enabled: submittedQuery.length >= 1,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+
+  const notices: Notice[] = data?.pages.flatMap((p) => p.items) ?? [];
+  const totalCount: number = data?.pages[0]?.total_count ?? 0;
+
+  return {
+    notices,
+    totalCount,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isFetching,
+  };
+}

--- a/app/(main)/search/_hooks/useSearchState.ts
+++ b/app/(main)/search/_hooks/useSearchState.ts
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+
+export type DateRange = '1w' | '1m' | '3m' | 'all';
+
+const HISTORY_KEY = 'search_history';
+const MAX_HISTORY = 8;
+
+function loadHistory(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(items: string[]) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(items));
+}
+
+export function useSearchState() {
+  const searchParams = useSearchParams();
+
+  // 입력 중인 쿼리
+  const [query, setQuery] = useState<string>(() => searchParams.get('q') ?? '');
+  // Enter 확정된 쿼리
+  const [submittedQuery, setSubmittedQuery] = useState<string>(() => searchParams.get('q') ?? '');
+  // 디바운스된 쿼리 (UI용)
+  const [debouncedQuery, setDebouncedQuery] = useState<string>(query);
+
+  const [dateRange, setDateRange] = useState<DateRange>(
+    () => (searchParams.get('period') as DateRange) ?? 'all',
+  );
+  const [selectedBoards, setSelectedBoards] = useState<string[]>(() => {
+    const raw = searchParams.get('boards');
+    return raw ? raw.split(',').filter(Boolean) : [];
+  });
+
+  const [searchHistory, setSearchHistory] = useState<string[]>([]);
+
+  // 클라이언트 마운트 후 localStorage에서 히스토리 로드
+  useEffect(() => {
+    setSearchHistory(loadHistory());
+  }, []);
+
+  // 300ms 디바운스
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, 300);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [query]);
+
+  // URL 동기화
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams();
+    if (submittedQuery) params.set('q', submittedQuery);
+    if (dateRange !== 'all') params.set('period', dateRange);
+    if (selectedBoards.length > 0) params.set('boards', selectedBoards.join(','));
+    const qs = params.toString();
+    const next = qs ? `/search?${qs}` : '/search';
+    const current = `${window.location.pathname}${window.location.search}`;
+    if (next !== current) {
+      window.history.replaceState(null, '', next);
+    }
+  }, [submittedQuery, dateRange, selectedBoards]);
+
+  const submitQuery = useCallback((q: string) => {
+    const trimmed = q.trim();
+    setQuery(trimmed);
+    setDebouncedQuery(trimmed);
+    setSubmittedQuery(trimmed);
+    if (trimmed) {
+      addToHistory(trimmed);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const addToHistory = useCallback((term: string) => {
+    setSearchHistory((prev) => {
+      const filtered = prev.filter((h) => h !== term);
+      const next = [term, ...filtered].slice(0, MAX_HISTORY);
+      saveHistory(next);
+      return next;
+    });
+  }, []);
+
+  const removeFromHistory = useCallback((term: string) => {
+    setSearchHistory((prev) => {
+      const next = prev.filter((h) => h !== term);
+      saveHistory(next);
+      return next;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    saveHistory([]);
+    setSearchHistory([]);
+  }, []);
+
+  return {
+    query,
+    setQuery,
+    debouncedQuery,
+    submittedQuery,
+    submitQuery,
+    dateRange,
+    setDateRange,
+    selectedBoards,
+    setSelectedBoards,
+    searchHistory,
+    addToHistory,
+    removeFromHistory,
+    clearHistory,
+  };
+}

--- a/app/(main)/search/page.tsx
+++ b/app/(main)/search/page.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { Suspense } from 'react';
+
+import SearchContent from './_components/SearchContent';
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full flex-1 items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-gray-900" />
+        </div>
+      }
+    >
+      <SearchContent />
+    </Suspense>
+  );
+}

--- a/app/_components/layout/SharedHeader.tsx
+++ b/app/_components/layout/SharedHeader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { FiUser, FiBell } from 'react-icons/fi';
+import { FiUser, FiBell, FiSearch } from 'react-icons/fi';
+
 import Logo from '@/_components/ui/Logo';
 import { useNotificationBadge } from '@/_context/NotificationBadgeContext';
 import { useUserStore } from '@/_lib/store/useUserStore';
@@ -53,8 +54,15 @@ export default function SharedHeader({ title, onMenuClick }: SharedHeaderProps) 
         )}
       </div>
 
-      {/* Right: Notification bell */}
-      <div className="flex w-20 items-center justify-end">
+      {/* Right: Search + Notification bell */}
+      <div className="flex items-center justify-end gap-1">
+        <button
+          onClick={() => router.push('/search')}
+          className="rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100"
+          aria-label="검색"
+        >
+          <FiSearch size={19} />
+        </button>
         <button
           onClick={handleNotificationClick}
           className="relative rounded-full p-2 text-gray-600 transition-all hover:bg-gray-100"

--- a/app/_lib/api/index.ts
+++ b/app/_lib/api/index.ts
@@ -38,8 +38,8 @@ export * from './subscriptions';
 export * from './activities';
 
 // Types re-export for convenience
-export type { Notice, NoticeListResponse } from '@/_types/notice';
-export type { Keyword } from '@/_types/keyword';
+export type { Notice, NoticeListResponse, SearchNoticeListResponse } from '@/_types/notice';
+export type { Keyword, UpdateKeywordBoardsResponse } from '@/_types/keyword';
 export type { UserProfile, UserSubscription, OnboardingRequest } from '@/_types/user';
 export type { Department, DepartmentSearchResponse } from '@/_types/department';
 export type { TimetableData, TimetableClass, TimetableAnalysisResponse } from '@/_types/timetable';

--- a/app/_lib/api/notices.ts
+++ b/app/_lib/api/notices.ts
@@ -1,11 +1,13 @@
-import api from './client';
 import type {
     Notice,
     NoticeListResponse,
     MarkAsReadResponse,
     ToggleFavoriteResponse,
     IncrementViewResponse,
+    SearchNoticeListResponse,
 } from '@/_types/notice';
+
+import api from './client';
 
 // 공지사항 조회 (페이지네이션)
 export const fetchNotices = async (
@@ -69,4 +71,25 @@ export const incrementNoticeView = async (noticeId: number) => {
 // DB 데이터 전체 초기화 (관리자용)
 export const resetNotices = async () => {
     return api.delete('/notices/reset');
+};
+
+// 공지사항 검색
+export const searchNotices = async (
+    query: string,
+    cursor: string | null = null,
+    limit: number = 20,
+    dateRange: '1w' | '1m' | '3m' | 'all' = 'all',
+    boardCodes?: string[],
+): Promise<SearchNoticeListResponse> => {
+    const params: Record<string, string | number | boolean> = {
+        q: query,
+        limit,
+        date_range: dateRange,
+    };
+    if (cursor) params.cursor = cursor;
+    if (boardCodes && boardCodes.length > 0) {
+        params.board_codes = boardCodes.join(',');
+    }
+    const response = await api.get('/notices/search', { params });
+    return response.data;
 };

--- a/app/_types/notice.ts
+++ b/app/_types/notice.ts
@@ -42,3 +42,11 @@ export interface IncrementViewResponse {
     user_view_count: number;
     message: string;
 }
+
+// 공지사항 검색 응답
+export interface SearchNoticeListResponse {
+    items: Notice[];
+    next_cursor: string | null;
+    has_next: boolean;
+    total_count: number;
+}


### PR DESCRIPTION
## Summary
- 검색 페이지 라우트 및 11개 컴포넌트/훅 신규 생성 (SearchContent, SearchInput, SearchFilters, DateRangePresets, SearchBoardFilter, SearchHistory, SearchResultHeader, HighlightedTitle, useSearchState, useSearchNotices)
- SharedHeader에 검색 아이콘(FiSearch) 추가, 클릭 시 `/search` 이동
- `searchNotices` API 함수 및 `SearchNoticeListResponse` 타입 추가
- 날짜 범위(1주/1달/3달/전체) + 게시판 필터 + 최근 검색어(localStorage) 지원
- 커서 기반 무한 스크롤, 검색어 하이라이트, URL 파라미터 동기화

## Test plan
- [ ] 홈 헤더에서 검색 아이콘 클릭 → `/search` 이동 확인
- [ ] 검색어 입력 후 Enter → 결과 표시 확인
- [ ] 날짜 필터(1주/1달/3달/전체) 토글 → 결과 변경 확인
- [ ] 게시판 필터 선택 → 결과 필터링 확인
- [ ] 무한 스크롤 → 다음 페이지 로드 확인
- [ ] 검색어 하이라이트(노란색) 확인
- [ ] 최근 검색어 저장/표시/삭제 확인
- [ ] 뒤로가기 → 홈 복귀 확인
- [ ] 모바일: 키보드 자동 포커스, 검색 버튼 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)