### PR TITLE
fix(chinba): 구독 관리 버튼을 회장·부회장 전용으로 제한

### DIFF
--- a/app/(main)/chinba/_components/team/SubscriptionSection.test.tsx
+++ b/app/(main)/chinba/_components/team/SubscriptionSection.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useSubscription } from '@/_lib/hooks/useSubscription';
+
+import SubscriptionSection from './SubscriptionSection';
+
+vi.mock('@/_lib/hooks/useSubscription', () => ({
+  useSubscription: vi.fn(),
+  useCreateSubscription: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCancelSubscription: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/_context/ToastContext', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+
+const mockedUseSubscription = vi.mocked(useSubscription);
+
+const TIER = {
+  tier: 'standard',
+  tier_label: '스탠다드',
+  member_range: '1-40명',
+  monthly_price: 9900,
+  semester_price: 35000,
+  annual_price: 99000,
+};
+
+const subscriptionData = (status: string | null) => ({
+  status,
+  tier: 'standard',
+  tier_label: '스탠다드',
+  billing_cycle: status ? 'monthly' : null,
+  amount: status ? 9900 : null,
+  started_at: status ? '2026-07-01T00:00:00' : null,
+  expires_at: status ? '2026-08-01T00:00:00' : null,
+  member_count: 12,
+  available_tiers: [TIER],
+});
+
+const setSubscription = (status: string | null) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockedUseSubscription.mockReturnValue({ data: subscriptionData(status), isLoading: false } as any);
+};
+
+describe('SubscriptionSection 관리 권한', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('구독 중 + 관리 권한 없음 → 상태는 보이되 해지 버튼이 없다', () => {
+    setSubscription('active');
+    render(<SubscriptionSection teamId={1} canManage={false} />);
+
+    expect(screen.getByText('구독 중')).toBeInTheDocument();
+    expect(screen.queryByText('구독 해지')).not.toBeInTheDocument();
+  });
+
+  it('구독 중 + 관리 권한 있음 → 해지 버튼이 있다', () => {
+    setSubscription('active');
+    render(<SubscriptionSection teamId={1} canManage={true} />);
+
+    expect(screen.getByText('구독 해지')).toBeInTheDocument();
+  });
+
+  it('미구독 + 관리 권한 없음 → 섹션 자체가 렌더되지 않는다', () => {
+    setSubscription(null);
+    const { container } = render(<SubscriptionSection teamId={1} canManage={false} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('미구독 + 관리 권한 있음 → 구독하기 버튼이 있다', () => {
+    setSubscription(null);
+    render(<SubscriptionSection teamId={1} canManage={true} />);
+
+    expect(screen.getByText('구독하기')).toBeInTheDocument();
+  });
+
+  it('해지 예정 상태는 관리 권한이 없어도 계속 보인다', () => {
+    setSubscription('cancelled');
+    render(<SubscriptionSection teamId={1} canManage={false} />);
+
+    expect(screen.getByText('해지 예정')).toBeInTheDocument();
+    expect(screen.queryByText('구독 해지')).not.toBeInTheDocument();
+  });
+});

--- a/app/(main)/chinba/_components/team/SubscriptionSection.tsx
+++ b/app/(main)/chinba/_components/team/SubscriptionSection.tsx
@@ -72,6 +72,9 @@ export default function SubscriptionSection({ teamId, canManage }: SubscriptionS
 
   const isSubscribed = sub.status === 'active';
   const isCancelled = sub.status === 'cancelled';
+
+  // 관리 권한도 없고 구독도 없으면 보여줄 것이 없다 (요금제 안내만 남은 막다른 화면 방지)
+  if (!canManage && !isSubscribed && !isCancelled) return null;
   const statusInfo = STATUS_LABELS[sub.status ?? ''] ?? { label: '미구독', className: 'bg-gray-50 text-gray-400' };
 
   // 현재 멤버 수 기반으로 해당하는 티어 찾기

--- a/app/(main)/chinba/_components/team/TeamSettingsView.tsx
+++ b/app/(main)/chinba/_components/team/TeamSettingsView.tsx
@@ -23,6 +23,7 @@ import { getCategoryOptions } from '@/_lib/utils/teamDisplay';
 import {
   canEditTeam,
   canDeleteTeam,
+  canManageSubscription,
   canRegenerateInvitation,
 } from '@/_lib/utils/teamPermissions';
 import type { TeamRole } from '@/_types/team';
@@ -252,7 +253,7 @@ export default function TeamSettingsView() {
         {/* Section 2: 구독 관리 */}
         <SubscriptionSection
           teamId={teamId}
-          canManage={canEditTeam(myRole)}
+          canManage={canManageSubscription(myRole)}
         />
 
         {/* Section 3: Invite */}

--- a/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
+++ b/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
@@ -23,6 +23,7 @@ import { getCategoryOptions } from '@/_lib/utils/teamDisplay';
 import {
   canEditTeam,
   canDeleteTeam,
+  canManageSubscription,
   canRegenerateInvitation,
 } from '@/_lib/utils/teamPermissions';
 import type { TeamRole } from '@/_types/team';
@@ -330,7 +331,7 @@ export default function TeamSettingsClient() {
         {/* Section 5: 구독 관리 */}
         <SubscriptionSection
           teamId={teamId}
-          canManage={canEditTeam(myRole)}
+          canManage={canManageSubscription(myRole)}
         />
       </div>
 

--- a/app/_lib/utils/teamPermissions.test.ts
+++ b/app/_lib/utils/teamPermissions.test.ts
@@ -8,6 +8,7 @@ import {
   canViewInvitation,
   canRegenerateInvitation,
   canTransferCaptain,
+  canManageSubscription,
 } from './teamPermissions';
 
 describe('canEditTeam', () => {
@@ -191,5 +192,23 @@ describe('canTransferCaptain', () => {
 
   it('member cannot transfer captain', () => {
     expect(canTransferCaptain('member')).toBe(false);
+  });
+});
+
+describe('canManageSubscription', () => {
+  it('captain can manage subscription', () => {
+    expect(canManageSubscription('captain')).toBe(true);
+  });
+
+  it('vice_captain can manage subscription', () => {
+    expect(canManageSubscription('vice_captain')).toBe(true);
+  });
+
+  it('executive cannot manage subscription', () => {
+    expect(canManageSubscription('executive')).toBe(false);
+  });
+
+  it('member cannot manage subscription', () => {
+    expect(canManageSubscription('member')).toBe(false);
   });
 });

--- a/app/_lib/utils/teamPermissions.ts
+++ b/app/_lib/utils/teamPermissions.ts
@@ -33,3 +33,8 @@ export function canRegenerateInvitation(role: TeamRole): boolean {
 export function canTransferCaptain(role: TeamRole): boolean {
   return role === 'captain';
 }
+
+// 구독 생성·해지는 서버가 회장·부회장만 허용한다 (LEADER_ROLES)
+export function canManageSubscription(role: TeamRole): boolean {
+  return role === 'captain' || role === 'vice_captain';
+}


### PR DESCRIPTION
백엔드는 구독 생성·해지를 LEADER_ROLES(회장·부회장)로 막고 있는데 프론트는
canEditTeam(운영진 포함)으로 버튼을 노출해, 운영진이 누르면 403 "권한이 없습니다" 토스트만 뜨는 상태였다. canManageSubscription 술어를 신설해 두 설정 화면의 canManage를 백엔드 게이트와 일치시킨다.

미구독 상태에서 관리 권한이 없으면 요금제 안내만 남아 막다른 화면이 되므로
섹션 자체를 렌더하지 않는다. 구독 중인 팀의 운영진은 상태·금액·만료일은
계속 볼 수 있다 (백엔드 GET은 MANAGER_ROLES로 열려 있음).