### PR TITLE
Fix/heatmap colors

### DIFF
--- a/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
@@ -20,10 +20,6 @@ interface ChinbaHeatmapGridProps {
   totalParticipants: number;
 }
 
-// 전원 불가: red-500 바탕 + 회색 사선 빗금
-const FULL_UNAVAIL_BG =
-  'bg-[repeating-linear-gradient(45deg,#ef4444_0px,#ef4444_9px,#d1d5db_9px,#d1d5db_10px)]';
-
 function getHeatColor(unavailCount: number, total: number): string {
   if (total === 0) return 'bg-gray-50';
   if (unavailCount === 0) return 'bg-[#21a278]';
@@ -32,7 +28,7 @@ function getHeatColor(unavailCount: number, total: number): string {
   if (ratio <= 0.5) return 'bg-[#62c784]';
   if (ratio <= 0.75) return 'bg-[#a3ec8f]';
   if (ratio < 1) return 'bg-[#c4fe95]';
-  return FULL_UNAVAIL_BG;
+  return 'bg-red-500';
 }
 
 function getTextColor(unavailCount: number, total: number): string {
@@ -240,7 +236,7 @@ export default function ChinbaHeatmapGrid({
         <div className="w-4 h-3 rounded-sm bg-[#62c784]" />
         <div className="w-4 h-3 rounded-sm bg-[#a3ec8f]" />
         <div className="w-4 h-3 rounded-sm bg-[#c4fe95]" />
-        <div className={`w-4 h-3 rounded-sm ${FULL_UNAVAIL_BG}`} />
+        <div className="w-4 h-3 rounded-sm bg-red-500" />
         <span className="text-[10px] text-gray-400">불가</span>
       </div>
     </div>

--- a/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
@@ -20,23 +20,24 @@ interface ChinbaHeatmapGridProps {
   totalParticipants: number;
 }
 
+// 전원 불가: red-500 바탕 + 회색 사선 빗금
+const FULL_UNAVAIL_BG =
+  'bg-[repeating-linear-gradient(45deg,#ef4444_0px,#ef4444_9px,#d1d5db_9px,#d1d5db_10px)]';
+
 function getHeatColor(unavailCount: number, total: number): string {
   if (total === 0) return 'bg-gray-50';
-  if (unavailCount === 0) return 'bg-[#008f72]';
+  if (unavailCount === 0) return 'bg-[#21a278]';
   const ratio = unavailCount / total;
-  if (ratio <= 0.25) return 'bg-[#62c784]';
-  if (ratio <= 0.5) return 'bg-[#c4fe95]';
-  if (ratio <= 0.75) return 'bg-orange-100 ring-1 ring-inset ring-orange-300';
-  if (ratio < 1) return 'bg-red-200 ring-1 ring-inset ring-red-400';
-  return 'bg-red-400';
+  if (ratio <= 0.25) return 'bg-[#41b47e]';
+  if (ratio <= 0.5) return 'bg-[#62c784]';
+  if (ratio <= 0.75) return 'bg-[#a3ec8f]';
+  if (ratio < 1) return 'bg-[#c4fe95]';
+  return FULL_UNAVAIL_BG;
 }
 
 function getTextColor(unavailCount: number, total: number): string {
   if (total === 0) return 'text-gray-300';
-  if (unavailCount === 0) return 'text-white';
-  const ratio = unavailCount / total;
-  if (ratio < 1) return 'text-gray-800';
-  return 'text-white';
+  return 'text-gray-800';
 }
 
 export default function ChinbaHeatmapGrid({
@@ -234,12 +235,12 @@ export default function ChinbaHeatmapGrid({
       {/* Legend */}
       <div className="flex items-center justify-center gap-2 mt-3 px-2">
         <span className="text-[10px] text-gray-400">가능</span>
-        <div className="w-4 h-3 rounded-sm bg-[#008f72]" />
+        <div className="w-4 h-3 rounded-sm bg-[#21a278]" />
+        <div className="w-4 h-3 rounded-sm bg-[#41b47e]" />
         <div className="w-4 h-3 rounded-sm bg-[#62c784]" />
+        <div className="w-4 h-3 rounded-sm bg-[#a3ec8f]" />
         <div className="w-4 h-3 rounded-sm bg-[#c4fe95]" />
-        <div className="w-4 h-3 rounded-sm bg-orange-100 ring-1 ring-inset ring-orange-300" />
-        <div className="w-4 h-3 rounded-sm bg-red-200 ring-1 ring-inset ring-red-400" />
-        <div className="w-4 h-3 rounded-sm bg-red-400" />
+        <div className={`w-4 h-3 rounded-sm ${FULL_UNAVAIL_BG}`} />
         <span className="text-[10px] text-gray-400">불가</span>
       </div>
     </div>

--- a/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
@@ -22,20 +22,20 @@ interface ChinbaHeatmapGridProps {
 
 function getHeatColor(unavailCount: number, total: number): string {
   if (total === 0) return 'bg-gray-50';
-  if (unavailCount === 0) return 'bg-emerald-300';
+  if (unavailCount === 0) return 'bg-[#008f72]';
   const ratio = unavailCount / total;
-  if (ratio <= 0.25) return 'bg-emerald-200';
-  if (ratio <= 0.5) return 'bg-emerald-100';
-  if (ratio <= 0.75) return 'bg-red-300';
-  if (ratio < 1) return 'bg-red-500';
-  return 'bg-red-800';
+  if (ratio <= 0.25) return 'bg-[#62c784]';
+  if (ratio <= 0.5) return 'bg-[#c4fe95]';
+  if (ratio <= 0.75) return 'bg-orange-100 ring-1 ring-inset ring-orange-300';
+  if (ratio < 1) return 'bg-red-200 ring-1 ring-inset ring-red-400';
+  return 'bg-red-400';
 }
 
 function getTextColor(unavailCount: number, total: number): string {
   if (total === 0) return 'text-gray-300';
-  if (unavailCount === 0) return 'text-emerald-700';
+  if (unavailCount === 0) return 'text-white';
   const ratio = unavailCount / total;
-  if (ratio <= 0.5) return 'text-gray-700';
+  if (ratio < 1) return 'text-gray-800';
   return 'text-white';
 }
 
@@ -234,12 +234,12 @@ export default function ChinbaHeatmapGrid({
       {/* Legend */}
       <div className="flex items-center justify-center gap-2 mt-3 px-2">
         <span className="text-[10px] text-gray-400">가능</span>
-        <div className="w-4 h-3 rounded-sm bg-emerald-300" />
-        <div className="w-4 h-3 rounded-sm bg-emerald-200" />
-        <div className="w-4 h-3 rounded-sm bg-emerald-100" />
-        <div className="w-4 h-3 rounded-sm bg-red-300" />
-        <div className="w-4 h-3 rounded-sm bg-red-500" />
-        <div className="w-4 h-3 rounded-sm bg-red-800" />
+        <div className="w-4 h-3 rounded-sm bg-[#008f72]" />
+        <div className="w-4 h-3 rounded-sm bg-[#62c784]" />
+        <div className="w-4 h-3 rounded-sm bg-[#c4fe95]" />
+        <div className="w-4 h-3 rounded-sm bg-orange-100 ring-1 ring-inset ring-orange-300" />
+        <div className="w-4 h-3 rounded-sm bg-red-200 ring-1 ring-inset ring-red-400" />
+        <div className="w-4 h-3 rounded-sm bg-red-400" />
         <span className="text-[10px] text-gray-400">불가</span>
       </div>
     </div>


### PR DESCRIPTION
 ## 개요

  친바 "전체 일정 히트맵"의 색상 단계가 애매하고(초록 농도가 역방향), '전원 불가'의
  red-800이 과하게 짙어 보여 팔레트를 전면 조정했습니다.

  <!-- 관련 이슈가 있으면: Resolve #NN -->

  ## 변경 내용

  - 가능 구간을 emerald 3단계 → **그린 5단계**로 세분화
    - `#21a278 → #41b47e → #62c784 → #a3ec8f → #c4fe95` (가능 인원이 많을수록 진한 초록)
  - '전원 불가'는 `red-800` → **`red-500` 단색**으로 변경 (빨강은 이 한 단계만 사용)
  - 셀 숫자 텍스트를 전 구간 어두운 글자(`text-gray-800`)로 통일
    - 기존에 불가 비율 50% 초과 구간에서 흰 글자가 연한 배경(red-300)에 얹혀 대비 1.9:1로 안 보이던 문제 해소
  - 범례 스와치를 새 6단계에 맞게 갱신

  ## 변경 파일

  - `app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx` — `getHeatColor` / `getTextColor` / 범례