### PR TITLE
feat(keywords): 키워드 알림 게시판 범위 지정 UI 구현

### DIFF
--- a/app/(main)/keywords/_components/KeywordBoardSelector.tsx
+++ b/app/(main)/keywords/_components/KeywordBoardSelector.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { FiRotateCcw, FiSearch, FiX } from 'react-icons/fi';
+import { BOARD_MAP, CATEGORY_ORDER, BoardCategory } from '@/_lib/constants/boards';
+import Button from '@/_components/ui/Button';
+
+interface KeywordBoardSelectorProps {
+    subscribedBoardCodes: string[];
+    selectedBoardCodes: string[] | null;
+    onApply: (boardCodes: string[] | null) => void;
+    onClose: () => void;
+}
+
+const CHOSEONG = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'];
+
+const normalizeSearchText = (text: string) => text.toLowerCase().replace(/\s+/g, '');
+
+const getChoseong = (text: string) => {
+    let result = '';
+    for (const char of text) {
+        const code = char.charCodeAt(0);
+        if (code < 0xac00 || code > 0xd7a3) {
+            result += char;
+            continue;
+        }
+        const index = Math.floor((code - 0xac00) / 588);
+        result += CHOSEONG[index] || '';
+    }
+    return result;
+};
+
+export default function KeywordBoardSelector({
+    subscribedBoardCodes,
+    selectedBoardCodes,
+    onApply,
+    onClose,
+}: KeywordBoardSelectorProps) {
+    const [tempSelection, setTempSelection] = useState<Set<string>>(
+        new Set(selectedBoardCodes ?? [])
+    );
+    const [searchQuery, setSearchQuery] = useState('');
+    const searchInputRef = useRef<HTMLInputElement>(null);
+
+    const normalizedQuery = normalizeSearchText(searchQuery);
+
+    const matchesSearch = (boardCode: string) => {
+        if (!normalizedQuery) return true;
+        const meta = BOARD_MAP[boardCode];
+        if (!meta) return false;
+        const name = normalizeSearchText(meta.name);
+        const id = normalizeSearchText(boardCode);
+        const category = normalizeSearchText(meta.category);
+        const choseong = normalizeSearchText(getChoseong(meta.name));
+        return (
+            name.includes(normalizedQuery) ||
+            id.includes(normalizedQuery) ||
+            category.includes(normalizedQuery) ||
+            choseong.includes(normalizedQuery)
+        );
+    };
+
+    const toggleBoard = (boardCode: string) => {
+        setTempSelection((prev) => {
+            const next = new Set(prev);
+            if (next.has(boardCode)) {
+                next.delete(boardCode);
+            } else {
+                next.add(boardCode);
+            }
+            return next;
+        });
+    };
+
+    const handleReset = () => {
+        setTempSelection(new Set());
+    };
+
+    // 선택된 게시판 칩 (검색 무관하게 항상 표시)
+    const selectedItems = subscribedBoardCodes.filter((code) => tempSelection.has(code));
+
+    // 미선택 게시판 (검색 적용)
+    const unselectedItems = subscribedBoardCodes.filter(
+        (code) => !tempSelection.has(code) && matchesSearch(code)
+    );
+
+    // 카테고리별 그룹화
+    const groupedUnselected: Record<BoardCategory, string[]> = {
+        전북대: [],
+        단과대: [],
+        학과: [],
+        사업단: [],
+    };
+
+    unselectedItems.forEach((code) => {
+        const meta = BOARD_MAP[code];
+        if (meta) {
+            groupedUnselected[meta.category].push(code);
+        }
+    });
+
+    return (
+        <div className="flex h-full flex-col">
+            {/* 헤더 */}
+            <div className="flex shrink-0 items-center justify-between border-b border-gray-100 px-5 py-4">
+                <h2 className="text-base font-bold text-gray-800">알림 받을 게시판</h2>
+                <button
+                    onClick={onClose}
+                    className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                    aria-label="닫기"
+                >
+                    <FiX size={20} />
+                </button>
+            </div>
+
+            {/* Body - Scrollable */}
+            <div className="flex-1 overflow-y-auto">
+                {/* 선택된 게시판 영역 */}
+                <div className="border-b border-gray-100 bg-blue-50/50 p-4">
+                    <div className="mb-3 flex items-center justify-between">
+                        <h3 className="text-xs font-bold text-gray-500">선택된 게시판</h3>
+                        <button
+                            onClick={handleReset}
+                            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900"
+                            aria-label="초기화"
+                        >
+                            <FiRotateCcw size={16} />
+                            <span>초기화</span>
+                        </button>
+                    </div>
+                    {selectedItems.length === 0 ? (
+                        <p className="py-4 text-center text-sm text-gray-400">
+                            알림 받을 게시판을 선택해주세요
+                        </p>
+                    ) : (
+                        <div className="flex flex-wrap gap-2">
+                            {selectedItems.map((code) => (
+                                <button
+                                    key={code}
+                                    onClick={() => toggleBoard(code)}
+                                    className="rounded-full border-2 border-gray-900 bg-white px-4 py-2 text-sm font-bold text-gray-900 shadow-md transition-all hover:bg-gray-50 active:scale-95"
+                                >
+                                    {BOARD_MAP[code]?.name ?? code}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* 게시판 목록 */}
+                <div className="p-4">
+                    <div className="mb-3 flex items-center justify-between gap-2">
+                        <h3 className="text-xs font-bold text-gray-500">구독 게시판</h3>
+                        <div className="relative w-[140px]">
+                            <input
+                                ref={searchInputRef}
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                placeholder="게시판 검색"
+                                className="h-8 w-full rounded-lg border border-gray-200 bg-white px-3 pr-14 text-xs outline-none transition-colors focus:border-blue-400"
+                            />
+                            {searchQuery.length > 0 && (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setSearchQuery('');
+                                        searchInputRef.current?.focus();
+                                    }}
+                                    className="absolute right-8 top-1/2 -translate-y-1/2 rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                                    aria-label="검색어 지우기"
+                                >
+                                    <FiX size={12} />
+                                </button>
+                            )}
+                            <button
+                                type="button"
+                                onClick={() => searchInputRef.current?.focus()}
+                                className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                                aria-label="게시판 검색"
+                            >
+                                <FiSearch size={13} />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col gap-6">
+                        {CATEGORY_ORDER.map((category) => {
+                            const boards = groupedUnselected[category];
+                            if (boards.length === 0) return null;
+                            return (
+                                <div key={category}>
+                                    <h4 className="mb-3 text-xs font-bold text-gray-400">{category}</h4>
+                                    <div className="flex flex-wrap gap-2">
+                                        {boards.map((code) => (
+                                            <button
+                                                key={code}
+                                                onClick={() => toggleBoard(code)}
+                                                className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-600 transition-all hover:bg-gray-100 active:scale-95"
+                                            >
+                                                {BOARD_MAP[code]?.name ?? code}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                        {unselectedItems.length === 0 && normalizedQuery && (
+                            <p className="py-6 text-center text-sm text-gray-400">
+                                검색 결과가 없습니다.
+                            </p>
+                        )}
+                        {subscribedBoardCodes.length === 0 && (
+                            <p className="py-6 text-center text-sm text-gray-400">
+                                구독 중인 게시판이 없습니다.
+                            </p>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Footer */}
+            <div className="shrink-0 border-t border-gray-100">
+                <div className="flex gap-3 px-5 py-4 pb-safe">
+                    <Button variant="outline" fullWidth onClick={() => onApply(null)}>
+                        구독 게시판 전체
+                    </Button>
+                    <Button
+                        variant="primary"
+                        fullWidth
+                        onClick={() => onApply(tempSelection.size > 0 ? Array.from(tempSelection) : null)}
+                    >
+                        적용
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/(main)/keywords/_components/KeywordsModalContent.tsx
+++ b/app/(main)/keywords/_components/KeywordsModalContent.tsx
@@ -1,18 +1,29 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
-import { addKeyword, deleteKeyword, getMyKeywords, Keyword } from '@/_lib/api';
+import { addKeyword, deleteKeyword, getMyKeywords, updateKeywordBoards, Keyword } from '@/_lib/api';
 import { useUser } from '@/_lib/hooks/useUser';
+import { useSelectedCategories } from '@/_lib/hooks/useSelectedCategories';
+import { BOARD_MAP } from '@/_lib/constants/boards';
 import Toast from '@/_components/ui/Toast';
 import Button from '@/_components/ui/Button';
 import GoogleLoginButton from '@/_components/auth/GoogleLoginButton';
-import { FiTrash2 } from 'react-icons/fi';
+import KeywordBoardSelector from './KeywordBoardSelector';
+import { FiTrash2, FiSliders } from 'react-icons/fi';
 
 interface KeywordsModalContentProps {
   onUpdate?: () => void;
 }
 
+function formatBoardCodes(boardCodes: string[] | null): string {
+  if (!boardCodes || boardCodes.length === 0) return '구독 게시판 전체';
+  const firstName = BOARD_MAP[boardCodes[0]]?.name ?? boardCodes[0];
+  if (boardCodes.length === 1) return firstName;
+  return `${firstName} 외 ${boardCodes.length - 1}개`;
+}
+
 export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentProps) {
   const { isLoggedIn } = useUser();
+  const { selectedCategories } = useSelectedCategories();
   const [keywords, setKeywords] = useState<Keyword[]>([]);
   const [keywordInput, setKeywordInput] = useState('');
   const [keywordsLoading, setKeywordsLoading] = useState(false);
@@ -20,6 +31,12 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
   const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('info');
   const [showToast, setShowToast] = useState(false);
   const [toastKey, setToastKey] = useState(0);
+
+  // 게시판 선택 상태
+  const [addBoardCodes, setAddBoardCodes] = useState<string[] | null>(null);
+  const [showAddBoardSelector, setShowAddBoardSelector] = useState(false);
+  const [editingKeyword, setEditingKeyword] = useState<Keyword | null>(null);
+  const [showEditBoardSelector, setShowEditBoardSelector] = useState(false);
 
   const showToastMessage = (message: string, type: 'success' | 'error' | 'info' = 'info') => {
     setToastMessage(message);
@@ -63,9 +80,10 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
     }
 
     try {
-      const created = await addKeyword(trimmed);
+      const created = await addKeyword(trimmed, addBoardCodes ?? undefined);
       setKeywords((prev) => [created, ...prev]);
       setKeywordInput('');
+      setAddBoardCodes(null);
       showToastMessage('키워드가 추가되었습니다.', 'success');
       onUpdate?.();
     } catch (error) {
@@ -81,7 +99,8 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
     }
   };
 
-  const handleDeleteKeyword = async (keywordId: number) => {
+  const handleDeleteKeyword = async (e: React.MouseEvent, keywordId: number) => {
+    e.stopPropagation();
     try {
       await deleteKeyword(keywordId);
       setKeywords((prev) => prev.filter((item) => item.id !== keywordId));
@@ -92,6 +111,59 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
       showToastMessage('키워드 삭제에 실패했습니다.', 'error');
     }
   };
+
+  const handleEditBoards = (keyword: Keyword) => {
+    setEditingKeyword(keyword);
+    setShowEditBoardSelector(true);
+  };
+
+  const handleUpdateBoards = async (boardCodes: string[] | null) => {
+    if (!editingKeyword) return;
+    try {
+      const result = await updateKeywordBoards(editingKeyword.id, boardCodes);
+      setKeywords(prev => prev.map(k =>
+        k.id === editingKeyword.id ? { ...k, board_codes: result.board_codes } : k
+      ));
+      setShowEditBoardSelector(false);
+      setEditingKeyword(null);
+      showToastMessage('게시판 범위가 수정되었습니다.', 'success');
+      onUpdate?.();
+    } catch (error) {
+      console.error('Failed to update keyword boards', error);
+      showToastMessage('게시판 범위 수정에 실패했습니다.', 'error');
+    }
+  };
+
+  const handleAddBoardApply = (boardCodes: string[] | null) => {
+    setAddBoardCodes(boardCodes);
+    setShowAddBoardSelector(false);
+  };
+
+  // 게시판 선택 UI 표시 중이면 해당 컴포넌트 렌더링
+  if (showAddBoardSelector) {
+    return (
+      <KeywordBoardSelector
+        subscribedBoardCodes={selectedCategories}
+        selectedBoardCodes={addBoardCodes}
+        onApply={handleAddBoardApply}
+        onClose={() => setShowAddBoardSelector(false)}
+      />
+    );
+  }
+
+  if (showEditBoardSelector && editingKeyword) {
+    return (
+      <KeywordBoardSelector
+        subscribedBoardCodes={selectedCategories}
+        selectedBoardCodes={editingKeyword.board_codes}
+        onApply={handleUpdateBoards}
+        onClose={() => {
+          setShowEditBoardSelector(false);
+          setEditingKeyword(null);
+        }}
+      />
+    );
+  }
 
   return (
     <>
@@ -130,6 +202,17 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
                   추가
                 </Button>
               </div>
+
+              {/* 게시판 범위 선택 */}
+              <button
+                onClick={() => setShowAddBoardSelector(true)}
+                className="mt-3 flex w-full items-center gap-2 rounded-lg border border-gray-200 px-3 py-2.5 text-left transition-colors hover:bg-gray-50"
+              >
+                <FiSliders size={14} className="shrink-0 text-gray-400" />
+                <span className={`flex-1 text-sm ${addBoardCodes ? 'font-medium text-blue-600' : 'text-gray-400'}`}>
+                  {formatBoardCodes(addBoardCodes)}
+                </span>
+              </button>
             </div>
 
             <div className="mt-6 flex min-h-0 flex-1 flex-col">
@@ -143,7 +226,7 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
                 {keywordsLoading ? (
                   <div className="space-y-2">
                     {[...Array(4)].map((_, idx) => (
-                      <div key={idx} className="h-10 animate-pulse rounded-lg bg-gray-100" />
+                      <div key={idx} className="h-14 animate-pulse rounded-lg bg-gray-100" />
                     ))}
                   </div>
                 ) : keywords.length > 0 ? (
@@ -151,12 +234,18 @@ export default function KeywordsModalContent({ onUpdate }: KeywordsModalContentP
                     {keywords.map((item) => (
                       <li
                         key={item.id}
-                        className="flex items-center justify-between rounded-lg border border-gray-100 bg-white px-4 py-2.5 text-sm shadow-sm"
+                        onClick={() => handleEditBoards(item)}
+                        className="flex cursor-pointer items-center justify-between rounded-lg border border-gray-100 bg-white px-4 py-2.5 shadow-sm transition-colors hover:bg-gray-50"
                       >
-                        <span className="font-medium text-gray-800">{item.keyword}</span>
+                        <div className="min-w-0 flex-1">
+                          <span className="text-sm font-medium text-gray-800">{item.keyword}</span>
+                          <p className={`mt-0.5 truncate text-xs ${item.board_codes ? 'text-blue-500' : 'text-gray-400'}`}>
+                            {formatBoardCodes(item.board_codes)}
+                          </p>
+                        </div>
                         <button
-                          onClick={() => handleDeleteKeyword(item.id)}
-                          className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-red-500"
+                          onClick={(e) => handleDeleteKeyword(e, item.id)}
+                          className="ml-2 shrink-0 rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-50 hover:text-red-500"
                           aria-label={`${item.keyword} 삭제`}
                         >
                           <FiTrash2 size={16} />

--- a/app/_lib/api/keywords.ts
+++ b/app/_lib/api/keywords.ts
@@ -1,5 +1,5 @@
 import api from './client';
-import type { Keyword, DeleteKeywordResponse } from '@/_types/keyword';
+import type { Keyword, DeleteKeywordResponse, UpdateKeywordBoardsResponse } from '@/_types/keyword';
 import type { Notice } from '@/_types/notice';
 
 // 내 키워드 조회
@@ -9,14 +9,26 @@ export const getMyKeywords = async () => {
 };
 
 // 키워드 추가
-export const addKeyword = async (keyword: string) => {
-    const response = await api.post<Keyword>('/users/me/keywords', { keyword });
+export const addKeyword = async (keyword: string, boardCodes?: string[]) => {
+    const response = await api.post<Keyword>('/users/me/keywords', {
+        keyword,
+        board_codes: boardCodes?.length ? boardCodes : undefined
+    });
     return response.data;
 };
 
 // 키워드 삭제
 export const deleteKeyword = async (keywordId: number) => {
     const response = await api.delete<DeleteKeywordResponse>(`/users/me/keywords/${keywordId}`);
+    return response.data;
+};
+
+// 키워드 게시판 범위 수정
+export const updateKeywordBoards = async (keywordId: number, boardCodes: string[] | null) => {
+    const response = await api.put<UpdateKeywordBoardsResponse>(
+        `/users/me/keywords/${keywordId}/boards`,
+        { board_codes: boardCodes }
+    );
     return response.data;
 };
 

--- a/app/_types/keyword.ts
+++ b/app/_types/keyword.ts
@@ -4,15 +4,24 @@ export interface Keyword {
     id: number;
     keyword: string;
     created_at: string;
+    board_codes: string[] | null;  // null = 구독 게시판 전체
 }
 
 // 키워드 추가 요청
 export interface AddKeywordRequest {
     keyword: string;
+    board_codes?: string[];
 }
 
 // 키워드 삭제 응답
 export interface DeleteKeywordResponse {
     message: string;
     keyword_id: number;
+}
+
+// 키워드 게시판 범위 수정 응답
+export interface UpdateKeywordBoardsResponse {
+    message: string;
+    keyword_id: number;
+    board_codes: string[] | null;
 }


### PR DESCRIPTION
## Summary
- 키워드 추가/수정 시 알림 받을 게시판 범위 선택 UI 추가
- `KeywordBoardSelector` 컴포넌트 신규 생성 (초성 검색, 카테고리별 그룹, 구독 게시판만 표시)
- `KeywordsModalContent`에 게시판 선택 통합 (추가 시 선택 + 목록에서 탭하여 수정)
- `Keyword` 타입에 `board_codes` 필드 추가
- `addKeyword` API에 `boardCodes` 파라미터 추가
- `updateKeywordBoards` API 신규 추가

## 연관 PR
- Backend: zeroone-2025/jbnu-alarm-api-v1 `feature/keyword-board-scope`

## Test plan
- [ ] 키워드 추가 시 게시판 선택 버튼 동작 확인
- [ ] 게시판 선택 후 키워드 추가 시 board_codes 전송 확인
- [ ] 키워드 목록에서 게시판 범위 표시 확인 (null → "구독 게시판 전체", [...] → "교내공지 외 N개")
- [ ] 키워드 탭하여 게시판 범위 수정 동작 확인
- [ ] 삭제 버튼 클릭 시 수정 모달이 열리지 않는지 확인 (e.stopPropagation)
- [ ] TypeScript 타입 체크 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)