### PR TITLE
feat: 친바 서비스 표시명을 타임라인(TIMELINE)으로 변경

### DIFF
--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -50,7 +50,7 @@ export default function ChinbaHomePage() {
         {/* 제목 카드 */}
         <header className="rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-1.5">
-            <span className="text-lg font-bold tracking-tight text-blue-700">타임라인</span>
+            <span className="text-lg font-bold tracking-tight text-blue-700">TIMELINE</span>
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
           </div>
 

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -50,7 +50,7 @@ export default function ChinbaHomePage() {
         {/* 제목 카드 */}
         <header className="rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-1.5">
-            <span className="text-lg font-bold tracking-tight text-blue-700">친해지길 바래</span>
+            <span className="text-lg font-bold tracking-tight text-blue-700">타임라인</span>
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
           </div>
 
@@ -82,10 +82,10 @@ export default function ChinbaHomePage() {
           )}
         </header>
 
-        {/* 친바 동아리 선택 — 목록을 펼친 채로 + 만들기/참여 */}
+        {/* 타임라인 동아리 선택 — 목록을 펼친 채로 + 만들기/참여 */}
         <section className="rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center justify-between gap-2">
-            <h2 className="text-sm font-bold text-gray-900">친바 동아리 선택</h2>
+            <h2 className="text-sm font-bold text-gray-900">타임라인 동아리 선택</h2>
             <div className="flex shrink-0 gap-1.5">
               <button
                 type="button"
@@ -148,7 +148,7 @@ export default function ChinbaHomePage() {
             <section className="rounded-2xl bg-white p-4 shadow-sm">
               <div className="mb-3 flex items-center gap-2">
                 <FiGrid size={16} className="text-gray-500" />
-                <h2 className="text-sm font-bold text-gray-900">친바가 하는 일</h2>
+                <h2 className="text-sm font-bold text-gray-900">타임라인이 하는 일</h2>
               </div>
               <div className="grid gap-2">
                 {CONCEPTS.map((item) => {

--- a/app/_components/layout/DesktopSidebar.tsx
+++ b/app/_components/layout/DesktopSidebar.tsx
@@ -26,7 +26,7 @@ interface CollapsedNavItem {
 const NAV_ITEMS: CollapsedNavItem[] = [
   // jbnu-alarm 라벨(툴팁)은 렌더 시점에 `<학교 전체명> 알리미`로 치환한다(아래 alarmLabel 참고).
   { id: 'jbnu-alarm', icon: FiBell, href: '/', label: '알리미', matchPath: '/' },
-  { id: 'chinba', icon: FiUsers, href: '/chinba', label: '친해지길 바래', matchPath: '/chinba' },
+  { id: 'chinba', icon: FiUsers, href: '/chinba', label: '타임라인', matchPath: '/chinba' },
   { id: 'flow', icon: FiZap, href: '/flow', label: 'FLOW', matchPath: '/flow' },
 ];
 

--- a/app/_components/layout/SidebarContent.tsx
+++ b/app/_components/layout/SidebarContent.tsx
@@ -48,7 +48,7 @@ const SERVICE_ITEMS: ServiceItem[] = [
   { id: 'profile', label: '프로필', icon: FiUser, href: '/profile', matchPath: '/profile' },
   // jbnu-alarm 라벨은 렌더 시점에 `<학교 전체명> 알리미`로 치환한다(아래 alarmLabel 참고).
   { id: 'jbnu-alarm', label: '알리미', icon: FiBell, matchPath: '/' },
-  { id: 'chinba', label: '친해지길 바래', icon: FiUsers, matchPath: '/chinba' },
+  { id: 'chinba', label: '타임라인', icon: FiUsers, matchPath: '/chinba' },
 ];
 
 function formatAdmissionYear(year: number | null | undefined): string | null {

--- a/e2e/chinba.spec.ts
+++ b/e2e/chinba.spec.ts
@@ -8,7 +8,7 @@ test.describe('친바 페이지 - 게스트', () => {
 
   test('섹션 헤더가 표시된다', async ({ asGuest }) => {
     await asGuest.goto('/chinba');
-    await expect(asGuest.getByText('친바 동아리 선택')).toBeVisible({ timeout: 10_000 });
+    await expect(asGuest.getByText('타임라인 동아리 선택')).toBeVisible({ timeout: 10_000 });
   });
 
   test('동아리 만들기 버튼이 있다', async ({ asGuest }) => {


### PR DESCRIPTION
## 요약
- 사이드바 메뉴 라벨(모바일 `SidebarContent` / 데스크톱 접힘 툴팁 `DesktopSidebar`) '친해지길 바래' → '타임라인'
- 친바 홈 화면 문구 변경: 제목 카드 브랜드명 → 영문 **TIMELINE**, '친바 동아리 선택' → '타임라인 동아리 선택', '친바가 하는 일' → '타임라인이 하는 일'
- 해당 문구를 검증하는 e2e 텍스트 단언(`e2e/chinba.spec.ts`) 동반 수정

## 범위 참고
- 라우트(`/chinba`)·타입·컴포넌트명·localStorage 키 등 내부 식별자는 그대로 유지 (표시 문자열만 변경)
- 다른 화면의 '친바' 표기(이벤트 상세 모달, 내 친바 일정 등)는 이번 범위에서 제외
- 비주얼 스냅샷(`e2e/visual`)은 문구 변경으로 베이스라인 재생성 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mjfgz5KgnrVMJyKcs6VDTv