### PR TITLE
hotfix(auth): AASA를 prod 웹에 배포 — 유니버설 링크 미등록으로 네이티브 로그인 불가 수정

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appID": "5ZR495UQN7.kr.zerotime.app",
+        "paths": [
+          "/auth/native/callback/"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
zerotime.kr/.well-known/apple-app-site-association이 404라 iOS가 /auth/native/callback/ 경로의 앱 소유권을 등록하지 못해 OAuth 콜백이 앱으로 돌아오지 못했다. 생성 산출물이던 파일을 커밋 대상으로 승격.
Refs #197


Claude-Session: https://claude.ai/code/session_01MMAt7yVCQn3k2SVX3bdGZX