### PR TITLE
fix(chinba): 조 필터 활성 시 전체 대상 일정이 만나자 탭에서 사라지는 문제 수정

### DIFF
--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -72,7 +72,8 @@ export default function MannajaTab({
     }
     if (!selectedGroupIds && !selectedGroupId) return list;
     return list.filter((event) => {
-      if (event.target_groups.length === 0) return false;
+      // 대상 조 없음 = 전체 일정 → 모든 조에 해당하므로 필터와 무관하게 표시
+      if (event.target_groups.length === 0) return true;
       if (selectedGroupId) {
         return event.target_groups.some((g) => g.id === selectedGroupId);
       }
@@ -98,7 +99,6 @@ export default function MannajaTab({
   }, [events]);
 
   const hasGroups = groupSets.length > 0;
-  const isFilterActive = !!selectedSetId || !!selectedGroupId;
 
   if (isLoading) {
     return (
@@ -141,25 +141,21 @@ export default function MannajaTab({
       {hasGroups ? (
         /* 섹션 분리 레이아웃 */
         <>
-          {!isFilterActive && (
-            <>
-              <SectionHeader icon={FiUsers} label={terminology === 'club' ? '동아리 전체 일정' : '팀 전체 일정'} />
-              {teamWideEvents.length > 0 ? (
-                teamWideEvents.map((event) => (
-                  <EventCard
-                    key={event.event_id}
-                    event={event}
-                    groupSetNameMap={groupSetNameMap}
-                    onClick={() => openEvent(event.event_id)}
-                  />
-                ))
-              ) : (
-                <SectionEmptyState message={terminology === 'club' ? '동아리 전체 일정이 없습니다' : '팀 전체 일정이 없습니다'} />
-              )}
-            </>
+          <SectionHeader icon={FiUsers} label={terminology === 'club' ? '동아리 전체 일정' : '팀 전체 일정'} />
+          {teamWideEvents.length > 0 ? (
+            teamWideEvents.map((event) => (
+              <EventCard
+                key={event.event_id}
+                event={event}
+                groupSetNameMap={groupSetNameMap}
+                onClick={() => openEvent(event.event_id)}
+              />
+            ))
+          ) : (
+            <SectionEmptyState message={terminology === 'club' ? '동아리 전체 일정이 없습니다' : '팀 전체 일정이 없습니다'} />
           )}
 
-          {!isFilterActive && <SectionHeader icon={FiLayers} label="조별 일정" />}
+          <SectionHeader icon={FiLayers} label="조별 일정" />
           {groupEvents.length > 0 ? (
             groupEvents.map((event) => (
               <EventCard


### PR DESCRIPTION
## 🐛 증상

  동아리 상세 > 만나자 탭에서 **"동아리 친바 만들기"로 조 선택 없이(전체 대상) 만든 일정이 목록에 표시되지 않음**.
  같은 일정이 MY 탭 "내 할일"에는 정상적으로 표시됨 (MY 탭은 참가자 기준 API `/chinba/my-events`를 쓰고 조 필터가 없기 때문).

  ## 🔍 원인

  두 가지가 겹쳐서 발생:

  1. **조 세트 1개면 필터 자동 활성화** — `TeamDetailView.tsx`
     ```ts
     const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
     ```
     조 세트가 정확히 1개인 동아리는 사용자가 필터를 건드리지 않아도 세트 필터가 항상 걸린 상태가 됨.

  2. **필터가 전체 일정을 무조건 탈락시킴** — `MannajaTab.tsx`
     ```ts
     if (event.target_groups.length === 0) return false; // 전체 대상 일정 탈락
     ```
     게다가 필터 활성 시 "동아리 전체 일정" 섹션 자체가 `!isFilterActive` 조건으로 렌더링되지 않음.

  결과: **조 편성을 한 번이라도 한 동아리(= 세트 1개)에서는 전체 대상 일정이 만나자 탭에서 절대 보이지 않음.**

  ## 🔧 수정 내용 (`MannajaTab.tsx`)

  - 조 필터링에서 대상 조가 없는 일정(전체 일정)은 **모든 조에 해당하는 것으로 보고 통과**시킴 (`return false` → `return true`)
  - "동아리 전체 일정" / "조별 일정" 섹션을 필터 상태와 무관하게 **항상 렌더링** (`!isFilterActive` 가드 제거)
  - 미사용이 된 `isFilterActive` 변수 제거

  특정 조를 필터로 골라도 전체 일정은 그 조원에게도 해당되는 일정이므로, 필터 의미상으로도 이게 올바른 동작임.

  ## ⚠️  근본 문제: "조 세트" 개념이 사용자에게 안 보이는데 데이터에는 존재함

  이 버그의 배경에는 **조 세트(group set) ↔ 조(group) 혼동** 문제가 있음.

  - 데이터 구조는 `동아리 → 조 세트 → 조 → 멤버` 2층 구조 (`chinba_group_sets` / `chinba_groups` 별도 테이블). 초창기에 "활동별로 조편성 여러 벌"(친바용/스터디용 등)을 상정한 설계.
  - 그런데 현재 조 편성 플로우(`GroupManageView`)는 첫 화면에서 "새 그룹세트" 이름 입력을 **강제**하고, 이 화면이 사용자에게는 그냥 "조 편성 이름 짓기"로 읽힘. 즉 **세트를 만든 줄도 모른 채 세트가 1개 생김**.
  - 세트가 1개 생기는 순간 위의 자동 필터 조건이 걸리면서 이번 버그가 트리거됨. 사실상 조 편성한 모든 동아리에서 기본으로 발생하는 구조였음.
  - 현재 제품 방향(카테고리 + 조 이름으로 활동 구분)에서는 세트 계층이 사실상 흔적 기관.

  ### 후속 제안 (이 PR 범위 아님)

  - 조 편성 플로우에서 세트 이름 입력 스텝 제거, 팀당 기본 세트 자동 생성 (DB 스키마 변경 없이 가능)
  - 상세 화면 필터에서 세트 선택 UI 숨기고 조만 노출