### PR TITLE
style(filter): 카테고리 헤더에 색상 구분 적용

### DIFF
--- a/app/(main)/filter/_components/BoardFilterContent.tsx
+++ b/app/(main)/filter/_components/BoardFilterContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { FiBookmark, FiInfo, FiRotateCcw, FiSave, FiSearch, FiTrash2, FiX } from 'react-icons/fi';
-import { BOARD_LIST, CATEGORY_ORDER, BoardCategory, GUEST_DEFAULT_BOARDS } from '@/_lib/constants/boards';
+import { BOARD_LIST, CATEGORY_ORDER, CATEGORY_COLORS, BoardCategory, GUEST_DEFAULT_BOARDS } from '@/_lib/constants/boards';
 import { useUser } from '@/_lib/hooks/useUser';
 import {
   BoardGroup,
@@ -419,7 +419,7 @@ export default function BoardFilterContent({
 
               return (
                 <div key={category}>
-                  <h4 className="mb-3 text-xs font-bold text-gray-400">{category}</h4>
+                  <h4 className={`mb-3 border-l-[3px] pl-2 text-xs font-bold ${CATEGORY_COLORS[category].border} ${CATEGORY_COLORS[category].text}`}>{category}</h4>
                   {unselectedBoards.length > 0 ? (
                     <div className="flex flex-wrap gap-2">
                       {unselectedBoards.map((board) => (

--- a/app/(main)/keywords/_components/KeywordBoardSelector.tsx
+++ b/app/(main)/keywords/_components/KeywordBoardSelector.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { FiRotateCcw, FiSearch, FiX } from 'react-icons/fi';
+import { BOARD_MAP, CATEGORY_ORDER, CATEGORY_COLORS, BoardCategory } from '@/_lib/constants/boards';
+import Button from '@/_components/ui/Button';
+
+interface KeywordBoardSelectorProps {
+    subscribedBoardCodes: string[];
+    selectedBoardCodes: string[] | null;
+    onApply: (boardCodes: string[] | null) => void;
+    onClose: () => void;
+}
+
+const CHOSEONG = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'];
+
+const normalizeSearchText = (text: string) => text.toLowerCase().replace(/\s+/g, '');
+
+const getChoseong = (text: string) => {
+    let result = '';
+    for (const char of text) {
+        const code = char.charCodeAt(0);
+        if (code < 0xac00 || code > 0xd7a3) {
+            result += char;
+            continue;
+        }
+        const index = Math.floor((code - 0xac00) / 588);
+        result += CHOSEONG[index] || '';
+    }
+    return result;
+};
+
+export default function KeywordBoardSelector({
+    subscribedBoardCodes,
+    selectedBoardCodes,
+    onApply,
+    onClose,
+}: KeywordBoardSelectorProps) {
+    const [tempSelection, setTempSelection] = useState<Set<string>>(
+        new Set(selectedBoardCodes ?? [])
+    );
+    const [searchQuery, setSearchQuery] = useState('');
+    const searchInputRef = useRef<HTMLInputElement>(null);
+
+    const normalizedQuery = normalizeSearchText(searchQuery);
+
+    const matchesSearch = (boardCode: string) => {
+        if (!normalizedQuery) return true;
+        const meta = BOARD_MAP[boardCode];
+        if (!meta) return false;
+        const name = normalizeSearchText(meta.name);
+        const id = normalizeSearchText(boardCode);
+        const category = normalizeSearchText(meta.category);
+        const choseong = normalizeSearchText(getChoseong(meta.name));
+        return (
+            name.includes(normalizedQuery) ||
+            id.includes(normalizedQuery) ||
+            category.includes(normalizedQuery) ||
+            choseong.includes(normalizedQuery)
+        );
+    };
+
+    const toggleBoard = (boardCode: string) => {
+        setTempSelection((prev) => {
+            const next = new Set(prev);
+            if (next.has(boardCode)) {
+                next.delete(boardCode);
+            } else {
+                next.add(boardCode);
+            }
+            return next;
+        });
+    };
+
+    const handleReset = () => {
+        setTempSelection(new Set());
+    };
+
+    // 선택된 게시판 칩 (검색 무관하게 항상 표시)
+    const selectedItems = subscribedBoardCodes.filter((code) => tempSelection.has(code));
+
+    // 미선택 게시판 (검색 적용)
+    const unselectedItems = subscribedBoardCodes.filter(
+        (code) => !tempSelection.has(code) && matchesSearch(code)
+    );
+
+    // 카테고리별 그룹화
+    const groupedUnselected: Record<BoardCategory, string[]> = {
+        전북대: [],
+        단과대: [],
+        학과: [],
+        사업단: [],
+    };
+
+    unselectedItems.forEach((code) => {
+        const meta = BOARD_MAP[code];
+        if (meta) {
+            groupedUnselected[meta.category].push(code);
+        }
+    });
+
+    return (
+        <div className="flex h-full flex-col">
+            {/* 헤더 */}
+            <div className="flex shrink-0 items-center justify-between border-b border-gray-100 px-5 py-4">
+                <h2 className="text-base font-bold text-gray-800">알림 받을 게시판</h2>
+                <button
+                    onClick={onClose}
+                    className="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                    aria-label="닫기"
+                >
+                    <FiX size={20} />
+                </button>
+            </div>
+
+            {/* Body - Scrollable */}
+            <div className="flex-1 overflow-y-auto">
+                {/* 선택된 게시판 영역 */}
+                <div className="border-b border-gray-100 bg-blue-50/50 p-4">
+                    <div className="mb-3 flex items-center justify-between">
+                        <h3 className="text-xs font-bold text-gray-500">선택된 게시판</h3>
+                        <button
+                            onClick={handleReset}
+                            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900"
+                            aria-label="초기화"
+                        >
+                            <FiRotateCcw size={16} />
+                            <span>초기화</span>
+                        </button>
+                    </div>
+                    {selectedItems.length === 0 ? (
+                        <p className="py-4 text-center text-sm text-gray-400">
+                            알림 받을 게시판을 선택해주세요
+                        </p>
+                    ) : (
+                        <div className="flex flex-wrap gap-2">
+                            {selectedItems.map((code) => (
+                                <button
+                                    key={code}
+                                    onClick={() => toggleBoard(code)}
+                                    className="rounded-full border-2 border-gray-900 bg-white px-4 py-2 text-sm font-bold text-gray-900 shadow-md transition-all hover:bg-gray-50 active:scale-95"
+                                >
+                                    {BOARD_MAP[code]?.name ?? code}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* 게시판 목록 */}
+                <div className="p-4">
+                    <div className="mb-3 flex items-center justify-between gap-2">
+                        <h3 className="text-xs font-bold text-gray-500">구독 게시판</h3>
+                        <div className="relative w-[140px]">
+                            <input
+                                ref={searchInputRef}
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                placeholder="게시판 검색"
+                                className="h-8 w-full rounded-lg border border-gray-200 bg-white px-3 pr-14 text-xs outline-none transition-colors focus:border-blue-400"
+                            />
+                            {searchQuery.length > 0 && (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setSearchQuery('');
+                                        searchInputRef.current?.focus();
+                                    }}
+                                    className="absolute right-8 top-1/2 -translate-y-1/2 rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                                    aria-label="검색어 지우기"
+                                >
+                                    <FiX size={12} />
+                                </button>
+                            )}
+                            <button
+                                type="button"
+                                onClick={() => searchInputRef.current?.focus()}
+                                className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+                                aria-label="게시판 검색"
+                            >
+                                <FiSearch size={13} />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-col gap-6">
+                        {CATEGORY_ORDER.map((category) => {
+                            const boards = groupedUnselected[category];
+                            if (boards.length === 0) return null;
+                            return (
+                                <div key={category}>
+                                    <h4 className={`mb-3 border-l-[3px] pl-2 text-xs font-bold ${CATEGORY_COLORS[category].border} ${CATEGORY_COLORS[category].text}`}>{category}</h4>
+                                    <div className="flex flex-wrap gap-2">
+                                        {boards.map((code) => (
+                                            <button
+                                                key={code}
+                                                onClick={() => toggleBoard(code)}
+                                                className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-600 transition-all hover:bg-gray-100 active:scale-95"
+                                            >
+                                                {BOARD_MAP[code]?.name ?? code}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                        {unselectedItems.length === 0 && normalizedQuery && (
+                            <p className="py-6 text-center text-sm text-gray-400">
+                                검색 결과가 없습니다.
+                            </p>
+                        )}
+                        {subscribedBoardCodes.length === 0 && (
+                            <p className="py-6 text-center text-sm text-gray-400">
+                                구독 중인 게시판이 없습니다.
+                            </p>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Footer */}
+            <div className="shrink-0 border-t border-gray-100">
+                <div className="flex gap-3 px-5 py-4 pb-safe">
+                    <Button variant="outline" fullWidth onClick={() => onApply(null)}>
+                        구독 게시판 전체
+                    </Button>
+                    <Button
+                        variant="primary"
+                        fullWidth
+                        onClick={() => onApply(tempSelection.size > 0 ? Array.from(tempSelection) : null)}
+                    >
+                        적용
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/_lib/constants/boards.ts
+++ b/app/_lib/constants/boards.ts
@@ -201,6 +201,13 @@ export const GUEST_DEFAULT_BOARDS = [
  */
 export const CATEGORY_ORDER: BoardCategory[] = ['전북대', '단과대', '학과', '사업단'];
 
+export const CATEGORY_COLORS: Record<BoardCategory, { text: string; border: string }> = {
+  '전북대': { text: 'text-blue-600',   border: 'border-l-blue-400' },
+  '단과대': { text: 'text-indigo-600', border: 'border-l-indigo-400' },
+  '학과':   { text: 'text-amber-600',  border: 'border-l-amber-400' },
+  '사업단': { text: 'text-green-600',  border: 'border-l-green-400' },
+};
+
 /**
  * 전체 게시판 목록 (카테고리 포함)
  * - 카테고리 순서: CATEGORY_ORDER


### PR DESCRIPTION
## Summary

- 관심 게시판 설정(/filter) 및 키워드 게시판 선택 페이지에서 전북대/단과대/학과/사업단 카테고리 헤더가 모두 동일한 회색(`text-gray-400`)으로 표시되어 구분이 어려운 문제 해결
- 카테고리별 고유 색상(좌측 보더 + 텍스트 색상) 부여: 전북대(blue), 단과대(indigo), 학과(amber), 사업단(green)
- `CATEGORY_COLORS` 상수를 `boards.ts`에 추가하여 재사용 가능하도록 구성

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `app/_lib/constants/boards.ts` | `CATEGORY_COLORS` 상수 추가 |
| `app/(main)/filter/_components/BoardFilterContent.tsx` | 카테고리 헤더에 색상 적용 |
| `app/(main)/keywords/_components/KeywordBoardSelector.tsx` | 카테고리 헤더에 색상 적용 |

## Test plan

- [ ] `/filter` 페이지에서 4개 카테고리 헤더가 각기 다른 색상(좌측 보더 + 텍스트)으로 표시되는지 확인
- [ ] 키워드 게시판 선택 모달에서도 동일한 색상 구분이 적용되는지 확인
- [ ] 프로덕션 빌드 시 Tailwind 색상 클래스가 정상 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a board selector interface to manage which category boards you receive notifications from, with searchable options and Hangul character matching support.

* **Visual Improvements**
  * Category headings now display with category-specific colors for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->