### PR TITLE
Feat/chinba remake

### DIFF
--- a/app/(main)/chinba/_components/MyTabContent.tsx
+++ b/app/(main)/chinba/_components/MyTabContent.tsx
@@ -1,18 +1,185 @@
 'use client';
 
+import { useMemo, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { FiCalendar, FiCheckSquare, FiClock, FiUsers } from 'react-icons/fi';
+
+import TeamCard from '@/(main)/teams/_components/TeamCard';
+import FullPageModal from '@/_components/layout/FullPageModal';
 import { TimetableTab } from '@/_components/timetable';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
+import { useMyTeams } from '@/_lib/hooks/useTeam';
+import { useUser } from '@/_lib/hooks/useUser';
+
+import { ChinbaEventListItem } from './ChinbaEventListItem';
+
+/** dates 배열에서 오늘(자정) 이후의 가장 이른 날짜를 ms로 반환. 없으면 null. */
+function earliestUpcoming(dates: string[], todayMs: number): number | null {
+  let min: number | null = null;
+  for (const d of dates) {
+    const t = new Date(d).getTime();
+    if (Number.isNaN(t) || t < todayMs) continue;
+    if (min === null || t < min) min = t;
+  }
+  return min;
+}
 
 export default function MyTabContent() {
+  const router = useRouter();
+  const { isAuthLoaded, isLoggedIn, user } = useUser();
+  const { data: events, isLoading: isEventsLoading } = useMyChinbaEvents(
+    isAuthLoaded && isLoggedIn,
+  );
+  const { data: teamsData, isLoading: isTeamsLoading } = useMyTeams();
+
+  const [showTimetable, setShowTimetable] = useState(false);
+
+  // 내 할일: 미제출 + active
+  const todos = useMemo(
+    () => (events ?? []).filter((e) => !e.my_submitted && e.status === 'active'),
+    [events],
+  );
+
+  // 다가오는 일정: 오늘 이후 날짜를 가진 active 일정, 가장 이른 날짜 오름차순
+  const upcoming = useMemo(() => {
+    const todayMs = new Date(new Date().toDateString()).getTime();
+    return (events ?? [])
+      .filter((e) => e.status === 'active')
+      .map((e) => ({ event: e, when: earliestUpcoming(e.dates, todayMs) }))
+      .filter((x): x is { event: (typeof x)['event']; when: number } => x.when !== null)
+      .sort((a, b) => a.when - b.when)
+      .map((x) => x.event);
+  }, [events]);
+
+  const teams = teamsData?.teams ?? [];
+  const isLoading = !isAuthLoaded || (isLoggedIn && (isEventsLoading || isTeamsLoading));
+
   return (
-    <div className="flex h-full flex-col">
-      <div className="shrink-0 px-4 pt-4 pb-2">
-        <h2 className="text-lg font-bold text-gray-900">MY</h2>
+    <div className="h-full overflow-y-auto bg-gray-50">
+      {/* 헤더 + 시간표 진입 버튼 */}
+      <div className="sticky top-0 z-10 flex items-center justify-between bg-gray-50/95 px-4 pt-4 pb-3 backdrop-blur">
+        <div className="min-w-0">
+          <h2 className="text-lg font-bold text-gray-900">MY</h2>
+          {isLoggedIn && user?.nickname && (
+            <p className="truncate text-xs text-gray-500">{user.nickname}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowTimetable(true)}
+          className="inline-flex items-center gap-1.5 rounded-xl bg-white px-3 py-2 text-xs font-bold text-gray-700 shadow-sm transition active:scale-[0.98]"
+        >
+          <FiCalendar size={15} />내 시간표
+        </button>
       </div>
 
-      {/* Timetable */}
-      <div className="flex-1 min-h-0">
-        <TimetableTab />
+      <div className="space-y-4 px-4 pb-10">
+        {!isLoggedIn && isAuthLoaded ? (
+          <div className="rounded-2xl bg-white px-4 py-8 text-center shadow-sm">
+            <p className="text-sm font-bold text-gray-700 break-keep">
+              로그인하면 내 정보를 모아볼 수 있어요
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-gray-400 break-keep">
+              내 할일, 동아리, 다가오는 일정을 한 곳에서 확인하세요.
+            </p>
+            <button
+              type="button"
+              onClick={() => router.push('/login?redirect=/chinba/my')}
+              className="mt-3 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-bold text-white shadow-sm transition active:scale-[0.98]"
+            >
+              로그인하기
+            </button>
+          </div>
+        ) : isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <LoadingSpinner size="sm" />
+          </div>
+        ) : (
+          <>
+            {/* 내 할일 */}
+            <section className="rounded-2xl bg-white p-4 shadow-sm">
+              <SectionTitle icon={<FiCheckSquare size={15} className="text-amber-500" />} title="내 할일" />
+              {todos.length > 0 ? (
+                <div className="space-y-2">
+                  {todos.map((event) => (
+                    <ChinbaEventListItem
+                      key={event.event_id}
+                      event={event}
+                      compact
+                      onClick={() => router.push(`/chinba/event?id=${event.event_id}&tab=my`)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <EmptyText message="제출할 일정이 없어요" />
+              )}
+            </section>
+
+            {/* 나의 동아리 */}
+            <section className="rounded-2xl bg-white p-4 shadow-sm">
+              <SectionTitle icon={<FiUsers size={15} className="text-blue-500" />} title="나의 동아리" />
+              {teams.length > 0 ? (
+                <div className="space-y-2">
+                  {teams.map((team) => (
+                    <TeamCard
+                      key={team.id}
+                      team={team}
+                      terminology="club"
+                      onClick={() => router.push(`/chinba/team/detail?id=${team.id}`)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <EmptyText message="아직 참여 중인 동아리가 없어요" />
+              )}
+            </section>
+
+            {/* 다가오는 일정 */}
+            <section className="rounded-2xl bg-white p-4 shadow-sm">
+              <SectionTitle icon={<FiClock size={15} className="text-emerald-500" />} title="다가오는 일정" />
+              {upcoming.length > 0 ? (
+                <div className="space-y-2">
+                  {upcoming.map((event) => (
+                    <ChinbaEventListItem
+                      key={event.event_id}
+                      event={event}
+                      compact
+                      onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <EmptyText message="예정된 일정이 없어요" />
+              )}
+            </section>
+          </>
+        )}
       </div>
+
+      {/* 시간표 모달 (기존 TimetableTab 그대로 재사용) */}
+      <FullPageModal
+        isOpen={showTimetable}
+        onClose={() => setShowTimetable(false)}
+        title="내 시간표"
+        mode="overlay"
+      >
+        <TimetableTab />
+      </FullPageModal>
     </div>
   );
+}
+
+function SectionTitle({ icon, title }: { icon: React.ReactNode; title: string }) {
+  return (
+    <div className="mb-3 flex items-center gap-2">
+      {icon}
+      <h3 className="text-sm font-bold text-gray-900">{title}</h3>
+    </div>
+  );
+}
+
+function EmptyText({ message }: { message: string }) {
+  return <p className="py-3 text-center text-xs text-gray-400">{message}</p>;
 }

--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -1,22 +1,23 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
 
+import { useRouter, useSearchParams } from 'next/navigation';
 import { FiSettings } from 'react-icons/fi';
 
-import FullPageModal from '@/_components/layout/FullPageModal';
-import LoadingSpinner from '@/_components/ui/LoadingSpinner';
-import { useGroupSets } from '@/_lib/hooks/useGroups';
-import { useSmartBack } from '@/_lib/hooks/useSmartBack';
-import { useTeamDetail } from '@/_lib/hooks/useTeam';
-import { useAuthInitialized } from '@/providers';
 import GroupFilterBar from '@/(main)/teams/_components/GroupFilterBar';
 import TeamSegmentTabs, { type TeamSegment } from '@/(main)/teams/_components/TeamSegmentTabs';
 import UpgradeModal from '@/(main)/teams/_components/UpgradeModal';
 import ActivityTab from '@/(main)/teams/detail/_components/ActivityTab';
 import JababwaTab from '@/(main)/teams/detail/_components/JababwaTab';
 import MannajaTab from '@/(main)/teams/detail/_components/MannajaTab';
+import FullPageModal from '@/_components/layout/FullPageModal';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useGroupSets } from '@/_lib/hooks/useGroups';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { useTeamDetail } from '@/_lib/hooks/useTeam';
+import { setLastTeamId } from '@/_lib/utils/chinbaSelection';
+import { useAuthInitialized } from '@/providers';
 
 export default function TeamDetailView() {
   const router = useRouter();
@@ -37,6 +38,11 @@ export default function TeamDetailView() {
 
   const groupSets = groupSetsData?.group_sets ?? [];
   const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
+
+  // 마지막으로 본 동아리를 기억 → 하단 `동아리` 탭이 여기로 바로 들어옴
+  useEffect(() => {
+    if (teamId) setLastTeamId(teamId);
+  }, [teamId]);
 
   // Sync tab state when URL changes (e.g. browser back/forward)
   useEffect(() => {

--- a/app/(main)/chinba/_components/team/TeamListView.tsx
+++ b/app/(main)/chinba/_components/team/TeamListView.tsx
@@ -1,107 +1,70 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
-import { FiPlus, FiUsers } from 'react-icons/fi';
+import { useRouter } from 'next/navigation';
+import { FiUsers } from 'react-icons/fi';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
-import Toast from '@/_components/ui/Toast';
-import { hasAccessToken } from '@/_lib/auth/tokenStore';
-import { useMyTeams } from '@/_lib/hooks/useTeam';
-import { useAuthInitialized } from '@/providers';
-import TeamCard from '@/(main)/teams/_components/TeamCard';
 import TeamStatsBanner from '@/_components/ui/TeamStatsBanner';
+import { useMyTeams } from '@/_lib/hooks/useTeam';
+import { clearLastTeamId, getLastTeamId } from '@/_lib/utils/chinbaSelection';
+import { useAuthInitialized } from '@/providers';
 
 export default function TeamListView() {
   const router = useRouter();
   const isAuthReady = useAuthInitialized();
-  const isLoggedIn = isAuthReady && hasAccessToken();
-  const { data, isLoading, isError } = useMyTeams();
+  const { data, isLoading } = useMyTeams();
   const teams = data?.teams ?? [];
 
-  const [toastVisible, setToastVisible] = useState(false);
-  const [toastKey, setToastKey] = useState(0);
+  // localStorage는 클라이언트에서만 읽어 hydration mismatch 방지
+  const [lastId, setLastId] = useState<number | null>(null);
+  const [checked, setChecked] = useState(false);
+  useEffect(() => {
+    setLastId(getLastTeamId());
+    setChecked(true);
+  }, []);
 
-  const handleRequireLogin = () => {
-    setToastVisible(true);
-    setToastKey(prev => prev + 1);
-  };
+  // 마지막 선택 동아리가 여전히 내 동아리 목록에 있으면 그 상세로 이동
+  const redirectId = checked && lastId && teams.some((t) => t.id === lastId) ? lastId : null;
 
+  useEffect(() => {
+    if (!checked || !isAuthReady || isLoading) return;
+    if (redirectId) {
+      router.replace(`/chinba/team/detail?id=${redirectId}`);
+    } else if (lastId) {
+      clearLastTeamId(); // 이미 나간 동아리 등 → 기억 초기화
+    }
+  }, [checked, isAuthReady, isLoading, redirectId, lastId, router]);
+
+  // 로딩 중이거나 리다이렉트 예정이면 스피너 (안내 화면 깜빡임 방지)
+  if (!checked || !isAuthReady || isLoading || redirectId) {
+    return (
+      <div className="flex h-full items-center justify-center bg-white">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  // 선택된 동아리가 없으면 홈에서 고르도록 안내
   return (
     <div className="flex h-full flex-col bg-white">
       <TeamStatsBanner />
-
-      {/* Header */}
-      <div className="shrink-0 px-4 pb-3">
-        <div className="pt-safe md:pt-0" />
-        <div className="relative mt-4 flex items-center justify-between">
-          <h1 className="text-lg font-bold text-gray-800">내 동아리</h1>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => isLoggedIn ? router.push('/chinba/team/join') : handleRequireLogin()}
-              className="flex items-center gap-1 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 active:scale-95"
-            >
-              초대 코드 입력
-            </button>
-            <button
-              onClick={() => isLoggedIn ? router.push('/chinba/team/create') : handleRequireLogin()}
-              className="flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
-            >
-              <FiPlus size={14} />
-              만들기
-            </button>
-          </div>
+      <div className="flex flex-1 flex-col items-center justify-center px-6 pb-16 text-center">
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+          <FiUsers size={28} className="text-gray-300" />
         </div>
+        <p className="mb-1 text-sm font-bold text-gray-700">선택된 동아리가 없어요</p>
+        <p className="mb-4 text-xs leading-relaxed text-gray-400 break-keep">
+          홈에서 동아리를 선택하면 여기로 바로 들어와요.
+        </p>
+        <button
+          onClick={() => router.push('/chinba')}
+          className="rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-bold text-white transition active:scale-95"
+        >
+          홈에서 동아리 선택
+        </button>
       </div>
-
-      {/* Content */}
-      <div className="flex-1 min-h-0 overflow-y-auto px-4 pb-4">
-        {!isAuthReady || isLoading ? (
-          <div className="flex items-center justify-center py-20">
-            <LoadingSpinner />
-          </div>
-        ) : isError ? (
-          <div className="flex flex-col items-center justify-center py-20">
-            <p className="text-sm text-gray-400">동아리 목록을 불러오지 못했습니다</p>
-            <button
-              onClick={() => window.location.reload()}
-              className="mt-3 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200"
-            >
-              다시 시도
-            </button>
-          </div>
-        ) : teams.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20">
-            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
-              <FiUsers size={28} className="text-gray-300" />
-            </div>
-            <p className="text-sm font-medium text-gray-500 mb-1">동아리가 없습니다</p>
-            <p className="text-xs text-gray-400 text-center">
-              새 동아리를 만들거나 초대 링크로 가입하세요
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            {teams.map((team) => (
-              <TeamCard
-                key={team.id}
-                team={team}
-                terminology="club"
-                onClick={() => router.push(`/chinba/team/detail?id=${team.id}`)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
-
-      <Toast
-        message="로그인이 필요합니다"
-        isVisible={toastVisible}
-        onClose={() => setToastVisible(false)}
-        type="info"
-        triggerKey={toastKey}
-      />
     </div>
   );
 }

--- a/app/(main)/chinba/layout.tsx
+++ b/app/(main)/chinba/layout.tsx
@@ -4,7 +4,12 @@ import { usePathname } from 'next/navigation';
 
 import BottomTabBar from './_components/BottomTabBar';
 
-const BOTTOM_TAB_PATHS = new Set(['/chinba', '/chinba/team', '/chinba/my']);
+const BOTTOM_TAB_PATHS = new Set([
+  '/chinba',
+  '/chinba/team',
+  '/chinba/team/detail',
+  '/chinba/my',
+]);
 
 export default function ChinbaLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -1,25 +1,14 @@
 'use client';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import {
-  FiCalendar,
-  FiChevronRight,
-  FiClock,
-  FiGrid,
-  FiLink,
-  FiPlus,
-  FiUsers,
-} from 'react-icons/fi';
+import { FiCalendar, FiClock, FiGrid, FiLink, FiPlus, FiUsers } from 'react-icons/fi';
 
-import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import TeamCard from '@/(main)/teams/_components/TeamCard';
-import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
+import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { useTeamStats } from '@/_lib/hooks/useTeamStats';
 import { useUser } from '@/_lib/hooks/useUser';
-
-import { ChinbaEventListItem } from './_components/ChinbaEventListItem';
+import type { TeamListItem } from '@/_types/team';
 
 const CONCEPTS = [
   {
@@ -45,233 +34,159 @@ export default function ChinbaHomePage() {
   const router = useRouter();
   const { isAuthLoaded, isLoggedIn } = useUser();
   const { data: stats } = useTeamStats();
-  const {
-    data: events,
-    isLoading: isEventsLoading,
-  } = useMyChinbaEvents(isAuthLoaded && isLoggedIn);
-  const {
-    data: teamsData,
-    isLoading: isTeamsLoading,
-  } = useMyTeams();
+  const { data: teamsData, isLoading: isTeamsLoading } = useMyTeams();
 
-  const visibleEvents = (events ?? []).slice(0, 3);
-  const visibleTeams = (teamsData?.teams ?? []).slice(0, 3);
-  const hasEvents = visibleEvents.length > 0;
-  const hasTeams = visibleTeams.length > 0;
+  const teams = teamsData?.teams ?? [];
+
+  // 신규/미가입자에게는 소개를, 단골에게는 바로 액션을
+  const isNewcomer = !isLoggedIn || teams.length === 0;
+
+  const requireLoginThen = (path: string) =>
+    isLoggedIn ? router.push(path) : router.push('/login?redirect=/chinba');
 
   return (
     <div className="h-full overflow-y-auto bg-gray-50">
-      <div className="space-y-4 px-4 pt-4 pb-10">
-        <section className="rounded-2xl bg-white p-5 shadow-sm">
+      <div className="space-y-5 px-5 pt-6 pb-10">
+        {/* 제목 (카드 없이 상단에 붙은 형태) */}
+        <header>
           <div className="flex items-center gap-1.5">
             <span className="text-lg font-bold tracking-tight text-blue-700">친해지길 바래</span>
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
           </div>
-          <h1 className="mt-2 text-xl font-bold leading-snug text-gray-900 break-keep">
-            단톡방 투표 없이,
-            <br />
-            시간표로 바로 만나는 시간 찾기
-          </h1>
-          <p className="mt-2 text-sm leading-relaxed text-gray-500 break-keep">
-            동아리 정모, 조별과제, 스터디 시간을 가장 빠르게 맞춰요.
-          </p>
+
+          {!isAuthLoaded ? (
+            <div className="mt-1 h-8" />
+          ) : isNewcomer ? (
+            <>
+              <h1 className="mt-1 text-2xl font-extrabold leading-snug text-gray-900 break-keep">
+                시간표로 바로 만나는
+                <br />
+                시간 찾기
+              </h1>
+              <p className="mt-2 text-sm leading-relaxed text-gray-500 break-keep">
+                동아리 정모, 조별과제, 스터디 시간을 가장 빠르게 맞춰요.
+              </p>
+            </>
+          ) : (
+            <h1 className="mt-1 text-2xl font-extrabold leading-snug text-gray-900 break-keep">
+              시간표로 바로 만나는 시간 찾기
+            </h1>
+          )}
+
           {stats && (
             <p className="mt-3 inline-flex rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
               {stats.total_teams.toLocaleString('ko-KR')}개의 동아리가 함께하고 있어요
             </p>
           )}
-        </section>
+        </header>
 
-        <div className="grid grid-cols-2 gap-3">
-          <Link
-            href="/chinba/create"
-            className="rounded-2xl bg-gray-900 p-4 text-white shadow-sm transition active:scale-[0.99]"
-          >
-            <FiPlus size={20} />
-            <p className="mt-3 text-sm font-bold">새 일정</p>
-            <p className="mt-1 text-xs leading-relaxed text-white/60">링크로 빠르게 시간을 모아요.</p>
-          </Link>
-          <Link
-            href="/chinba/team"
-            className="rounded-2xl bg-white p-4 text-gray-900 shadow-sm transition active:scale-[0.99]"
-          >
-            <FiUsers size={20} />
-            <p className="mt-3 text-sm font-bold">동아리</p>
-            <p className="mt-1 text-xs leading-relaxed text-gray-500">동아리와 조별 일정을 관리해요.</p>
-          </Link>
-        </div>
-
+        {/* 친바 동아리 선택 — 목록을 펼친 채로 + 만들기/참여 */}
         <section className="rounded-2xl bg-white p-4 shadow-sm">
-          <div className="mb-3 flex items-center gap-2">
-            <FiGrid size={16} className="text-gray-500" />
-            <h2 className="text-sm font-bold text-gray-900">친바가 하는 일</h2>
-          </div>
-          <div className="grid gap-2">
-            {CONCEPTS.map((item) => {
-              const Icon = item.icon;
-              return (
-                <div key={item.title} className="flex gap-3 rounded-xl bg-gray-50 px-3 py-3">
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-gray-700 shadow-sm">
-                    <Icon size={17} />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-bold text-gray-900">{item.title}</p>
-                    <p className="mt-0.5 text-xs leading-relaxed text-gray-500 break-keep">
-                      {item.description}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="rounded-2xl bg-white p-4 shadow-sm">
-          <div className="mb-3 flex items-center gap-2">
-            <FiCalendar size={16} className="text-gray-500" />
-            <h2 className="text-sm font-bold text-gray-900">이럴 때 써요</h2>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {USE_CASES.map((label) => (
-              <span
-                key={label}
-                className="rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600"
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-sm font-bold text-gray-900">친바 동아리 선택</h2>
+            <div className="flex shrink-0 gap-1.5">
+              <button
+                type="button"
+                onClick={() => requireLoginThen('/chinba/team/join')}
+                className="rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50 active:scale-95"
               >
-                {label}
-              </span>
-            ))}
+                초대코드
+              </button>
+              <button
+                type="button"
+                onClick={() => requireLoginThen('/chinba/team/create')}
+                className="flex items-center gap-1 rounded-lg bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+              >
+                <FiPlus size={13} />
+                만들기
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-3">
+            {!isAuthLoaded || (isLoggedIn && isTeamsLoading) ? (
+              <div className="flex items-center justify-center py-8">
+                <LoadingSpinner size="sm" />
+              </div>
+            ) : !isLoggedIn ? (
+              <p className="py-6 text-center text-xs text-gray-400 break-keep">
+                로그인하면 내 동아리를 골라 바로 들어갈 수 있어요.
+              </p>
+            ) : teams.length === 0 ? (
+              <p className="py-6 text-center text-xs text-gray-400 break-keep">
+                아직 참여 중인 동아리가 없어요. 동아리를 만들거나 초대코드로 참여하세요.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {teams.map((team: TeamListItem) => (
+                  <TeamCard
+                    key={team.id}
+                    team={team}
+                    terminology="club"
+                    onClick={() => router.push(`/chinba/team/detail?id=${team.id}`)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </section>
 
-        <section className="rounded-2xl bg-white p-4 shadow-sm">
-          <SectionHeader
-            title="내 친바 일정"
-            href="/chinba/create"
-            actionLabel="생성"
-            icon={<FiPlus size={14} />}
-          />
-          {!isAuthLoaded || (isLoggedIn && isEventsLoading) ? (
-            <LoadingBlock />
-          ) : !isLoggedIn ? (
-            <EmptyState
-              title="로그인하면 내 일정을 모아볼 수 있어요"
-              description="친바를 만들고 공유한 일정을 한 곳에서 관리하세요."
-              actionLabel="로그인하기"
-              onAction={() => router.push('/login?redirect=/chinba')}
-            />
-          ) : hasEvents ? (
-            <div className="space-y-2">
-              {visibleEvents.map((event) => (
-                <ChinbaEventListItem
-                  key={event.event_id}
-                  event={event}
-                  compact
-                  onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
-                />
-              ))}
-            </div>
-          ) : (
-            <EmptyState
-              title="아직 참여 중인 친바가 없어요"
-              description="새 일정을 만들어 단톡방에 공유해보세요."
-              actionLabel="일정 만들기"
-              onAction={() => router.push('/chinba/create')}
-            />
-          )}
-        </section>
+        {/* 동아리 없이 일정 잡기 — 항상 노출 (텍스트 버튼) */}
+        <button
+          type="button"
+          onClick={() => router.push('/chinba/create')}
+          className="w-full py-1 text-center text-sm font-bold text-gray-900 transition active:scale-[0.99]"
+        >
+          동아리 없이 일정 잡기 →
+        </button>
 
-        <section className="rounded-2xl bg-white p-4 shadow-sm">
-          <SectionHeader title="내 동아리" href="/chinba/team" actionLabel="전체" />
-          {!isAuthLoaded || (isLoggedIn && isTeamsLoading) ? (
-            <LoadingBlock />
-          ) : !isLoggedIn ? (
-            <EmptyState
-              title="동아리를 만들거나 초대 코드로 참여하세요"
-              description="동아리 전체와 조별 친바를 한 곳에서 운영할 수 있어요."
-              actionLabel="로그인하기"
-              onAction={() => router.push('/login?redirect=/chinba/team')}
-            />
-          ) : hasTeams ? (
-            <div className="space-y-2">
-              {visibleTeams.map((team) => (
-                <TeamCard
-                  key={team.id}
-                  team={team}
-                  terminology="club"
-                  onClick={() => router.push(`/chinba/team/detail?id=${team.id}`)}
-                />
-              ))}
-            </div>
-          ) : (
-            <EmptyState
-              title="아직 참여 중인 동아리가 없어요"
-              description="새 동아리를 만들거나 받은 초대 코드로 참여하세요."
-              actionLabel="동아리 시작하기"
-              onAction={() => router.push('/chinba/team')}
-            />
-          )}
-        </section>
+        {/* 소개 모드일 때만: 친바가 하는 일 / 이럴 때 써요 */}
+        {isAuthLoaded && isNewcomer && (
+          <>
+            <section className="rounded-2xl bg-white p-4 shadow-sm">
+              <div className="mb-3 flex items-center gap-2">
+                <FiGrid size={16} className="text-gray-500" />
+                <h2 className="text-sm font-bold text-gray-900">친바가 하는 일</h2>
+              </div>
+              <div className="grid gap-2">
+                {CONCEPTS.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <div key={item.title} className="flex gap-3 rounded-xl bg-gray-50 px-3 py-3">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white text-gray-700 shadow-sm">
+                        <Icon size={17} />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-bold text-gray-900">{item.title}</p>
+                        <p className="mt-0.5 text-xs leading-relaxed text-gray-500 break-keep">
+                          {item.description}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="rounded-2xl bg-white p-4 shadow-sm">
+              <div className="mb-3 flex items-center gap-2">
+                <FiCalendar size={16} className="text-gray-500" />
+                <h2 className="text-sm font-bold text-gray-900">이럴 때 써요</h2>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {USE_CASES.map((label) => (
+                  <span
+                    key={label}
+                    className="rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600"
+                  >
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
       </div>
-    </div>
-  );
-}
-
-function SectionHeader({
-  title,
-  href,
-  actionLabel,
-  icon,
-}: {
-  title: string;
-  href: string;
-  actionLabel: string;
-  icon?: React.ReactNode;
-}) {
-  return (
-    <div className="mb-3 flex items-center justify-between">
-      <h2 className="text-sm font-bold text-gray-900">{title}</h2>
-      <Link
-        href={href}
-        className="inline-flex items-center gap-1 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-bold text-gray-700 transition-colors hover:bg-gray-200"
-      >
-        {icon}
-        {actionLabel}
-        {!icon && <FiChevronRight size={13} />}
-      </Link>
-    </div>
-  );
-}
-
-function LoadingBlock() {
-  return (
-    <div className="flex items-center justify-center py-8">
-      <LoadingSpinner size="sm" />
-    </div>
-  );
-}
-
-function EmptyState({
-  title,
-  description,
-  actionLabel,
-  onAction,
-}: {
-  title: string;
-  description: string;
-  actionLabel: string;
-  onAction: () => void;
-}) {
-  return (
-    <div className="rounded-xl bg-gray-50 px-4 py-5 text-center">
-      <p className="text-sm font-bold text-gray-700 break-keep">{title}</p>
-      <p className="mt-1 text-xs leading-relaxed text-gray-400 break-keep">{description}</p>
-      <button
-        type="button"
-        onClick={onAction}
-        className="mt-3 rounded-lg bg-white px-3 py-1.5 text-xs font-bold text-gray-700 shadow-sm transition active:scale-[0.98]"
-      >
-        {actionLabel}
-      </button>
     </div>
   );
 }

--- a/app/_lib/utils/chinbaSelection.ts
+++ b/app/_lib/utils/chinbaSelection.ts
@@ -1,0 +1,34 @@
+// 홈에서 선택(또는 마지막으로 본) 친바 동아리 id를 기억한다.
+// 하단 `동아리` 탭(/chinba/team)이 이 값을 읽어 해당 동아리 상세로 바로 들어간다.
+
+const KEY = 'chinba:lastTeamId';
+
+export function setLastTeamId(id: number): void {
+  try {
+    if (typeof window !== 'undefined' && id > 0) {
+      window.localStorage.setItem(KEY, String(id));
+    }
+  } catch {
+    /* localStorage 접근 불가(프라이빗 모드 등) 시 무시 */
+  }
+}
+
+export function getLastTeamId(): number | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLastTeamId(): void {
+  try {
+    if (typeof window !== 'undefined') window.localStorage.removeItem(KEY);
+  } catch {
+    /* 무시 */
+  }
+}


### PR DESCRIPTION
  ## 변경 사항

  ### ① 하단 탭 유지 (`layout.tsx`)
  - `BOTTOM_TAB_PATHS`에 `/chinba/team/detail` 추가 → 동아리 상세에서도 홈/동아리/MY 탭 노출.

  ### ② 홈을 동아리 선택 허브로 개편 (`page.tsx`)
  - 제목(`친해지길 바래 / 시간표로 바로 만나는 시간 찾기`)을 카드 없이 상단에 배치.
  - 그 아래 **내 동아리 목록을 펼친 채로** 노출. 동아리 클릭 → 상세 이동.
  - `친바 동아리 선택` 헤더 옆에 **만들기 / 초대코드** 버튼 배치(기존 동아리 탭에서 이전).
  - `동아리 없이 일정 잡기`는 하단 텍스트 버튼으로 → `/chinba/create`.
  - 소개 블록(`친바가 하는 일`/`이럴 때 써요`)은 신규·미가입자(`!isLoggedIn || 동아리 0개`)에게만 노출. 통계 문구는 유지.

  ### ③ MY 화면을 대시보드로 개편 (`MyTabContent.tsx`)
  - **내 할일**(미제출 active 일정) / **나의 동아리** / **다가오는 일정** 3개 섹션.
  - 데이터는 `useMyChinbaEvents`·`useMyTeams`에서 **프론트 파생**(신규 API 없음).
  - 기존 `TimetableTab`은 수정 없이 우상단 `내 시간표` 버튼 + `FullPageModal`로 위치만 이동.

  ### ④ 동아리 선택 기억 + 동아리 탭 동작 변경
  - `app/_lib/utils/chinbaSelection.ts` 신설: 마지막 선택 동아리 id를 `localStorage`에 저장/조회(SSR·프라이빗 모드 안전).
  - `TeamDetailView`: 상세 진입 시 해당 동아리를 마지막 선택으로 기록.
  - `TeamListView`(`동아리` 탭): 마지막 선택 동아리로 자동 이동, 없으면 "홈에서 동아리를 선택하세요" 안내. 생성/참여 버튼은
  홈으로 이전.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a personalized “My” dashboard with your tasks, clubs, and upcoming schedules.
  * Added a timetable pop-up accessible from the dashboard.
  * Improved the main Chinba page with clearer club selection, onboarding guidance, and quick actions.

* **Bug Fixes**
  * Kept your last viewed club available for faster return visits.
  * Updated tab visibility so club detail pages keep the bottom navigation consistent.

* **Chores**
  * Simplified the club list flow to focus on the currently selected club state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->