### PR TITLE
Feat/group split

### DIFF
--- a/app/(main)/chinba/_components/team/GroupManageView.tsx
+++ b/app/(main)/chinba/_components/team/GroupManageView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { FiClipboard, FiUsers } from 'react-icons/fi';
 
 import FullPageModal from '@/_components/layout/FullPageModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
@@ -14,7 +15,7 @@ import GroupTextInput from './groups/GroupTextInput';
 import GroupParsePreview from './groups/GroupParsePreview';
 import GroupInlineEditor from './groups/GroupInlineEditor';
 
-type Step = 'current' | 'set-select' | 'input' | 'preview' | 'edit';
+type Step = 'current' | 'set-select' | 'method' | 'compose' | 'input' | 'preview' | 'edit';
 
 export default function GroupManageView() {
   const router = useRouter();
@@ -48,7 +49,7 @@ export default function GroupManageView() {
         setStep('edit');
       } else if (initialMode === 'recompose' && initialSetId) {
         setSelectedGroupSetId(Number(initialSetId));
-        setStep('input');
+        setStep('method');
       } else {
         setStep(hasExistingGroups ? 'current' : 'set-select');
       }
@@ -66,14 +67,14 @@ export default function GroupManageView() {
       try {
         const created = await createGroupSet.mutateAsync({ name: newSetName.trim() });
         setSelectedGroupSetId(created.id);
-        setStep('input');
+        setStep('method');
       } catch (err: any) {
         setError(err.response?.data?.detail || '그룹세트 생성에 실패했습니다.');
       }
       return;
     }
 
-    setStep('input');
+    setStep('method');
   };
 
   const handleParse = async (text: string) => {
@@ -127,7 +128,7 @@ export default function GroupManageView() {
           groupSets={groupSets}
           onRecompose={(setId?: number) => {
             setSelectedGroupSetId(setId ?? null);
-            setStep(setId ? 'input' : 'set-select');
+            setStep(setId ? 'method' : 'set-select');
           }}
           onEdit={(setId?: number) => {
             setSelectedGroupSetId(setId ?? null);
@@ -192,11 +193,62 @@ export default function GroupManageView() {
           </div>
         </div>
       )}
+      {step === 'method' && (
+        <div className="flex flex-col h-full">
+          <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+            <div>
+              <h3 className="text-sm font-bold text-gray-800">편성 방식 선택</h3>
+              <p className="text-xs text-gray-500 mt-0.5">조를 어떻게 만들지 고르세요.</p>
+            </div>
+
+            <button
+              onClick={() => { setError(null); setStep('compose'); }}
+              className="w-full text-left rounded-xl border border-gray-200 p-4 transition-colors hover:border-gray-300 active:scale-[0.99]"
+            >
+              <div className="flex items-center gap-2">
+                <FiUsers size={16} className="text-gray-500" />
+                <span className="text-sm font-medium text-gray-800">직접 선택하기</span>
+              </div>
+              <p className="mt-1 text-xs text-gray-400">멤버를 눌러 조에 배정합니다</p>
+            </button>
+
+            <button
+              onClick={() => { setError(null); setStep('input'); }}
+              className="w-full text-left rounded-xl border border-gray-200 p-4 transition-colors hover:border-gray-300 active:scale-[0.99]"
+            >
+              <div className="flex items-center gap-2">
+                <FiClipboard size={16} className="text-gray-500" />
+                <span className="text-sm font-medium text-gray-800">텍스트 붙여넣기 (AI)</span>
+              </div>
+              <p className="mt-1 text-xs text-gray-400">엑셀·카톡 명단을 붙여넣어 자동 분석합니다</p>
+            </button>
+          </div>
+
+          <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+            <button
+              onClick={() => { setError(null); setStep(hasExistingGroups ? 'current' : 'set-select'); }}
+              className="w-full rounded-xl border border-gray-200 py-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+            >
+              돌아가기
+            </button>
+          </div>
+        </div>
+      )}
+      {step === 'compose' && (
+        <GroupInlineEditor
+          teamId={teamId}
+          groupSetId={selectedGroupSetId ?? undefined}
+          mode="compose"
+          onSave={handleConfirm}
+          onBack={() => { setError(null); setStep('method'); }}
+          isSaving={saveGroups.isPending}
+        />
+      )}
       {step === 'input' && (
         <GroupTextInput
           onParse={handleParse}
           isParsing={parseGroups.isPending}
-          onBack={() => { setError(null); setStep('set-select'); }}
+          onBack={() => { setError(null); setStep('method'); }}
         />
       )}
       {step === 'preview' && parseResult && (

--- a/app/(main)/chinba/_components/team/groups/GroupInlineEditor.test.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupInlineEditor.test.tsx
@@ -55,7 +55,8 @@ describe('GroupInlineEditor — compose 모드', () => {
   it('조가 없으면 1조를 만들어 두고, 빈 조 상태에서는 저장을 막는다', () => {
     renderCompose();
 
-    expect(screen.getByRole('button', { name: /1조/ })).toBeInTheDocument();
+    // 정확히 일치로 찾는다 — 삭제 버튼의 aria-label("1조 삭제")과 겹치지 않게
+    expect(screen.getByRole('button', { name: '1조' })).toBeInTheDocument();
     expect(screen.getByText('멤버 필요')).toBeInTheDocument();
     expect(screen.getByText('멤버가 없는 조가 있습니다')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '저장하기' })).toBeDisabled();
@@ -100,5 +101,43 @@ describe('GroupInlineEditor — compose 모드', () => {
     // 시트 후보에는 박지현만 남는다 (김민수는 이미 조에 들어갔다)
     expect(within(second).queryByText('김민수')).not.toBeInTheDocument();
     expect(within(second).getByText('박지현')).toBeInTheDocument();
+  });
+
+  it('중간 조를 삭제하면 뒤 조들의 번호가 앞당겨진다', () => {
+    renderCompose();
+
+    // 1조(자동 생성) + 2조 + 3조
+    fireEvent.click(screen.getByRole('button', { name: /새 조 추가/ }));
+    fireEvent.click(screen.getByRole('button', { name: /새 조 추가/ }));
+    expect(screen.getByRole('button', { name: '3조' })).toBeInTheDocument();
+
+    // 2조 삭제 → 3조가 2조로 당겨진다
+    fireEvent.click(screen.getByRole('button', { name: '2조 삭제' }));
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }));
+
+    expect(screen.getByRole('button', { name: '1조' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '2조' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '3조' })).not.toBeInTheDocument();
+  });
+
+  it('직접 지은 조 이름은 삭제 후에도 그대로 둔다', () => {
+    renderCompose();
+
+    fireEvent.click(screen.getByRole('button', { name: /새 조 추가/ }));
+    fireEvent.click(screen.getByRole('button', { name: /새 조 추가/ }));
+
+    // 3조 → "친목조"로 이름 변경
+    fireEvent.click(screen.getByRole('button', { name: '3조' }));
+    const input = screen.getByDisplayValue('3조');
+    fireEvent.change(input, { target: { value: '친목조' } });
+    fireEvent.blur(input);
+
+    // 2조 삭제 → 1조는 그대로, 친목조는 이름 유지
+    fireEvent.click(screen.getByRole('button', { name: '2조 삭제' }));
+    fireEvent.click(screen.getByRole('button', { name: '삭제' }));
+
+    expect(screen.getByRole('button', { name: '1조' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '친목조' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '2조' })).not.toBeInTheDocument();
   });
 });

--- a/app/(main)/chinba/_components/team/groups/GroupInlineEditor.test.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupInlineEditor.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useGroups } from '@/_lib/hooks/useGroups';
+import { useTeamMembers } from '@/_lib/hooks/useTeam';
+
+import GroupInlineEditor from './GroupInlineEditor';
+
+vi.mock('@/_lib/hooks/useGroups', () => ({ useGroups: vi.fn() }));
+vi.mock('@/_lib/hooks/useTeam', () => ({ useTeamMembers: vi.fn() }));
+
+const mockedUseGroups = vi.mocked(useGroups);
+const mockedUseTeamMembers = vi.mocked(useTeamMembers);
+
+const UNASSIGNED = [
+  { member_id: 1, user_id: 11, nickname: '김민수' },
+  { member_id: 2, user_id: 12, nickname: '박지현' },
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asHook = (value: object) => value as any;
+
+beforeEach(() => {
+  mockedUseGroups.mockReturnValue(
+    asHook({ data: { groups: [], unassigned_members: UNASSIGNED }, isLoading: false }),
+  );
+  mockedUseTeamMembers.mockReturnValue(
+    asHook({
+      data: {
+        members: [
+          { id: 1, user_id: 11, nickname: '김민수', profile_image: null, role: 'captain' },
+          { id: 2, user_id: 12, nickname: '박지현', profile_image: null, role: 'member' },
+        ],
+        total: 2,
+      },
+    }),
+  );
+});
+
+function renderCompose(onSave = vi.fn()) {
+  render(
+    <GroupInlineEditor
+      teamId={1}
+      groupSetId={7}
+      mode="compose"
+      onSave={onSave}
+      onBack={vi.fn()}
+      isSaving={false}
+    />,
+  );
+  return { onSave };
+}
+
+describe('GroupInlineEditor — compose 모드', () => {
+  it('조가 없으면 1조를 만들어 두고, 빈 조 상태에서는 저장을 막는다', () => {
+    renderCompose();
+
+    expect(screen.getByRole('button', { name: /1조/ })).toBeInTheDocument();
+    expect(screen.getByText('멤버 필요')).toBeInTheDocument();
+    expect(screen.getByText('멤버가 없는 조가 있습니다')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '저장하기' })).toBeDisabled();
+  });
+
+  it('멤버를 클릭해 넣고 조장을 지정하면 저장 payload를 만든다', () => {
+    const { onSave } = renderCompose();
+
+    // 멤버 추가 시트에서 클릭으로 배정
+    fireEvent.click(screen.getByRole('button', { name: /멤버 추가/ }));
+    const sheet = screen.getByRole('dialog');
+    fireEvent.click(within(sheet).getByText('김민수'));
+    fireEvent.click(within(sheet).getByRole('button', { name: '1명 추가' }));
+
+    // 조장이 없으면 아직 저장 불가
+    expect(screen.getByText('조장을 지정해주세요')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '저장하기' })).toBeDisabled();
+
+    // 멤버 칩 → 조장 지정
+    fireEvent.click(screen.getByRole('button', { name: '김민수' }));
+    fireEvent.click(screen.getByRole('button', { name: '조장 지정' }));
+
+    const save = screen.getByRole('button', { name: '저장하기' });
+    expect(save).toBeEnabled();
+    fireEvent.click(save);
+
+    expect(onSave).toHaveBeenCalledWith([
+      { name: '1조', display_order: 1, members: [{ member_id: 1, is_leader: true }] },
+    ]);
+  });
+
+  it('조에 들어간 멤버는 추가 시트 후보에서 빠진다', () => {
+    renderCompose();
+
+    fireEvent.click(screen.getByRole('button', { name: /멤버 추가/ }));
+    const first = screen.getByRole('dialog');
+    fireEvent.click(within(first).getByText('김민수'));
+    fireEvent.click(within(first).getByRole('button', { name: '1명 추가' }));
+
+    fireEvent.click(screen.getByRole('button', { name: /멤버 추가/ }));
+    const second = screen.getByRole('dialog');
+    // 시트 후보에는 박지현만 남는다 (김민수는 이미 조에 들어갔다)
+    expect(within(second).queryByText('김민수')).not.toBeInTheDocument();
+    expect(within(second).getByText('박지현')).toBeInTheDocument();
+  });
+});

--- a/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
@@ -8,10 +8,12 @@ import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Button from '@/_components/ui/Button';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import { useGroups } from '@/_lib/hooks/useGroups';
-import type { GroupInput, Group } from '@/_types/team';
+import { useTeamMembers } from '@/_lib/hooks/useTeam';
+import type { GroupInput, Group, TeamRole } from '@/_types/team';
 
 import EditableGroupName from './EditableGroupName';
 import MemberActionBar from './MemberActionBar';
+import MemberPickerSheet, { type PickableMember } from './MemberPickerSheet';
 import MoveTargetSheet from './MoveTargetSheet';
 
 // ── Editable types ──────────────────────────────────────────────
@@ -71,6 +73,11 @@ function toUnassigned(
 interface GroupInlineEditorProps {
   teamId: number;
   groupSetId?: number;
+  /**
+   * edit    — 기존 편성을 고친다 (변경사항이 있어야 저장)
+   * compose — 빈 상태에서 새로 편성한다 (첫 조를 자동으로 하나 만들어 준다)
+   */
+  mode?: 'edit' | 'compose';
   onSave: (groups: GroupInput[]) => void;
   onBack: () => void;
   isSaving: boolean;
@@ -79,11 +86,15 @@ interface GroupInlineEditorProps {
 export default function GroupInlineEditor({
   teamId,
   groupSetId,
+  mode = 'edit',
   onSave,
   onBack,
   isSaving,
 }: GroupInlineEditorProps) {
   const { data, isLoading } = useGroups(teamId, groupSetId);
+  // 프로필 사진·역할은 조 API가 주지 않으므로 팀 멤버 목록에서 가져와 합친다
+  const { data: teamMembersData } = useTeamMembers(teamId);
+  const isCompose = mode === 'compose';
 
   // Editable state — initialised once when data arrives
   const [groups, setGroups] = useState<EditableGroup[]>([]);
@@ -92,25 +103,48 @@ export default function GroupInlineEditor({
 
   useEffect(() => {
     if (data && !initialized) {
-      setGroups(groupsToEditable(data.groups));
+      const editable = groupsToEditable(data.groups);
+      setGroups(isCompose && editable.length === 0 ? [{ name: '1조', members: [] }] : editable);
       setUnassigned(toUnassigned(data.unassigned_members));
       setInitialized(true);
     }
-  }, [data, initialized]);
+  }, [data, initialized, isCompose]);
 
   // UI state
   const [selectedMember, setSelectedMember] = useState<SelectedMember | null>(null);
   const [showMoveSheet, setShowMoveSheet] = useState(false);
   const [showAddSheet, setShowAddSheet] = useState<number | null>(null);
-  const [addSelections, setAddSelections] = useState<Set<number>>(new Set());
+  const [assignTarget, setAssignTarget] = useState<EditableMember | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<number | null>(null);
   const [showUnsavedConfirm, setShowUnsavedConfirm] = useState(false);
+
+  // member_id -> 프로필 사진·역할
+  const memberMeta = useMemo(() => {
+    const map = new Map<number, { profile_image: string | null; role: TeamRole }>();
+    for (const m of teamMembersData?.members ?? []) {
+      map.set(m.id, { profile_image: m.profile_image, role: m.role });
+    }
+    return map;
+  }, [teamMembersData]);
+
+  const pickableUnassigned: PickableMember[] = useMemo(
+    () =>
+      unassigned.map((m) => ({
+        member_id: m.member_id,
+        nickname: m.nickname,
+        profile_image: memberMeta.get(m.member_id)?.profile_image,
+        role: memberMeta.get(m.member_id)?.role,
+      })),
+    [unassigned, memberMeta],
+  );
 
   // ── Validation ──────────────────────────────────────────────
 
   const groupsMissingLeader = groups.filter(
     (g) => g.members.length > 0 && !g.members.some((m) => m.is_leader),
   );
+  // 백엔드는 멤버 0명인 조도 "조장 최소 1명" 검사에 걸려 400을 낸다 — 저장 전에 막는다
+  const emptyGroups = groups.filter((g) => g.members.length === 0);
 
   const hasChanges = useMemo(() => {
     if (!data) return false;
@@ -130,7 +164,20 @@ export default function GroupInlineEditor({
     return false;
   }, [groups, unassigned, data]);
 
-  const canSave = groupsMissingLeader.length === 0 && hasChanges;
+  const canSave =
+    groupsMissingLeader.length === 0 &&
+    emptyGroups.length === 0 &&
+    groups.length > 0 &&
+    (isCompose || hasChanges);
+
+  const blockReason =
+    groups.length === 0
+      ? '조를 하나 이상 만들어주세요'
+      : emptyGroups.length > 0
+      ? '멤버가 없는 조가 있습니다'
+      : groupsMissingLeader.length > 0
+      ? '조장을 지정해주세요'
+      : null;
 
   // ── Group operations ────────────────────────────────────────
 
@@ -206,18 +253,29 @@ export default function GroupInlineEditor({
     setSelectedMember(null);
   };
 
-  const handleAddMembers = (groupIdx: number) => {
-    const selectedIds = Array.from(addSelections);
-    const membersToAdd = unassigned.filter((m) => selectedIds.includes(m.member_id));
+  const handleAddMembers = (groupIdx: number, memberIds: number[]) => {
+    const membersToAdd = unassigned.filter((m) => memberIds.includes(m.member_id));
     setGroups((prev) =>
       prev.map((g, gi) => {
         if (gi !== groupIdx) return g;
         return { ...g, members: [...g.members, ...membersToAdd] };
       }),
     );
-    setUnassigned((prev) => prev.filter((m) => !selectedIds.includes(m.member_id)));
+    setUnassigned((prev) => prev.filter((m) => !memberIds.includes(m.member_id)));
     setShowAddSheet(null);
-    setAddSelections(new Set());
+  };
+
+  /** 미배정 칩 → 조 선택 → 그 조에 넣기 */
+  const handleAssignUnassigned = (targetGroupIdx: number) => {
+    if (!assignTarget) return;
+    const member = { ...assignTarget, is_leader: false };
+    setGroups((prev) =>
+      prev.map((g, gi) =>
+        gi === targetGroupIdx ? { ...g, members: [...g.members, member] } : g,
+      ),
+    );
+    setUnassigned((prev) => prev.filter((m) => m.member_id !== member.member_id));
+    setAssignTarget(null);
   };
 
   const handleBack = () => {
@@ -254,9 +312,13 @@ export default function GroupInlineEditor({
       >
         {/* Header */}
         <div>
-          <h3 className="text-sm font-bold text-gray-800">조 편성 수정</h3>
+          <h3 className="text-sm font-bold text-gray-800">
+            {isCompose ? '직접 조 편성' : '조 편성 수정'}
+          </h3>
           <p className="text-[11px] text-gray-400 mt-0.5">
-            멤버를 눌러 이동하거나 조장을 변경할 수 있습니다
+            {isCompose
+              ? '조를 만들고 멤버를 눌러 넣어보세요'
+              : '멤버를 눌러 이동하거나 조장을 변경할 수 있습니다'}
           </p>
         </div>
 
@@ -272,13 +334,14 @@ export default function GroupInlineEditor({
 
         {/* Group cards */}
         {groups.map((group, gIdx) => {
-          const hasLeader =
-            group.members.length === 0 || group.members.some((m) => m.is_leader);
+          const isEmpty = group.members.length === 0;
+          const hasLeader = isEmpty || group.members.some((m) => m.is_leader);
+          const isValid = !isEmpty && hasLeader;
           return (
             <div
               key={gIdx}
               className={`rounded-xl border p-4 ${
-                hasLeader ? 'border-gray-200' : 'border-red-200 bg-red-50/30'
+                isValid ? 'border-gray-200' : 'border-red-200 bg-red-50/30'
               }`}
             >
               <div className="flex items-center justify-between mb-2">
@@ -287,8 +350,10 @@ export default function GroupInlineEditor({
                   onChange={(v) => handleRenameGroup(gIdx, v)}
                 />
                 <div className="flex items-center gap-2">
-                  {!hasLeader && (
-                    <span className="text-[11px] text-red-400">조장 필요</span>
+                  {isEmpty ? (
+                    <span className="text-[11px] text-red-400">멤버 필요</span>
+                  ) : (
+                    !hasLeader && <span className="text-[11px] text-red-400">조장 필요</span>
                   )}
                   <button
                     type="button"
@@ -331,19 +396,14 @@ export default function GroupInlineEditor({
               </div>
 
               {/* Add member to this group */}
-              {unassigned.length > 0 && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowAddSheet(gIdx);
-                    setAddSelections(new Set());
-                  }}
-                  className="mt-2 text-xs font-medium text-gray-400 hover:text-gray-600 transition-colors"
-                >
-                  <FiPlus className="inline mr-0.5" size={12} />
-                  멤버 추가
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => setShowAddSheet(gIdx)}
+                className="mt-2 text-xs font-medium text-gray-400 hover:text-gray-600 transition-colors"
+              >
+                <FiPlus className="inline mr-0.5" size={12} />
+                멤버 추가
+              </button>
             </div>
           );
         })}
@@ -351,15 +411,23 @@ export default function GroupInlineEditor({
         {/* Unassigned members */}
         {unassigned.length > 0 && (
           <div className="rounded-xl border border-dashed border-gray-300 p-4">
-            <h4 className="text-xs font-medium text-gray-500 mb-2">미배정 멤버</h4>
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-xs font-medium text-gray-500">미배정 멤버</h4>
+              {groups.length > 0 && (
+                <span className="text-[11px] text-gray-400">눌러서 조에 배정</span>
+              )}
+            </div>
             <div className="flex flex-wrap gap-1.5">
               {unassigned.map((m) => (
-                <span
+                <button
                   key={m.member_id}
-                  className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500"
+                  type="button"
+                  disabled={groups.length === 0}
+                  onClick={() => setAssignTarget(m)}
+                  className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500 transition-all hover:bg-gray-100 hover:text-gray-700 active:scale-95 disabled:cursor-default disabled:hover:bg-gray-50 disabled:hover:text-gray-500"
                 >
                   {m.nickname}
-                </span>
+                </button>
               ))}
             </div>
           </div>
@@ -377,19 +445,24 @@ export default function GroupInlineEditor({
           onClose={() => setSelectedMember(null)}
         />
       ) : (
-        <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100 flex gap-2">
-          <Button variant="secondary" size="md" onClick={handleBack} className="flex-1">
-            돌아가기
-          </Button>
-          <Button
-            variant="primary"
-            size="md"
-            onClick={() => onSave(editableToGroupInputs(groups))}
-            disabled={isSaving || !canSave}
-            className="flex-1"
-          >
-            {isSaving ? '저장 중...' : '저장하기'}
-          </Button>
+        <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+          {blockReason && (
+            <p className="mb-2 text-center text-[11px] text-red-400">{blockReason}</p>
+          )}
+          <div className="flex gap-2">
+            <Button variant="secondary" size="md" onClick={handleBack} className="flex-1">
+              돌아가기
+            </Button>
+            <Button
+              variant="primary"
+              size="md"
+              onClick={() => onSave(editableToGroupInputs(groups))}
+              disabled={isSaving || !canSave}
+              className="flex-1"
+            >
+              {isSaving ? '저장 중...' : '저장하기'}
+            </Button>
+          </div>
         </div>
       )}
 
@@ -406,72 +479,24 @@ export default function GroupInlineEditor({
         />
       )}
 
-      {/* Add members sheet */}
+      {/* Add members sheet — 카톡 초대식 다중 선택 */}
       {showAddSheet !== null && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40"
-          onClick={() => setShowAddSheet(null)}
-        >
-          <div
-            className="w-[80%] max-w-xs rounded-2xl bg-white p-5 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <p className="text-center text-base font-semibold text-gray-900 mb-3">
-              {groups[showAddSheet]?.name}에 추가할 멤버 선택
-            </p>
-            <div className="space-y-2 max-h-60 overflow-y-auto">
-              {unassigned.map((m) => (
-                <button
-                  key={m.member_id}
-                  type="button"
-                  onClick={() => {
-                    setAddSelections((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(m.member_id)) next.delete(m.member_id);
-                      else next.add(m.member_id);
-                      return next;
-                    });
-                  }}
-                  className={`w-full text-left rounded-xl border p-3 transition-colors ${
-                    addSelections.has(m.member_id)
-                      ? 'border-gray-900 bg-gray-50'
-                      : 'border-gray-200 hover:border-gray-300'
-                  }`}
-                >
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`w-4 h-4 rounded border flex items-center justify-center text-xs ${
-                        addSelections.has(m.member_id)
-                          ? 'bg-gray-900 border-gray-900 text-white'
-                          : 'border-gray-300'
-                      }`}
-                    >
-                      {addSelections.has(m.member_id) && '✓'}
-                    </span>
-                    <span className="text-sm font-medium text-gray-700">{m.nickname}</span>
-                  </div>
-                </button>
-              ))}
-            </div>
-            <div className="mt-4 flex gap-2">
-              <button
-                type="button"
-                onClick={() => setShowAddSheet(null)}
-                className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 active:scale-95 transition-all"
-              >
-                취소
-              </button>
-              <button
-                type="button"
-                onClick={() => handleAddMembers(showAddSheet)}
-                disabled={addSelections.size === 0}
-                className="flex-1 rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white hover:bg-gray-800 active:scale-95 transition-all disabled:opacity-50"
-              >
-                추가
-              </button>
-            </div>
-          </div>
-        </div>
+        <MemberPickerSheet
+          title={`${groups[showAddSheet]?.name}에 추가할 멤버`}
+          members={pickableUnassigned}
+          onConfirm={(memberIds) => handleAddMembers(showAddSheet, memberIds)}
+          onCancel={() => setShowAddSheet(null)}
+        />
+      )}
+
+      {/* 미배정 멤버를 조에 배정 */}
+      {assignTarget && (
+        <MoveTargetSheet
+          memberNickname={assignTarget.nickname}
+          groups={groups.map((g) => ({ name: g.name, isCurrent: false }))}
+          onSelect={handleAssignUnassigned}
+          onCancel={() => setAssignTarget(null)}
+        />
       )}
 
       {/* Delete group confirm */}

--- a/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
@@ -58,6 +58,13 @@ function editableToGroupInputs(groups: EditableGroup[]): GroupInput[] {
   }));
 }
 
+/** 기본 이름("N조")인 조만 순서대로 다시 번호를 매긴다 — 직접 지은 이름은 건드리지 않는다 */
+function renumberDefaultNames(groups: EditableGroup[]): EditableGroup[] {
+  return groups.map((g, idx) =>
+    /^\d+조$/.test(g.name) ? { ...g, name: `${idx + 1}조` } : g,
+  );
+}
+
 function toUnassigned(
   members: { member_id: number; nickname: string }[],
 ): EditableMember[] {
@@ -189,7 +196,7 @@ export default function GroupInlineEditor({
   const handleDeleteGroup = (groupIdx: number) => {
     const removed = groups[groupIdx];
     setUnassigned((u) => [...u, ...removed.members.map((m) => ({ ...m, is_leader: false }))]);
-    setGroups((prev) => prev.filter((_, i) => i !== groupIdx));
+    setGroups((prev) => renumberDefaultNames(prev.filter((_, i) => i !== groupIdx)));
     setShowDeleteConfirm(null);
     setSelectedMember(null);
   };
@@ -358,6 +365,7 @@ export default function GroupInlineEditor({
                   <button
                     type="button"
                     onClick={() => setShowDeleteConfirm(gIdx)}
+                    aria-label={`${group.name} 삭제`}
                     className="p-1 text-gray-300 hover:text-red-400 transition-colors"
                   >
                     <FiTrash2 size={14} />

--- a/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupInlineEditor.tsx
@@ -308,7 +308,7 @@ export default function GroupInlineEditor({
     <div className="flex flex-col h-full">
       <div
         className="flex-1 overflow-y-auto px-4 py-4 space-y-4"
-        style={{ paddingBottom: selectedMember ? 80 : undefined }}
+        style={{ paddingBottom: selectedMember ? 96 : undefined }}
       >
         {/* Header */}
         <div>

--- a/app/(main)/chinba/_components/team/groups/GroupTextInput.tsx
+++ b/app/(main)/chinba/_components/team/groups/GroupTextInput.tsx
@@ -31,11 +31,20 @@ export default function GroupTextInput({ onParse, isParsing, onBack }: GroupText
         />
       </div>
 
-      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100">
+      <div className="shrink-0 px-4 py-3 pb-safe border-t border-gray-100 flex gap-2">
+        {onBack && (
+          <button
+            onClick={onBack}
+            disabled={isParsing}
+            className="flex-1 rounded-lg border border-gray-200 px-6 py-3 text-base font-semibold text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+          >
+            돌아가기
+          </button>
+        )}
         <button
           onClick={() => onParse(text)}
           disabled={!text.trim() || isParsing}
-          className="w-full rounded-lg bg-gray-900 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-gray-800 disabled:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+          className="flex-1 rounded-lg bg-gray-900 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-gray-800 disabled:bg-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {isParsing ? (
             <span className="flex items-center justify-center gap-2">

--- a/app/(main)/chinba/_components/team/groups/MemberActionBar.tsx
+++ b/app/(main)/chinba/_components/team/groups/MemberActionBar.tsx
@@ -17,8 +17,9 @@ export default function MemberActionBar({
   onUnassign,
   onClose,
 }: MemberActionBarProps) {
+  // 바닥에 붙으면 잘 안 보여서 safe-area 위로 12px 더 띄운 카드형 바
   return (
-    <div className="shrink-0 border-t border-gray-200 bg-white px-4 py-3 pb-safe">
+    <div className="shrink-0 mx-3 mb-[calc(env(safe-area-inset-bottom)+0.75rem)] rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-lg">
       <div className="flex items-center justify-between mb-2">
         <span className="text-sm font-medium text-gray-800">{nickname}</span>
         <button

--- a/app/(main)/chinba/_components/team/groups/MemberPickerSheet.test.tsx
+++ b/app/(main)/chinba/_components/team/groups/MemberPickerSheet.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import MemberPickerSheet, { type PickableMember } from './MemberPickerSheet';
+
+const MEMBERS: PickableMember[] = [
+  { member_id: 1, nickname: '김민수', role: 'captain' },
+  { member_id: 2, nickname: '박지현', role: 'member' },
+  { member_id: 3, nickname: '이태호', role: 'executive' },
+];
+
+function setup(members: PickableMember[] = MEMBERS) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <MemberPickerSheet
+      title="1조에 추가할 멤버"
+      members={members}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />,
+  );
+  return { onConfirm, onCancel };
+}
+
+describe('MemberPickerSheet', () => {
+  it('선택한 멤버의 member_id만 확인 시 전달한다', () => {
+    const { onConfirm } = setup();
+
+    fireEvent.click(screen.getByText('김민수'));
+    fireEvent.click(screen.getByText('이태호'));
+    fireEvent.click(screen.getByRole('button', { name: '2명 추가' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0].sort()).toEqual([1, 3]);
+  });
+
+  it('다시 누르면 선택이 해제된다', () => {
+    const { onConfirm } = setup();
+
+    fireEvent.click(screen.getByText('김민수'));
+    fireEvent.click(screen.getByText('김민수'));
+
+    const confirm = screen.getByRole('button', { name: '추가' });
+    expect(confirm).toBeDisabled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('검색어로 닉네임을 걸러내되 이미 선택한 멤버는 유지한다', () => {
+    const { onConfirm } = setup();
+
+    fireEvent.click(screen.getByText('김민수'));
+    fireEvent.change(screen.getByLabelText('이름 검색'), { target: { value: '태호' } });
+
+    expect(screen.queryByText('김민수')).not.toBeInTheDocument();
+    expect(screen.getByText('이태호')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('이태호'));
+    fireEvent.click(screen.getByRole('button', { name: '2명 추가' }));
+
+    expect(onConfirm.mock.calls[0][0].sort()).toEqual([1, 3]);
+  });
+
+  it('검색 결과가 없으면 안내를 보여준다', () => {
+    setup();
+
+    fireEvent.change(screen.getByLabelText('이름 검색'), { target: { value: '없는이름' } });
+
+    expect(screen.getByText('검색 결과가 없습니다')).toBeInTheDocument();
+  });
+
+  it('후보가 없으면 빈 상태를 보여주고 검색창을 숨긴다', () => {
+    setup([]);
+
+    expect(screen.getByText('추가할 멤버가 없습니다')).toBeInTheDocument();
+    expect(screen.queryByLabelText('이름 검색')).not.toBeInTheDocument();
+  });
+
+  it('취소를 누르면 onCancel이 호출된다', () => {
+    const { onCancel, onConfirm } = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: '취소' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/app/(main)/chinba/_components/team/groups/MemberPickerSheet.tsx
+++ b/app/(main)/chinba/_components/team/groups/MemberPickerSheet.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { FiSearch, FiUser } from 'react-icons/fi';
+
+import type { TeamRole } from '@/_types/team';
+
+export interface PickableMember {
+  member_id: number;
+  nickname: string;
+  profile_image?: string | null;
+  role?: TeamRole;
+}
+
+const ROLE_LABELS: Partial<Record<TeamRole, string>> = {
+  captain: '회장',
+  executive: '운영진',
+};
+
+interface MemberPickerSheetProps {
+  title: string;
+  members: PickableMember[];
+  onConfirm: (memberIds: number[]) => void;
+  onCancel: () => void;
+}
+
+/**
+ * 멤버를 눌러서 고르는 다중 선택 시트 (카톡 초대 화면 대응).
+ * 오버레이 z-[60] — FullPageModal 안에서 열려도 위로 올라온다.
+ */
+export default function MemberPickerSheet({
+  title,
+  members,
+  onConfirm,
+  onCancel,
+}: MemberPickerSheetProps) {
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return members;
+    return members.filter((m) => m.nickname.toLowerCase().includes(q));
+  }, [members, query]);
+
+  const toggle = (memberId: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(memberId)) next.delete(memberId);
+      else next.add(memberId);
+      return next;
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="flex max-h-[70vh] w-full max-w-xs flex-col overflow-hidden rounded-2xl bg-white p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="mb-3 text-center text-base font-semibold text-gray-900">{title}</p>
+
+        {members.length > 0 && (
+          <div className="relative mb-3">
+            <FiSearch size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-300" />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="이름 검색"
+              aria-label="이름 검색"
+              className="w-full rounded-xl border border-gray-200 py-2.5 pl-9 pr-3 text-sm text-gray-800 outline-none transition-colors focus:border-gray-900"
+            />
+          </div>
+        )}
+
+        <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
+          {members.length === 0 ? (
+            <p className="py-10 text-center text-sm text-gray-400">추가할 멤버가 없습니다</p>
+          ) : filtered.length === 0 ? (
+            <p className="py-10 text-center text-sm text-gray-400">검색 결과가 없습니다</p>
+          ) : (
+            filtered.map((m) => {
+              const isSelected = selected.has(m.member_id);
+              const roleLabel = m.role ? ROLE_LABELS[m.role] : undefined;
+              return (
+                <button
+                  key={m.member_id}
+                  type="button"
+                  onClick={() => toggle(m.member_id)}
+                  aria-pressed={isSelected}
+                  className={`flex w-full items-center gap-3 rounded-xl border p-2.5 text-left transition-colors ${
+                    isSelected ? 'border-gray-900 bg-gray-50' : 'border-gray-200 hover:border-gray-300'
+                  }`}
+                >
+                  <span
+                    className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border text-xs ${
+                      isSelected ? 'border-gray-900 bg-gray-900 text-white' : 'border-gray-300'
+                    }`}
+                  >
+                    {isSelected && '✓'}
+                  </span>
+
+                  {m.profile_image ? (
+                    <img
+                      src={m.profile_image}
+                      alt=""
+                      className="h-8 w-8 shrink-0 rounded-full border border-gray-100 object-cover"
+                    />
+                  ) : (
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-400">
+                      <FiUser size={14} />
+                    </span>
+                  )}
+
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium text-gray-700">
+                    {m.nickname}
+                  </span>
+
+                  {roleLabel && (
+                    <span className="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500">
+                      {roleLabel}
+                    </span>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <div className="mt-4 flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 transition-all hover:bg-gray-50 active:scale-95"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(Array.from(selected))}
+            disabled={selected.size === 0}
+            className="flex-1 rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-all hover:bg-gray-800 active:scale-95 disabled:opacity-50"
+          >
+            {selected.size > 0 ? `${selected.size}명 추가` : '추가'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
1. 멤버 클릭 선택 경로
- 그룹세트 선택 뒤 편성 방식 단계 추가 — 직접 선택하기 / 텍스트 붙여넣기(AI)
- MemberPickerSheet 신규 — 카톡 초대식 다중 선택 시트(이름 검색, 프로필 사진, 역할 배지)
- GroupInlineEditor에 compose 모드 추가 — 조를 만들고 멤버를 눌러 배정, 미배정 칩 탭 배정
- 멤버 0명인 조는 저장 차단(백엔드가 빈 조에 400)

2. 멤버 액션 바가 바닥에 붙어 잘 안 보이던 문제 
- 조장 지정 / 이동 / 미배정으로 바를 카드형으로 바꾸고 바닥에서 12px 더 올림. 스크롤 하단 여백 80 → 96

3. 조 삭제 시 번호가 앞당겨지지 않던 문제 (5a733f8)
- 1~5조에서 4조를 지우면 1,2,3,5조로 번호가 비던 것을 재번호. 기본 이름(N조)만 대상 — 직접 지은 이름은 유지
- 삭제 버튼에 aria-label("2조 삭제") 추가