### PR TITLE
feat(chinba): 일정 카테고리 UI 명칭을 해시태그로 변경

### DIFF
--- a/app/(main)/chinba/_components/team/TeamCategoriesModal.tsx
+++ b/app/(main)/chinba/_components/team/TeamCategoriesModal.tsx
@@ -14,13 +14,13 @@ interface TeamCategoriesModalProps {
   myRole: TeamRole;
 }
 
-/** 가운데 모달로 여는 카테고리 관리. 기존 EventCategorySection(전부 inline)을 재사용. */
+/** 가운데 모달로 여는 해시태그 관리. 기존 EventCategorySection(전부 inline)을 재사용. */
 export default function TeamCategoriesModal({ isOpen, onClose, teamId, myRole }: TeamCategoriesModalProps) {
   return (
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title="카테고리 관리"
+      title="해시태그 관리"
       titleIcon={<FiTag size={18} className="text-gray-500" />}
     >
       <EventCategorySection teamId={teamId} canManage={canEditTeam(myRole)} embedded />

--- a/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
@@ -97,7 +97,7 @@ export default function TeamEventCreateBody({
       setShowQuickAdd(false);
       setQuickAddError(null);
     } catch (err: any) {
-      setQuickAddError(err.response?.data?.detail || '카테고리 추가에 실패했습니다');
+      setQuickAddError(err.response?.data?.detail || '해시태그 추가에 실패했습니다');
     }
   };
 
@@ -182,7 +182,7 @@ export default function TeamEventCreateBody({
           {(categories.length > 0 || canManageCategory) && (
             <div className="mb-6">
               <label className="block text-sm font-bold text-gray-700 mb-2">
-                카테고리 <span className="text-xs font-normal text-gray-400">(선택)</span>
+                해시태그 <span className="text-xs font-normal text-gray-400">(선택)</span>
               </label>
               <div className="flex flex-wrap gap-2">
                 {categories.map((category) => {
@@ -198,7 +198,7 @@ export default function TeamEventCreateBody({
                           : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
                       }`}
                     >
-                      {category.name}
+                      #{category.name}
                     </button>
                   );
                 })}
@@ -209,7 +209,7 @@ export default function TeamEventCreateBody({
                     className="flex items-center gap-1 rounded-full border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-400 transition-colors hover:border-gray-400 hover:text-gray-500"
                   >
                     <FiPlus size={14} />
-                    카테고리 추가
+                    해시태그 추가
                   </button>
                 )}
               </div>
@@ -220,7 +220,7 @@ export default function TeamEventCreateBody({
                     value={quickAddName}
                     maxLength={30}
                     autoFocus
-                    placeholder="카테고리 이름"
+                    placeholder="해시태그 이름"
                     onChange={(e) => setQuickAddName(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') handleQuickAdd();

--- a/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
@@ -109,7 +109,7 @@ export default function TeamOpsPanel({
           <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">운영 도구</span>
           <PanelButton icon={FiUsers} label="멤버 관리" onClick={onOpenMembers} trailing="modal" />
           <PanelButton icon={FiGrid} label="조 / 그룹 관리" onClick={onOpenGroups} trailing="modal" />
-          <PanelButton icon={FiTag} label="카테고리 관리" onClick={onOpenCategories} trailing="modal" />
+          <PanelButton icon={FiTag} label="해시태그 관리" onClick={onOpenCategories} trailing="modal" />
           <PanelButton icon={FiLink} label="초대링크 복사" onClick={handleCopyInvite} trailing="copy" />
         </section>
 

--- a/app/(main)/chinba/_components/team/categories/EventCategorySection.tsx
+++ b/app/(main)/chinba/_components/team/categories/EventCategorySection.tsx
@@ -13,6 +13,7 @@ import {
   useDeleteEventCategory,
 } from '@/_lib/hooks/useCategories';
 
+// UI 용어는 '해시태그' — 코드·API 식별자는 event category 유지 (개명 범위: UI 문구만)
 interface EventCategorySectionProps {
   teamId: number;
   canManage: boolean;
@@ -44,11 +45,11 @@ export default function EventCategorySection({ teamId, canManage, embedded = fal
     }
     try {
       await createCategory.mutateAsync({ name: trimmed });
-      showToast('카테고리가 추가되었습니다', 'success');
+      showToast('해시태그가 추가되었습니다', 'success');
       setAddName('');
       setShowAdd(false);
     } catch (err: any) {
-      showToast(err.response?.data?.detail || '카테고리 추가에 실패했습니다', 'error');
+      showToast(err.response?.data?.detail || '해시태그 추가에 실패했습니다', 'error');
     }
   };
 
@@ -87,7 +88,7 @@ export default function EventCategorySection({ teamId, canManage, embedded = fal
     if (deleteConfirmId === null) return;
     try {
       await deleteCategoryMutation.mutateAsync(deleteConfirmId);
-      showToast('카테고리가 삭제되었습니다', 'success');
+      showToast('해시태그가 삭제되었습니다', 'success');
     } catch (err: any) {
       showToast(err.response?.data?.detail || '삭제에 실패했습니다', 'error');
     }
@@ -98,7 +99,7 @@ export default function EventCategorySection({ teamId, canManage, embedded = fal
     <section className={embedded ? 'p-4' : 'mb-6'}>
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          {!embedded && <h2 className="text-sm font-bold text-gray-800">일정 카테고리</h2>}
+          {!embedded && <h2 className="text-sm font-bold text-gray-800">해시태그</h2>}
           {categories.length > 0 && (
             <span className="text-xs text-gray-400">{categories.length}개</span>
           )}
@@ -123,7 +124,7 @@ export default function EventCategorySection({ teamId, canManage, embedded = fal
               onChange={(e) => setAddName(e.target.value)}
               maxLength={30}
               autoFocus
-              placeholder="카테고리 이름"
+              placeholder="해시태그 이름"
               className="flex-1 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-800 outline-none focus:border-gray-900 transition-colors"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleAdd();
@@ -148,13 +149,13 @@ export default function EventCategorySection({ teamId, canManage, embedded = fal
 
         {categories.length === 0 && !showAdd ? (
           <div className="flex flex-col items-center justify-center py-10">
-            <p className="text-sm text-gray-400 mb-3">아직 카테고리가 없습니다</p>
+            <p className="text-sm text-gray-400 mb-3">아직 해시태그가 없습니다</p>
             {canManage && (
               <button
                 onClick={() => setShowAdd(true)}
                 className="rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
               >
-                카테고리 추가
+                해시태그 추가
               </button>
             )}
           </div>
@@ -222,14 +223,14 @@ export default function EventCategorySection({ teamId, canManage, embedded = fal
         isOpen={deleteConfirmId !== null}
         onConfirm={handleDelete}
         onCancel={() => setDeleteConfirmId(null)}
-        title="카테고리 삭제"
+        title="해시태그 삭제"
         confirmLabel="삭제"
         cancelLabel="취소"
         variant="danger"
       >
-        <p>&ldquo;{deleteTarget?.name}&rdquo; 카테고리를 삭제하시겠습니까?</p>
+        <p>&ldquo;#{deleteTarget?.name}&rdquo; 해시태그를 삭제하시겠습니까?</p>
         <p className="mt-1 text-xs text-gray-400">
-          이 카테고리를 쓰는 일정·활동 기록에서는 카테고리만 해제되고 기록은 유지됩니다
+          이 해시태그를 쓰는 일정·활동 기록에서는 해시태그만 해제되고 기록은 유지됩니다
         </p>
       </ConfirmModal>
     </section>

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -287,7 +287,7 @@ export default function ActivityTab({
           {/* Category */}
           {categories.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-medium text-gray-500">카테고리 (선택)</p>
+              <p className="text-xs font-medium text-gray-500">해시태그 (선택)</p>
               <div className="flex flex-wrap gap-1.5">
                 {categories.map((category) => {
                   const isSelected = formData.category_id === category.id;
@@ -304,7 +304,7 @@ export default function ActivityTab({
                           : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
                       }`}
                     >
-                      {category.name}
+                      #{category.name}
                     </button>
                   );
                 })}


### PR DESCRIPTION
동아리 생성의 "카테고리"(동아리/학과/스터디 분류)와 용어가 겹쳐, 일정·활동을
묶는 쪽을 UI에서 "해시태그"로 부르기로 한 팀 결정 반영. 표시 배지 4곳이 이미
#{이름} 형태라 명칭과 정합하고, 이번에 선택 칩 2곳(일정 생성·활동기록 폼)에도
#를 붙여 통일했다.

코드 식별자·API 경로(/event-categories)·JSON 키·DB 테이블은 유지 — 개명 범위는 UI 문구만이라 breaking change가 없다 (경계 주석을 EventCategorySection에 명시).