### PR TITLE
hotfix(auth): AASA·assetlinks를 application/json으로 서빙 — iOS가 octet-stream…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [{ "key": "Content-Type", "value": "application/json" }]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [{ "key": "Content-Type", "value": "application/json" }]
+    }
+  ]
+}


### PR DESCRIPTION
… AASA를 거부해 유니버설 링크 미등록

Vercel이 확장자 없는 .well-known 파일을 application/octet-stream으로 서빙해 기기의 AASA 직접 fetch(developer mode)와 Apple CDN 등록이 실패했다. Refs #197