### PR TITLE
chore(rename): 패키지·문서의 jbnu-alarm 표기를 zerotime으로 변경

### DIFF
--- a/CAPACITOR_PLAN.md
+++ b/CAPACITOR_PLAN.md
@@ -1,6 +1,6 @@
 # Capacitor 기반 iOS/Android 앱 변환 계획
 
-Next.js 16 기반의 `jbnu-alarm-app-v1`을 Capacitor를 사용하여 iOS/Android 네이티브 앱으로 변환하는 상세 계획입니다.
+Next.js 16 기반의 `zerotime-front`을 Capacitor를 사용하여 iOS/Android 네이티브 앱으로 변환하는 상세 계획입니다.
 
 ## 현재 프로젝트 분석
 
@@ -99,7 +99,7 @@ sequenceDiagram
 
 ### 1. Next.js Static Export 설정
 
-#### [MODIFY] [next.config.ts](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/next.config.ts)
+#### [MODIFY] [next.config.ts](file:///Users/boseung/zerotime/zerotime-front/next.config.ts)
 
 Static Export 활성화:
 
@@ -129,7 +129,7 @@ PWA 설정에서 Capacitor 빌드 시 비활성화:
 
 ### 2. Server Component 호환성 수정
 
-#### [NEW] [DevHostMetaTag.tsx](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/app/_components/system/DevHostMetaTag.tsx)
+#### [NEW] [DevHostMetaTag.tsx](file:///Users/boseung/zerotime/zerotime-front/app/_components/system/DevHostMetaTag.tsx)
 
 `headers()` 대신 클라이언트 측 감지:
 
@@ -151,7 +151,7 @@ export default function DevHostMetaTag() {
 }
 ```
 
-#### [MODIFY] [layout.tsx](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/app/layout.tsx)
+#### [MODIFY] [layout.tsx](file:///Users/boseung/zerotime/zerotime-front/app/layout.tsx)
 
 ```diff
 -import { headers } from 'next/headers';
@@ -172,7 +172,7 @@ export default function DevHostMetaTag() {
 
 ### 3. Capacitor 프로젝트 초기화
 
-#### [NEW] [capacitor.config.ts](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/capacitor.config.ts)
+#### [NEW] [capacitor.config.ts](file:///Users/boseung/zerotime/zerotime-front/capacitor.config.ts)
 
 ```typescript
 import type { CapacitorConfig } from '@capacitor/cli';
@@ -210,7 +210,7 @@ export default config;
 
 ### 4. 네이티브 앱 환경 감지
 
-#### [NEW] [useNativeApp.ts](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/app/_lib/hooks/useNativeApp.ts)
+#### [NEW] [useNativeApp.ts](file:///Users/boseung/zerotime/zerotime-front/app/_lib/hooks/useNativeApp.ts)
 
 ```typescript
 'use client';
@@ -228,7 +228,7 @@ export function useNativeApp() {
 
 ### 5. 백엔드 CORS 및 쿠키 설정 수정
 
-#### [MODIFY] [config.py](file:///Users/boseung/zerotime/jbnu-alarm-api-v1/app/core/config.py)
+#### [MODIFY] [config.py](file:///Users/boseung/zerotime/zerotime-back/app/core/config.py)
 
 네이티브 앱의 origin 추가:
 
@@ -237,7 +237,7 @@ export function useNativeApp() {
 CORS_ORIGINS=http://localhost:3000,https://zerotime.kr,https://dev.zerotime.kr,https://app.zerotime.kr
 ```
 
-#### [MODIFY] [auth.py](file:///Users/boseung/zerotime/jbnu-alarm-api-v1/app/routers/auth.py)
+#### [MODIFY] [auth.py](file:///Users/boseung/zerotime/zerotime-back/app/routers/auth.py)
 
 쿠키 도메인 설정 (선택적):
 
@@ -259,7 +259,7 @@ CORS_ORIGINS=http://localhost:3000,https://zerotime.kr,https://dev.zerotime.kr,h
 
 ### 6. Google OAuth 네이티브 앱 지원
 
-#### [MODIFY] [auth.ts](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/app/_lib/api/auth.ts)
+#### [MODIFY] [auth.ts](file:///Users/boseung/zerotime/zerotime-front/app/_lib/api/auth.ts)
 
 네이티브 앱에서는 in-app browser를 사용:
 
@@ -306,7 +306,7 @@ useEffect(() => {
 
 ### 7. InAppBrowserGuide 조건부 렌더링
 
-#### [MODIFY] [InAppBrowserGuideModal.tsx](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/app/_components/system/InAppBrowserGuideModal.tsx)
+#### [MODIFY] [InAppBrowserGuideModal.tsx](file:///Users/boseung/zerotime/zerotime-front/app/_components/system/InAppBrowserGuideModal.tsx)
 
 ```typescript
 import { Capacitor } from '@capacitor/core';
@@ -324,7 +324,7 @@ export default function InAppBrowserGuideModal() {
 
 ### 8. Service Worker 조건부 등록
 
-#### [MODIFY] [ServiceWorkerRegistration.tsx](file:///Users/boseung/zerotime/jbnu-alarm-app-v1/app/_components/system/ServiceWorkerRegistration.tsx)
+#### [MODIFY] [ServiceWorkerRegistration.tsx](file:///Users/boseung/zerotime/zerotime-front/app/_components/system/ServiceWorkerRegistration.tsx)
 
 ```typescript
 import { Capacitor } from '@capacitor/core';
@@ -537,7 +537,7 @@ CAPACITOR_BUILD=true npm run build
 ## 디렉토리 구조 변경 예상
 
 ```
-jbnu-alarm-app-v1/
+zerotime-front/
 ├── android/                          # [NEW]
 ├── ios/                              # [NEW]
 ├── out/                              # Static export

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@
 저장소를 클론하고 패키지를 설치합니다.
 
 ```bash
-git clone https://github.com/zeroone-2025/jbnu-alarm-app-v1.git
-cd jbnu-alarm-app-v1
+git clone https://github.com/zeroone-2025/zerotime-front.git
+cd zerotime-front
 npm install
 ```
 
@@ -70,7 +70,7 @@ npm run start
 **Feature-based Architecture**로 구성되어 있습니다.
 
 ```
-jbnu-alarm-app-v1/
+zerotime-front/
 ├── app/
 │   ├── (routes)/            # 📍 모든 페이지 라우트
 │   │   ├── (home)/          # 홈 화면

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jbnu-alarm-app-v1",
+  "name": "zerotime-front",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jbnu-alarm-app-v1",
+      "name": "zerotime-front",
       "version": "0.1.0",
       "dependencies": {
         "@capacitor/android": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jbnu-alarm-app-v1",
+  "name": "zerotime-front",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -100,7 +100,7 @@ if [ "$HTTP_STATUS" = "200" ]; then
 else
     echo -e "${YELLOW}⚠ 백엔드 API 서버에 연결할 수 없습니다 (${API_URL})${NC}"
     echo -e "${YELLOW}⚠ 백엔드 서버를 먼저 실행해주세요:${NC}"
-    echo -e "${YELLOW}   cd ../jbnu-alarm-api-v1 && ./run-dev.sh${NC}\n"
+    echo -e "${YELLOW}   cd ../zerotime-back && ./run-dev.sh${NC}\n"
     
     read -p "계속 진행하시겠습니까? (y/N): " -n 1 -r
     echo


### PR DESCRIPTION
## 변경 요약
- package.json name
- package-lock(npm install, name 필드만)
- run-dev.sh 경로
- README·CAPACITOR_PLAN 표기 (5 files)

## 의도적 보존 목록 (수정하면 안 됨)
- `app/_components/layout/SidebarContent.tsx:47,99`, `DesktopSidebar.tsx:25`의 `id: 'jbnu-alarm'` 내부 식별자
- `CAPACITOR_PLAN.md:48`의 `jbnu-alarm://` scheme 문서 표기

## ⚠️ 주의
merge는 7/4 D-day Phase 1-C에서만

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native app support for iOS/Android builds, including app-specific web settings and native-aware login handling.
  * Improved development setup for the new project name and folder structure.

* **Bug Fixes**
  * Updated cookie and cross-origin settings so sign-in and session behavior work correctly in production.
  * Disabled web-only behaviors on native builds, including service worker registration and in-app browser guidance.

* **Documentation**
  * Refreshed setup instructions and directory references to match the new project layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->