### PR TITLE
feat(chinba): 기록/랭킹 무료 개방 및 완료→기록 자동 흐름 추가

### DIFF
--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -33,6 +33,8 @@ export default function TeamDetailView() {
   const { data: groupSetsData } = useGroupSets(teamId || undefined);
   const [activeTab, setActiveTab] = useState<TeamSegment>(initialTab);
   const [showUpgrade, setShowUpgrade] = useState(false);
+  const [pendingTab, setPendingTab] = useState<TeamSegment | null>(null);
+  const [freeNoticeSeen, setFreeNoticeSeen] = useState(false);
   const [selectedSetId, setSelectedSetId] = useState<number | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
 
@@ -54,16 +56,22 @@ export default function TeamDetailView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
+  // 뭐했니/잡아봐 탭: 무료 이벤트 기간 — 안내 팝업 1회 노출 후 진입 허용
   const isPaidTab = (tab: TeamSegment) => tab === 'mwoheni' || tab === 'jabahbwa';
   const needsSubscription = team && !team.is_paid;
 
+  const goToTab = (tab: TeamSegment) => {
+    setActiveTab(tab);
+    router.replace(`/chinba/team/detail?id=${teamId}&tab=${tab}`);
+  };
+
   const handleTabChange = (tab: TeamSegment) => {
-    if (isPaidTab(tab) && needsSubscription) {
+    if (isPaidTab(tab) && needsSubscription && !freeNoticeSeen) {
+      setPendingTab(tab);
       setShowUpgrade(true);
       return;
     }
-    setActiveTab(tab);
-    router.replace(`/chinba/team/detail?id=${teamId}&tab=${tab}`);
+    goToTab(tab);
   };
 
   const handleSettingsClick = () => {
@@ -160,6 +168,11 @@ export default function TeamDetailView() {
         onClose={() => setShowUpgrade(false)}
         teamId={teamId}
         terminology="club"
+        onConfirm={() => {
+          setFreeNoticeSeen(true);
+          if (pendingTab) goToTab(pendingTab);
+          setPendingTab(null);
+        }}
       />
     </FullPageModal>
   );

--- a/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
@@ -158,6 +158,19 @@ export default function ChinbaDetailClient() {
   const handleComplete = async () => {
     try {
       await completeMutation.mutateAsync(eventId);
+      setShowCompleteModal(false);
+      // 완료 처리 후, 넘어온 경로(팀 상세 '기록' 탭)로 이동하면서
+      // 완료된 일정 정보(제목/날짜)를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
+      const returnTo = searchParams.get('returnTo');
+      if (returnTo) {
+        const dest = decodeURIComponent(returnTo);
+        const recordParams = new URLSearchParams();
+        if (event?.title) recordParams.set('recordTitle', event.title);
+        if (event?.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
+        const suffix = recordParams.toString();
+        router.replace(suffix ? `${dest}${dest.includes('?') ? '&' : '?'}${suffix}` : dest);
+        return;
+      }
     } catch {
       alert('완료 처리에 실패했습니다');
     }

--- a/app/(main)/teams/_components/TeamSegmentTabs.tsx
+++ b/app/(main)/teams/_components/TeamSegmentTabs.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import type { IconType } from 'react-icons';
+import { LuCalendar, LuPencil, LuMedal } from 'react-icons/lu';
+
 export type TeamSegment = 'mannaja' | 'mwoheni' | 'jabahbwa';
 
 interface TeamSegmentTabsProps {
@@ -7,10 +10,10 @@ interface TeamSegmentTabsProps {
   onTabChange: (tab: TeamSegment) => void;
 }
 
-const TABS: { key: TeamSegment; label: string }[] = [
-  { key: 'mannaja', label: '만나자' },
-  { key: 'mwoheni', label: '뭐했니' },
-  { key: 'jabahbwa', label: '잡아봐' },
+const TABS: { key: TeamSegment; label: string; icon: IconType }[] = [
+  { key: 'mannaja', label: '일정', icon: LuCalendar },
+  { key: 'mwoheni', label: '기록', icon: LuPencil },
+  { key: 'jabahbwa', label: '랭킹', icon: LuMedal },
 ];
 
 export default function TeamSegmentTabs({ activeTab, onTabChange }: TeamSegmentTabsProps) {
@@ -18,6 +21,7 @@ export default function TeamSegmentTabs({ activeTab, onTabChange }: TeamSegmentT
     <div className="flex border-b border-gray-100">
       {TABS.map((tab) => {
         const isActive = activeTab === tab.key;
+        const Icon = tab.icon;
         return (
           <button
             key={tab.key}
@@ -28,7 +32,10 @@ export default function TeamSegmentTabs({ activeTab, onTabChange }: TeamSegmentT
                 : 'text-gray-400 hover:text-gray-600'
             }`}
           >
-            {tab.label}
+            <span className="inline-flex items-center justify-center gap-1.5">
+              <Icon size={16} strokeWidth={isActive ? 2.5 : 2} />
+              {tab.label}
+            </span>
             {isActive && (
               <span className="absolute bottom-0 left-1/2 -translate-x-1/2 h-0.5 w-12 rounded-full bg-gray-900" />
             )}

--- a/app/(main)/teams/_components/UpgradeModal.tsx
+++ b/app/(main)/teams/_components/UpgradeModal.tsx
@@ -1,28 +1,19 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 interface UpgradeModalProps {
   isOpen: boolean;
   onClose: () => void;
   teamId: number;
   terminology?: 'team' | 'club';
+  onConfirm?: () => void;
 }
 
 const PREMIUM_FEATURES = [
-  { label: '활동 기록 (뭐했니)', description: '조별 활동을 기록하고 공유' },
-  { label: '조별 기록 비교 (잡아봐)', description: '조별 활동 데이터를 비교·분석·랭킹' },
+  { label: '기록', description: '조별 활동을 기록하고 공유' },
+  { label: '랭킹', description: '조별 활동 데이터를 비교·분석·랭킹' },
 ];
 
-const PRICING_DISPLAY = [
-  { tier: 'Standard', members: '1~39명', price: '8,900원/월' },
-  { tier: 'Pro', members: '40~79명', price: '17,900원/월' },
-  { tier: 'Business', members: '80명+', price: '34,900원/월' },
-];
-
-export default function UpgradeModal({ isOpen, onClose, teamId, terminology = 'team' }: UpgradeModalProps) {
-  const router = useRouter();
-
+export default function UpgradeModal({ isOpen, onClose, onConfirm }: UpgradeModalProps) {
   if (!isOpen) return null;
 
   return (
@@ -38,9 +29,9 @@ export default function UpgradeModal({ isOpen, onClose, teamId, terminology = 't
               &#x2B50;
             </span>
           </div>
-          <p className="text-base font-bold text-gray-900">프리미엄 기능입니다</p>
+          <p className="text-base font-bold text-gray-900">지금은 무료 이벤트 기간!</p>
           <p className="mt-1 text-xs text-gray-500">
-            구독하고 {terminology === 'club' ? '동아리' : '팀'} 관리 기능을 모두 이용하세요
+            아래 기능을 지금 무료로 이용할 수 있어요
           </p>
         </div>
 
@@ -59,22 +50,6 @@ export default function UpgradeModal({ isOpen, onClose, teamId, terminology = 't
           ))}
         </div>
 
-        {/* Pricing preview */}
-        <div className="mb-5 rounded-xl bg-gray-50 p-3">
-          <p className="mb-2 text-xs font-semibold text-gray-500">
-            요금제 (월 결제 기준)
-          </p>
-          <div className="flex justify-between text-xs text-gray-600">
-            {PRICING_DISPLAY.map((item) => (
-              <div key={item.tier} className="text-center">
-                <p className="font-semibold text-gray-800">{item.tier}</p>
-                <p className="font-medium text-gray-700">{item.price}</p>
-                <p className="text-gray-400">{item.members}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-
         {/* Actions */}
         <div className="flex gap-2">
           <button
@@ -86,11 +61,11 @@ export default function UpgradeModal({ isOpen, onClose, teamId, terminology = 't
           <button
             onClick={() => {
               onClose();
-              router.push(`/chinba/team/settings?id=${teamId}`);
+              onConfirm?.();
             }}
             className="flex-1 rounded-xl bg-blue-500 py-3 text-sm font-semibold text-white hover:bg-blue-600 active:scale-95 transition-all"
           >
-            구독하기
+            무료로 시작하기
           </button>
         </div>
       </div>

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useEffect } from 'react';
 
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { LuPlus, LuClock, LuCalendar, LuTrash2 } from 'react-icons/lu';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
@@ -25,6 +26,10 @@ export default function ActivityTab({
   selectedGroupId,
   terminology = 'team',
 }: ActivityTabProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
   const { data, isLoading } = useActivities(teamId);
   const { data: groupsData } = useGroups(teamId);
   const createMutation = useCreateActivity(teamId);
@@ -66,6 +71,30 @@ export default function ActivityTab({
   useEffect(() => {
     setShowForm(false);
   }, [selectedGroupId]);
+
+  // 일정 완료 처리에서 넘어온 경우: 활동 기록 폼을 완료된 일정 정보로 미리 채워 자동 오픈.
+  // (URL의 recordTitle/recordDate 파라미터를 1회 소비하고 즉시 제거해 재오픈 방지)
+  useEffect(() => {
+    const recordTitle = searchParams.get('recordTitle');
+    if (recordTitle === null) return;
+
+    if (hasRole) {
+      const recordDate = searchParams.get('recordDate');
+      setFormData({
+        title: recordTitle,
+        activity_date: recordDate || new Date().toISOString().slice(0, 10),
+      });
+      setFormScores([]);
+      setShowForm(true);
+    }
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('recordTitle');
+    params.delete('recordDate');
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   // 활동 필터링
   const allActivities = data?.activities ?? [];

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { IconType } from 'react-icons';
 import { FiPlus, FiCalendar, FiUsers, FiLayers } from 'react-icons/fi';
@@ -34,8 +34,19 @@ export default function MannajaTab({
   terminology = 'team',
 }: MannajaTabProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const { data, isLoading } = useTeamEvents(teamId);
   const { data: groupSetsData } = useGroupSets(teamId);
+
+  // 이벤트 상세로 이동하면서, 완료 처리 후 돌아올 "기록(뭐했니)" 탭 경로를 넘긴다.
+  // 현재 위치(pathname)를 그대로 쓰므로 /teams/detail·/chinba/team/detail 어디서든 동작.
+  const openEvent = useCallback(
+    (eventId: string) => {
+      const returnTo = encodeURIComponent(`${pathname}?id=${teamId}&tab=mwoheni`);
+      router.push(`/chinba/event?id=${eventId}&returnTo=${returnTo}`);
+    },
+    [router, pathname, teamId],
+  );
 
   const canCreate = myRole === 'captain' || myRole === 'executive';
   const groupSets = groupSetsData?.group_sets ?? [];
@@ -131,7 +142,7 @@ export default function MannajaTab({
                     key={event.event_id}
                     event={event}
                     groupSetNameMap={groupSetNameMap}
-                    onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                    onClick={() => openEvent(event.event_id)}
                   />
                 ))
               ) : (
@@ -147,7 +158,7 @@ export default function MannajaTab({
                 key={event.event_id}
                 event={event}
                 groupSetNameMap={groupSetNameMap}
-                onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                onClick={() => openEvent(event.event_id)}
               />
             ))
           ) : (
@@ -179,7 +190,7 @@ export default function MannajaTab({
             key={event.event_id}
             event={event}
             groupSetNameMap={groupSetNameMap}
-            onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+            onClick={() => openEvent(event.event_id)}
           />
         ))
       )}

--- a/app/(main)/teams/detail/_components/TeamDetailClient.tsx
+++ b/app/(main)/teams/detail/_components/TeamDetailClient.tsx
@@ -26,8 +26,12 @@ export default function TeamDetailClient() {
   const { data: team, isLoading, isError } = useTeamDetail(teamId);
   const { data: groupSetsData } = useGroupSets(teamId);
 
-  const [activeTab, setActiveTab] = useState<TeamSegment>('mannaja');
+  const tabParam = searchParams.get('tab') as TeamSegment | null;
+  const initialTab: TeamSegment = tabParam === 'mwoheni' || tabParam === 'jabahbwa' ? tabParam : 'mannaja';
+  const [activeTab, setActiveTab] = useState<TeamSegment>(initialTab);
   const [showUpgrade, setShowUpgrade] = useState(false);
+  const [pendingTab, setPendingTab] = useState<TeamSegment | null>(null);
+  const [freeNoticeSeen, setFreeNoticeSeen] = useState(false);
   const [selectedSetId, setSelectedSetId] = useState<number | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
 
@@ -35,12 +39,13 @@ export default function TeamDetailClient() {
   // 세트 1개일 때 자동 선택
   const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
 
-  // 뭐했니/잡아봐 탭은 유료 기능 (구독 필요)
+  // 뭐했니/잡아봐 탭: 무료 이벤트 기간 — 안내 팝업 1회 노출 후 진입 허용
   const isPaidTab = (tab: TeamSegment) => tab === 'mwoheni' || tab === 'jabahbwa';
   const needsSubscription = team && !team.is_paid;
 
   const handleTabChange = (tab: TeamSegment) => {
-    if (isPaidTab(tab) && needsSubscription) {
+    if (isPaidTab(tab) && needsSubscription && !freeNoticeSeen) {
+      setPendingTab(tab);
       setShowUpgrade(true);
       return;
     }
@@ -140,6 +145,11 @@ export default function TeamDetailClient() {
           isOpen={showUpgrade}
           onClose={() => setShowUpgrade(false)}
           teamId={teamId}
+          onConfirm={() => {
+            setFreeNoticeSeen(true);
+            if (pendingTab) setActiveTab(pendingTab);
+            setPendingTab(null);
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
## 개요
  초반 마케팅을 위해 친바 팀 기능 중 **기록(구 뭐했니)** 과 **랭킹(구 잡아봐)** 을 무료로 개방하고,
  일정 완료 → 기록 작성으로 이어지는 흐름을 매끄럽게 개선합니다.

  > ⚠️  실제 데이터 무료 개방은 백엔드 게이트 해제가 함께 필요합니다.
  > 관련 PR: jbnu-alarm-api-v1 `feature/chinba-free-event` (base: develop)

  ## 변경 사항
  ### 1. 탭 명칭·아이콘 변경 (`TeamSegmentTabs.tsx`)
  - 만나자 → **일정** (📅 달력)
  - 뭐했니 → **기록** (✏️  연필)
  - 잡아봐 → **랭킹** (🏅 메달)
  - 내부 키(`mannaja`/`mwoheni`/`jabahbwa`)는 유지 — 표시 라벨/아이콘만 변경

  ### 2. 유료 게이트 → 무료 이벤트 안내로 전환
  - `UpgradeModal.tsx`: 요금제/구독 유도 팝업을 **"지금은 무료 이벤트 기간!"** 안내로 교체
    (`onConfirm` 추가, 요금제 블록·구독 이동 제거)
  - `TeamDetailClient.tsx` / `TeamDetailView.tsx`: 미구독 팀이 기록/랭킹 탭을 누르면
    안내 팝업을 **세션당 1회** 노출한 뒤 확인 시 탭에 진입 (`pendingTab`/`freeNoticeSeen`)

  ### 3. 일정 완료 → 기록 자동 흐름
  - `MannajaTab.tsx`: 일정(이벤트) 진입 시 돌아올 기록 탭 경로(`returnTo`)를 함께 전달
  - `ChinbaDetailClient.tsx`: 완료 처리 후 기록 탭으로 이동하며 완료된 일정의 **제목·날짜**를 전달
  - `ActivityTab.tsx`: 넘어온 정보로 **"활동 기록하기" 폼을 미리 채워 자동으로 오픈**
    (URL 파라미터는 1회 소비 후 제거)

  ## 참고
  - 유료 전환 시엔 팝업 문구와 `freeNoticeSeen` 게이트만 되돌리면 됩니다.
  - 백엔드 게이트(api PR)가 배포돼야 실제 기록/랭킹 데이터가 노출됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tab icons and refreshed tab labels in team views for clearer navigation.
  * Event completion can now return users to the originating screen, keeping context after finishing an event.
  * Team pages can now open specific tabs directly from the URL.

* **Bug Fixes**
  * Improved paid-tab access flow so users can continue to the intended tab after acknowledging the free notice.
  * Event links now preserve the previous page and selected tab when navigating back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->