### PR TITLE
feat(chinba): 랭킹 탭 잠금 및 무료 안내 팝업 1회 노출로 변경

### DIFF
--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -22,11 +22,15 @@ import JababwaTab from '@/(main)/teams/detail/_components/JababwaTab';
 import MannajaTab from '@/(main)/teams/detail/_components/MannajaTab';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useToast } from '@/_context/ToastContext';
+import { CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import { useTeamDetail } from '@/_lib/hooks/useTeam';
+import { useUserStore } from '@/_lib/store/useUserStore';
 import { setLastTeamId } from '@/_lib/utils/chinbaSelection';
+import { hasSeenFreeNotice, markFreeNoticeSeen } from '@/_lib/utils/freeNotice';
 import { canEditTeam } from '@/_lib/utils/teamPermissions';
 import { DESKTOP_MEDIA_QUERY, isDesktopViewport } from '@/_lib/utils/viewport';
 import { useAuthInitialized } from '@/providers';
@@ -38,7 +42,10 @@ export default function TeamDetailView() {
 
   const teamId = Number(searchParams.get('id'));
   const tabParam = searchParams.get('tab') as TeamSegment | null;
-  const initialTab: TeamSegment = tabParam === 'mwoheni' || tabParam === 'jabahbwa' ? tabParam : 'mannaja';
+  const initialTab: TeamSegment =
+    tabParam === 'mwoheni' || (tabParam === 'jabahbwa' && CHINBA_RANKING_TAB_ENABLED)
+      ? tabParam
+      : 'mannaja';
 
   // 데스크톱 임베드 뷰 (?view=create | ?view=event&eventId=..) — 만들기/이벤트 상세를
   // 팀 상세 프레임(세그먼트 탭 + 운영 패널) 안에서 렌더한다. 모바일은 풀페이지 라우트 유지.
@@ -53,12 +60,18 @@ export default function TeamDetailView() {
     viewCategoryIdRaw && Number.isFinite(Number(viewCategoryIdRaw)) ? Number(viewCategoryIdRaw) : null;
 
   const isAuthReady = useAuthInitialized();
+  const { showToast } = useToast();
+  const user = useUserStore((state) => state.user);
   const { data: team, isLoading, isError } = useTeamDetail(teamId);
   const { data: groupSetsData } = useGroupSets(teamId || undefined);
   const [activeTab, setActiveTab] = useState<TeamSegment>(initialTab);
   const [showUpgrade, setShowUpgrade] = useState(false);
   const [pendingTab, setPendingTab] = useState<TeamSegment | null>(null);
   const [freeNoticeSeen, setFreeNoticeSeen] = useState(false);
+  // (사용자, 동아리)별 1회 노출 기억 — 클라이언트에서만 읽어 hydration mismatch 방지
+  useEffect(() => {
+    setFreeNoticeSeen(hasSeenFreeNotice(user?.id, teamId));
+  }, [user?.id, teamId]);
   const [selectedSetId, setSelectedSetId] = useState<number | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
@@ -130,7 +143,8 @@ export default function TeamDetailView() {
   // Sync tab state when URL changes (e.g. browser back/forward)
   useEffect(() => {
     const tab = searchParams.get('tab') as TeamSegment | null;
-    const resolved: TeamSegment = tab === 'mwoheni' || tab === 'jabahbwa' ? tab : 'mannaja';
+    const resolved: TeamSegment =
+      tab === 'mwoheni' || (tab === 'jabahbwa' && CHINBA_RANKING_TAB_ENABLED) ? tab : 'mannaja';
     if (resolved !== activeTab) {
       setActiveTab(resolved);
     }
@@ -147,6 +161,10 @@ export default function TeamDetailView() {
   };
 
   const handleTabChange = (tab: TeamSegment) => {
+    if (tab === 'jabahbwa' && !CHINBA_RANKING_TAB_ENABLED) {
+      showToast('추후 업데이트 예정입니다');
+      return;
+    }
     if (isPaidTab(tab) && needsSubscription && !freeNoticeSeen) {
       setPendingTab(tab);
       setShowUpgrade(true);
@@ -269,6 +287,7 @@ export default function TeamDetailView() {
         teamId={teamId}
         terminology="club"
         onConfirm={() => {
+          markFreeNoticeSeen(user?.id, teamId);
           setFreeNoticeSeen(true);
           if (pendingTab) goToTab(pendingTab);
           setPendingTab(null);

--- a/app/(main)/teams/detail/_components/TeamDetailClient.tsx
+++ b/app/(main)/teams/detail/_components/TeamDetailClient.tsx
@@ -7,10 +7,14 @@ import { FiSettings } from 'react-icons/fi';
 import { LuChevronLeft } from 'react-icons/lu';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useToast } from '@/_context/ToastContext';
+import { CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import { useTeamDetail } from '@/_lib/hooks/useTeam';
+import { useUserStore } from '@/_lib/store/useUserStore';
+import { hasSeenFreeNotice, markFreeNoticeSeen } from '@/_lib/utils/freeNotice';
 
 import CategoryFilterBar from '../../_components/CategoryFilterBar';
 import GroupFilterBar from '../../_components/GroupFilterBar';
@@ -29,11 +33,20 @@ export default function TeamDetailClient() {
   const { data: groupSetsData } = useGroupSets(teamId);
 
   const tabParam = searchParams.get('tab') as TeamSegment | null;
-  const initialTab: TeamSegment = tabParam === 'mwoheni' || tabParam === 'jabahbwa' ? tabParam : 'mannaja';
+  const initialTab: TeamSegment =
+    tabParam === 'mwoheni' || (tabParam === 'jabahbwa' && CHINBA_RANKING_TAB_ENABLED)
+      ? tabParam
+      : 'mannaja';
+  const { showToast } = useToast();
+  const user = useUserStore((state) => state.user);
   const [activeTab, setActiveTab] = useState<TeamSegment>(initialTab);
   const [showUpgrade, setShowUpgrade] = useState(false);
   const [pendingTab, setPendingTab] = useState<TeamSegment | null>(null);
   const [freeNoticeSeen, setFreeNoticeSeen] = useState(false);
+  // (사용자, 동아리)별 1회 노출 기억 — 클라이언트에서만 읽어 hydration mismatch 방지
+  useEffect(() => {
+    setFreeNoticeSeen(hasSeenFreeNotice(user?.id, teamId ?? 0));
+  }, [user?.id, teamId]);
   const [selectedSetId, setSelectedSetId] = useState<number | null>(null);
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
@@ -61,6 +74,10 @@ export default function TeamDetailClient() {
   const needsSubscription = team && !team.is_paid;
 
   const handleTabChange = (tab: TeamSegment) => {
+    if (tab === 'jabahbwa' && !CHINBA_RANKING_TAB_ENABLED) {
+      showToast('추후 업데이트 예정입니다');
+      return;
+    }
     if (isPaidTab(tab) && needsSubscription && !freeNoticeSeen) {
       setPendingTab(tab);
       setShowUpgrade(true);
@@ -170,6 +187,7 @@ export default function TeamDetailClient() {
           onClose={() => setShowUpgrade(false)}
           teamId={teamId}
           onConfirm={() => {
+            markFreeNoticeSeen(user?.id, teamId);
             setFreeNoticeSeen(true);
             if (pendingTab) setActiveTab(pendingTab);
             setPendingTab(null);

--- a/app/_lib/constants/features.ts
+++ b/app/_lib/constants/features.ts
@@ -13,3 +13,10 @@
  * 이미 기록된 점수 데이터는 그대로 살아 있고, '랭킹' 탭도 그대로 노출된다.
  */
 export const CHINBA_GROUP_SCORING_ENABLED: boolean = false;
+
+/**
+ * 팀 상세의 '랭킹'(잡아봐) 탭.
+ * 추후 업데이트로 재공개 예정(2026-07 결정) — 탭 버튼은 그대로 두되 진입을 막고
+ * "추후 업데이트 예정입니다" 안내만 띄운다. 백엔드 랭킹 API·데이터는 그대로 살아 있다.
+ */
+export const CHINBA_RANKING_TAB_ENABLED: boolean = false;

--- a/app/_lib/utils/freeNotice.test.ts
+++ b/app/_lib/utils/freeNotice.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { hasSeenFreeNotice, markFreeNoticeSeen } from './freeNotice';
+
+describe('freeNotice', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('기본값은 안 본 상태다', () => {
+    expect(hasSeenFreeNotice(1, 10)).toBe(false);
+  });
+
+  it('한 번 기록하면 같은 (사용자, 동아리)에서만 본 것으로 처리된다', () => {
+    markFreeNoticeSeen(1, 10);
+
+    expect(hasSeenFreeNotice(1, 10)).toBe(true);
+    expect(hasSeenFreeNotice(1, 11)).toBe(false); // 다른 동아리
+    expect(hasSeenFreeNotice(2, 10)).toBe(false); // 다른 사용자
+  });
+
+  it('teamId가 없으면 기록하지도 읽지도 않는다', () => {
+    markFreeNoticeSeen(1, 0);
+    expect(hasSeenFreeNotice(1, 0)).toBe(false);
+  });
+});

--- a/app/_lib/utils/freeNotice.ts
+++ b/app/_lib/utils/freeNotice.ts
@@ -1,0 +1,24 @@
+// '지금은 무료 이벤트 기간' 안내 팝업(UpgradeModal)을 (사용자, 동아리)당 한 번만 띄우기 위한 기억.
+// 서버 저장이 아니라 기기 로컬 기억이다 — 기기를 바꾸면 한 번 다시 뜬다.
+
+const keyOf = (userId: number | undefined, teamId: number) =>
+  `chinba:freeNoticeSeen:${userId ?? 0}:${teamId}`;
+
+export function hasSeenFreeNotice(userId: number | undefined, teamId: number): boolean {
+  try {
+    if (typeof window === 'undefined' || !teamId) return false;
+    return window.localStorage.getItem(keyOf(userId, teamId)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function markFreeNoticeSeen(userId: number | undefined, teamId: number): void {
+  try {
+    if (typeof window !== 'undefined' && teamId) {
+      window.localStorage.setItem(keyOf(userId, teamId), '1');
+    }
+  } catch {
+    /* localStorage 접근 불가(프라이빗 모드 등) 시 무시 */
+  }
+}


### PR DESCRIPTION
- 랭킹(잡아봐) 탭: 추후 업데이트 예정으로 진입 차단, 누르면 '추후 업데이트 예정입니다' 토스트 노출 (features.ts CHINBA_RANKING_TAB_ENABLED 플래그 — 재공개 시 true로만 바꾸면 됨). URL로 직접 진입해도 일정 탭으로 폴백
- 무료 이벤트 안내 팝업(UpgradeModal): 매 방문마다 뜨던 것을 (사용자, 동아리)당 1회만 노출 — localStorage 기억 (freeNotice.ts), 백엔드 변경 불필요
- 모바일(TeamDetailView)·데스크톱(TeamDetailClient) 동일 적용, 유틸 테스트 추가


Claude-Session: https://claude.ai/code/session_01UxzpcAkb2uungs7pC6BJn6