### PR TITLE
feat(chinba): 동아리 설정에 회장 위임 UI 추가

### DIFF
--- a/app/(main)/chinba/_components/team/CaptainTransferSection.test.tsx
+++ b/app/(main)/chinba/_components/team/CaptainTransferSection.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useTransferCaptain } from '@/_lib/hooks/useTeam';
+import type { TeamMember } from '@/_types/team';
+
+import CaptainTransferSection from './CaptainTransferSection';
+
+vi.mock('@/_lib/hooks/useTeam', () => ({ useTransferCaptain: vi.fn() }));
+
+const showToast = vi.fn();
+vi.mock('@/_context/ToastContext', () => ({ useToast: () => ({ showToast }) }));
+
+const mutateAsync = vi.fn();
+const mockedUseTransferCaptain = vi.mocked(useTransferCaptain);
+
+const makeMember = (overrides: Partial<TeamMember>): TeamMember => ({
+  id: 1,
+  user_id: 1,
+  nickname: '멤버',
+  profile_image: null,
+  role: 'member',
+  group: null,
+  joined_at: '2026-01-01T00:00:00',
+  ...overrides,
+});
+
+const MEMBERS: TeamMember[] = [
+  makeMember({ id: 10, user_id: 100, nickname: '나회장', role: 'captain' }),
+  makeMember({ id: 11, user_id: 101, nickname: '김부회장', role: 'vice_captain' }),
+  makeMember({ id: 12, user_id: 102, nickname: '박부원', role: 'member' }),
+];
+
+const renderSection = (myRole: TeamMember['role'] = 'captain', members = MEMBERS) =>
+  render(<CaptainTransferSection teamId={1} members={members} myRole={myRole} />);
+
+describe('CaptainTransferSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockedUseTransferCaptain.mockReturnValue({ mutateAsync } as any);
+  });
+
+  it('회장에게만 노출된다', () => {
+    const { unmount } = renderSection('captain');
+    expect(screen.getByText('회장 위임하기')).toBeInTheDocument();
+    unmount();
+
+    renderSection('vice_captain');
+    expect(screen.queryByText('회장 위임하기')).not.toBeInTheDocument();
+  });
+
+  it('대상 목록에서 회장 본인은 제외된다', () => {
+    renderSection();
+    fireEvent.click(screen.getByText('회장 위임하기'));
+
+    expect(screen.getByText('김부회장')).toBeInTheDocument();
+    expect(screen.getByText('박부원')).toBeInTheDocument();
+    expect(screen.queryByText('나회장')).not.toBeInTheDocument();
+  });
+
+  it('대상을 고르면 운영진으로 강등된다는 경고와 함께 확인을 받는다', () => {
+    renderSection();
+    fireEvent.click(screen.getByText('회장 위임하기'));
+    fireEvent.click(screen.getByText('김부회장'));
+    fireEvent.click(screen.getByText('선택'));
+
+    expect(screen.getByText(/운영진이 되며/)).toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('확인하면 선택한 멤버의 member_id로 위임을 요청한다', async () => {
+    renderSection();
+    fireEvent.click(screen.getByText('회장 위임하기'));
+    fireEvent.click(screen.getByText('박부원'));
+    fireEvent.click(screen.getByText('선택'));
+    fireEvent.click(screen.getByText('위임'));
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({ new_captain_member_id: 12 }),
+    );
+  });
+
+  it('위임할 멤버가 없으면 버튼이 비활성화된다', () => {
+    renderSection('captain', [MEMBERS[0]]);
+    expect(screen.getByText('위임할 멤버가 없습니다')).toBeDisabled();
+  });
+});

--- a/app/(main)/chinba/_components/team/CaptainTransferSection.tsx
+++ b/app/(main)/chinba/_components/team/CaptainTransferSection.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+
+import ConfirmModal from '@/_components/ui/ConfirmModal';
+import { useToast } from '@/_context/ToastContext';
+import { useTransferCaptain } from '@/_lib/hooks/useTeam';
+import { canTransferCaptain } from '@/_lib/utils/teamPermissions';
+import type { TeamMember, TeamRole } from '@/_types/team';
+import MemberPickerSheet, { type PickableMember } from '@/(main)/chinba/_components/team/groups/MemberPickerSheet';
+
+interface CaptainTransferSectionProps {
+  teamId: number;
+  members: TeamMember[];
+  myRole: TeamRole;
+}
+
+/**
+ * 회장 위임 — 대상 선택 시트 → 확인 모달 2단계.
+ * 회장 전용(canTransferCaptain)이라 여기 보이는 role 'captain' 멤버는 곧 본인이며,
+ * 자기 자신에게는 위임할 수 없으므로 후보에서 제외한다.
+ */
+export default function CaptainTransferSection({
+  teamId,
+  members,
+  myRole,
+}: CaptainTransferSectionProps) {
+  const { showToast } = useToast();
+  const transferCaptain = useTransferCaptain(teamId);
+
+  const [showPicker, setShowPicker] = useState(false);
+  const [target, setTarget] = useState<TeamMember | null>(null);
+
+  if (!canTransferCaptain(myRole)) return null;
+
+  const candidates: PickableMember[] = members
+    .filter((m) => m.role !== 'captain')
+    .map((m) => ({
+      member_id: m.id,
+      nickname: m.nickname || '사용자',
+      profile_image: m.profile_image,
+      role: m.role,
+    }));
+
+  const handlePick = (memberIds: number[]) => {
+    const picked = members.find((m) => m.id === memberIds[0]);
+    if (!picked) return;
+    setShowPicker(false);
+    setTarget(picked);
+  };
+
+  const handleConfirm = async () => {
+    if (!target) return;
+    try {
+      await transferCaptain.mutateAsync({ new_captain_member_id: target.id });
+      showToast(`${target.nickname || '사용자'}님에게 회장을 위임했습니다`, 'success');
+    } catch (err: any) {
+      showToast(err.response?.data?.detail || '위임에 실패했습니다', 'error');
+    }
+    setTarget(null);
+  };
+
+  return (
+    <>
+      <section className="mb-6 pt-4 border-t border-gray-100">
+        <h2 className="text-sm font-bold text-gray-800 mb-1">회장 위임</h2>
+        <p className="mb-3 text-xs text-gray-400">
+          다른 멤버에게 회장을 넘깁니다. 위임하면 회원님은 운영진이 됩니다.
+        </p>
+        <button
+          onClick={() => setShowPicker(true)}
+          disabled={candidates.length === 0}
+          className="w-full rounded-xl border border-gray-200 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:opacity-50"
+        >
+          {candidates.length === 0 ? '위임할 멤버가 없습니다' : '회장 위임하기'}
+        </button>
+      </section>
+
+      {showPicker && (
+        <MemberPickerSheet
+          title="회장을 위임할 멤버"
+          members={candidates}
+          singleSelect
+          confirmLabel="선택"
+          onConfirm={handlePick}
+          onCancel={() => setShowPicker(false)}
+        />
+      )}
+
+      <ConfirmModal
+        isOpen={target !== null}
+        onConfirm={handleConfirm}
+        onCancel={() => setTarget(null)}
+        title="회장 위임"
+        confirmLabel="위임"
+        cancelLabel="취소"
+        variant="danger"
+      >
+        <p>
+          <span className="font-semibold text-gray-900">{target?.nickname || '사용자'}</span>
+          님에게 회장을 위임하시겠습니까?
+        </p>
+        <p className="mt-1 text-xs text-gray-400">
+          위임 후 회원님은 운영진이 되며, 되돌리려면 새 회장이 다시 위임해야 합니다.
+        </p>
+      </ConfirmModal>
+    </>
+  );
+}

--- a/app/(main)/chinba/_components/team/TeamSettingsView.tsx
+++ b/app/(main)/chinba/_components/team/TeamSettingsView.tsx
@@ -28,6 +28,7 @@ import {
 import type { TeamRole } from '@/_types/team';
 import InviteSection from '@/(main)/teams/_components/InviteSection';
 import MemberList from '@/(main)/teams/_components/MemberList';
+import CaptainTransferSection from '@/(main)/chinba/_components/team/CaptainTransferSection';
 import EventCategorySection from '@/(main)/chinba/_components/team/categories/EventCategorySection';
 import GroupSettingsSection from '@/(main)/chinba/_components/team/groups/GroupSettingsSection';
 import SubscriptionSection from '@/(main)/chinba/_components/team/SubscriptionSection';
@@ -310,6 +311,11 @@ export default function TeamSettingsView() {
           teamId={teamId}
           canManage={canEditTeam(myRole)}
         />
+
+        {/* Section 5: 회장 위임 */}
+        {!isEditing && (
+          <CaptainTransferSection teamId={teamId} members={members} myRole={myRole} />
+        )}
 
         {/* Section 6: 동아리 삭제 (Danger Zone) */}
         {canDeleteTeam(myRole) && !isEditing && (

--- a/app/(main)/chinba/_components/team/groups/MemberPickerSheet.test.tsx
+++ b/app/(main)/chinba/_components/team/groups/MemberPickerSheet.test.tsx
@@ -84,4 +84,24 @@ describe('MemberPickerSheet', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onConfirm).not.toHaveBeenCalled();
   });
+
+  it('singleSelect면 뒤에 고른 한 명만 남는다', () => {
+    const onConfirm = vi.fn();
+    render(
+      <MemberPickerSheet
+        title="회장을 위임할 멤버"
+        members={MEMBERS}
+        singleSelect
+        confirmLabel="선택"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('김민수'));
+    fireEvent.click(screen.getByText('박지현'));
+    fireEvent.click(screen.getByRole('button', { name: '선택' }));
+
+    expect(onConfirm).toHaveBeenCalledWith([2]);
+  });
 });

--- a/app/(main)/chinba/_components/team/groups/MemberPickerSheet.tsx
+++ b/app/(main)/chinba/_components/team/groups/MemberPickerSheet.tsx
@@ -24,10 +24,13 @@ interface MemberPickerSheetProps {
   members: PickableMember[];
   onConfirm: (memberIds: number[]) => void;
   onCancel: () => void;
+  singleSelect?: boolean;
+  confirmLabel?: string;
 }
 
 /**
  * 멤버를 눌러서 고르는 다중 선택 시트 (카톡 초대 화면 대응).
+ * singleSelect면 한 명만 고르는 라디오 동작 — 회장 위임처럼 대상이 하나인 경우.
  * 오버레이 z-[60] — FullPageModal 안에서 열려도 위로 올라온다.
  */
 export default function MemberPickerSheet({
@@ -35,6 +38,8 @@ export default function MemberPickerSheet({
   members,
   onConfirm,
   onCancel,
+  singleSelect = false,
+  confirmLabel,
 }: MemberPickerSheetProps) {
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<Set<number>>(new Set());
@@ -47,6 +52,9 @@ export default function MemberPickerSheet({
 
   const toggle = (memberId: number) => {
     setSelected((prev) => {
+      if (singleSelect) {
+        return prev.has(memberId) ? new Set<number>() : new Set([memberId]);
+      }
       const next = new Set(prev);
       if (next.has(memberId)) next.delete(memberId);
       else next.add(memberId);
@@ -102,9 +110,9 @@ export default function MemberPickerSheet({
                   }`}
                 >
                   <span
-                    className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border text-xs ${
-                      isSelected ? 'border-gray-900 bg-gray-900 text-white' : 'border-gray-300'
-                    }`}
+                    className={`flex h-4 w-4 shrink-0 items-center justify-center border text-xs ${
+                      singleSelect ? 'rounded-full' : 'rounded'
+                    } ${isSelected ? 'border-gray-900 bg-gray-900 text-white' : 'border-gray-300'}`}
                   >
                     {isSelected && '✓'}
                   </span>
@@ -150,7 +158,7 @@ export default function MemberPickerSheet({
             disabled={selected.size === 0}
             className="flex-1 rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-all hover:bg-gray-800 active:scale-95 disabled:opacity-50"
           >
-            {selected.size > 0 ? `${selected.size}명 추가` : '추가'}
+            {confirmLabel ?? (selected.size > 0 ? `${selected.size}명 추가` : '추가')}
           </button>
         </div>
       </div>


### PR DESCRIPTION
백엔드 captain-transfer 엔드포인트는 있었으나 호출할 화면이 없었다.
동아리 설정의 삭제(Danger Zone) 바로 위에 회장 전용 섹션을 두고,
멤버 선택 시트 → 확인 모달 2단계로 위임한다.

- 대상 후보에서 회장 본인 제외 (백엔드도 자기 위임을 400으로 거부)
- 확인 모달에 "위임 후 운영진이 됩니다"를 명시 — 백엔드 위임 스왑 동작
- MemberPickerSheet에 singleSelect·confirmLabel 옵션 추가 (기본 동작 불변)