### PR TITLE
feat(chinba): 타임라인 링크 프리뷰 분리

### DIFF
--- a/app/(main)/chinba/event/opengraph-image.tsx
+++ b/app/(main)/chinba/event/opengraph-image.tsx
@@ -9,12 +9,12 @@ import {
 export const dynamic = 'force-static';
 
 // Image metadata
-export const alt = '제로타임 - 전북대 공지사항 통합 알림';
+export const alt = '타임라인 (TimeLine) - 가장 편한 일정 잡기';
 export const size = OG_CARD_SIZE;
 
 export const contentType = OG_CARD_CONTENT_TYPE;
 
 // Image generation
 export default async function Image() {
-    return renderWordmarkCard('ZEROTIME', OG_ACCENT_COLOR.zerotime);
+    return renderWordmarkCard('TIMELINE', OG_ACCENT_COLOR.timeline);
 }

--- a/app/(main)/chinba/event/page.tsx
+++ b/app/(main)/chinba/event/page.tsx
@@ -1,5 +1,26 @@
 import { Suspense } from 'react';
+
+import type { Metadata } from 'next';
+
 import ChinbaDetailClient from './_components/ChinbaDetailClient';
+
+// 링크 프리뷰(OG) — 이 경로에서만 루트 layout의 제로타임 메타를 타임라인으로 덮는다.
+// openGraph는 세그먼트 단위로 통째 교체되므로 siteName·locale·type도 다시 적는다.
+// 카드 이미지는 같은 폴더의 opengraph-image.tsx가 자동으로 붙는다.
+const TITLE = '타임라인 - 가장 편한 일정 잡기';
+const DESCRIPTION = '내가 되는 시간만 체크하세요. 모두 되는 시간을 찾아드려요.';
+
+export const metadata: Metadata = {
+    title: TITLE,
+    description: DESCRIPTION,
+    openGraph: {
+        title: TITLE,
+        description: DESCRIPTION,
+        siteName: '타임라인 (TimeLine)',
+        locale: 'ko_KR',
+        type: 'website',
+    },
+};
 
 export default function ChinbaEventPage() {
     return (

--- a/app/(main)/chinba/team/join/opengraph-image.tsx
+++ b/app/(main)/chinba/team/join/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import {
+  OG_ACCENT_COLOR,
+  OG_CARD_CONTENT_TYPE,
+  OG_CARD_SIZE,
+  renderWordmarkCard,
+} from '@/_lib/og/wordmarkCard';
+
+// Static export를 위한 설정
+export const dynamic = 'force-static';
+
+// Image metadata
+export const alt = '타임라인 (TimeLine) - 가장 편한 일정 잡기';
+export const size = OG_CARD_SIZE;
+
+export const contentType = OG_CARD_CONTENT_TYPE;
+
+// Image generation
+export default async function Image() {
+  return renderWordmarkCard('TIMELINE', OG_ACCENT_COLOR.timeline);
+}

--- a/app/(main)/chinba/team/join/page.tsx
+++ b/app/(main)/chinba/team/join/page.tsx
@@ -1,5 +1,26 @@
 import { Suspense } from 'react';
+
+import type { Metadata } from 'next';
+
 import TeamJoinView from '../../_components/team/TeamJoinView';
+
+// 링크 프리뷰(OG) — 이 경로에서만 루트 layout의 제로타임 메타를 타임라인으로 덮는다.
+// openGraph는 세그먼트 단위로 통째 교체되므로 siteName·locale·type도 다시 적는다.
+// 카드 이미지는 같은 폴더의 opengraph-image.tsx가 자동으로 붙는다.
+const TITLE = '타임라인 - 우리 동아리에 초대합니다';
+const DESCRIPTION = '일정 조율부터 활동 기록, 조별 랭킹, 운영진 관리까지 한 곳에서.';
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: '타임라인 (TimeLine)',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+};
 
 export default function TeamJoinPage() {
   return (

--- a/app/_lib/og/wordmarkCard.tsx
+++ b/app/_lib/og/wordmarkCard.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from 'next/og';
+
+/** 링크 프리뷰 카드 규격 — 1200×630은 카카오톡·디스코드·슬랙 공통 안전지대 */
+export const OG_CARD_SIZE = { width: 1200, height: 630 };
+export const OG_CARD_CONTENT_TYPE = 'image/png';
+
+/** 워드마크 옆 강조 사각형 색 — 서비스별로 이 값만 다르다 */
+export const OG_ACCENT_COLOR = {
+  zerotime: '#3B82F6',
+  timeline: '#10B981',
+} as const;
+
+/**
+ * 워드마크 + 강조 사각형 카드를 굽는다 (빌드 타임 — 각 라우트의 opengraph-image가 호출).
+ *
+ * ⚠️ wordmark에는 **라틴 문자만** 넣는다. satori는 시스템 폰트 폴백이 없어서
+ * 아래 Inter latin 서브셋에 없는 글리프(한글 등)는 빈칸으로 렌더된다.
+ */
+export async function renderWordmarkCard(wordmark: string, accentColor: string) {
+  // Font loading
+  // Using standard fetch without import.meta.url for better compatibility
+  const interBold = await fetch(
+    'https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.18/files/inter-latin-800-normal.woff'
+  ).then((res) => {
+    if (!res.ok) {
+      throw new Error('Failed to fetch font');
+    }
+    return res.arrayBuffer();
+  });
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'white',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'center',
+          }}
+        >
+          {/* Wordmark */}
+          <div
+            style={{
+              fontFamily: 'Inter',
+              fontSize: '128px',
+              fontWeight: 800,
+              letterSpacing: '0.05em',
+              color: '#111827',
+              transform: 'skewX(-6deg)',
+            }}
+          >
+            {wordmark}
+          </div>
+
+          {/* Design Detail: Brand Accent Dot (Square) */}
+          <div
+            style={{
+              width: '35px',
+              height: '35px',
+              backgroundColor: accentColor,
+              marginLeft: '24px',
+              transform: 'skewX(-6deg)',
+            }}
+          />
+        </div>
+      </div>
+    ),
+    {
+      ...OG_CARD_SIZE,
+      fonts: [
+        {
+          name: 'Inter',
+          data: interBold,
+          style: 'normal',
+          weight: 800,
+        },
+      ],
+    }
+  );
+}

--- a/app/invite/opengraph-image.tsx
+++ b/app/invite/opengraph-image.tsx
@@ -1,20 +1,20 @@
 import {
-    OG_ACCENT_COLOR,
-    OG_CARD_CONTENT_TYPE,
-    OG_CARD_SIZE,
-    renderWordmarkCard,
+  OG_ACCENT_COLOR,
+  OG_CARD_CONTENT_TYPE,
+  OG_CARD_SIZE,
+  renderWordmarkCard,
 } from '@/_lib/og/wordmarkCard';
 
 // Static export를 위한 설정
 export const dynamic = 'force-static';
 
 // Image metadata
-export const alt = '제로타임 - 전북대 공지사항 통합 알림';
+export const alt = '타임라인 (TimeLine) - 가장 편한 일정 잡기';
 export const size = OG_CARD_SIZE;
 
 export const contentType = OG_CARD_CONTENT_TYPE;
 
 // Image generation
 export default async function Image() {
-    return renderWordmarkCard('ZEROTIME', OG_ACCENT_COLOR.zerotime);
+  return renderWordmarkCard('TIMELINE', OG_ACCENT_COLOR.timeline);
 }

--- a/app/invite/page.tsx
+++ b/app/invite/page.tsx
@@ -1,6 +1,26 @@
 import { Suspense } from 'react';
 
+import type { Metadata } from 'next';
+
 import InviteClient from './_components/InviteClient';
+
+// 링크 프리뷰(OG) — 이 경로에서만 루트 layout의 제로타임 메타를 타임라인으로 덮는다.
+// openGraph는 세그먼트 단위로 통째 교체되므로 siteName·locale·type도 다시 적는다.
+// 카드 이미지는 같은 폴더의 opengraph-image.tsx가 자동으로 붙는다.
+const TITLE = '타임라인 - 우리 동아리에 초대합니다';
+const DESCRIPTION = '일정 조율부터 활동 기록, 조별 랭킹, 운영진 관리까지 한 곳에서.';
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: '타임라인 (TimeLine)',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+};
 
 export default function InvitePage() {
   return (


### PR DESCRIPTION
## 배경

  친바(타임라인) 초대·일정 링크를 카톡방에 공유하면 `제로타임 - 전북대 공지사항 통합 알림`
  프리뷰가 떠서, 받는 사람이 무슨 링크인지 알 수 없었다. 루트 `app/layout.tsx`의 OG 메타를
  모든 경로가 그대로 상속하고 있었기 때문이다.

  ## 변경

  **타임라인 경로 3개에 전용 링크 프리뷰를 붙였다.**

  | 경로 | 제목 | 설명 |
  |---|---|---|
  | `/invite` | 타임라인 - 우리 동아리에 초대합니다 | 일정 조율부터 활동 기록, 조별 랭킹, 운영진 관리까지 한 곳에서. |
  | `/chinba/team/join` | (동일) | (동일) |
  | `/chinba/event` | 타임라인 - 가장 편한 일정 잡기 | 내가 되는 시간만 체크하세요. 모두 되는 시간을 찾아드려요. |

  - `og:site_name`은 세 경로 모두 `타임라인 (TimeLine)`
  - 카드 이미지는 `TIMELINE` 워드마크 + 초록 점(`#10B981`) — 친바 화면이 이미 emerald 계열을
    쓰고 있어 강조색을 거기 맞췄다. 기울기·크기·여백은 ZEROTIME 카드와 동일해 한 시스템으로 보인다.
  - `app/_lib/og/wordmarkCard.tsx`를 신설해 카드 렌더러를 공용화했다. ZEROTIME 카드도 이 모듈을
    쓰도록 바꿨다 — 같은 JSX가 여러 벌로 갈라지면 한쪽만 바뀌어 카드끼리 어긋나기 때문이다.

  ## 바뀌지 않은 것

  - **제로타임 공유는 그대로다.** 루트 카드는 원본 코드로 되돌려 재빌드한 결과와 **바이트 동일**
    (`md5 6054929dee5210b8ad38b36b7c26affc`)함을 확인했다. 메타태그도 변동 없다.
  - 위 3개 경로 외에는 전부 기존 제로타임 메타를 그대로 상속한다.
  - 파비콘(`app/icon.tsx`)은 사이트 단위라 경로별 분리가 불가능해 제로타임 로고 그대로 둔다.
    슬랙처럼 파비콘을 쓰는 클라이언트에서는 "제로타임 로고 + 타임라인 텍스트"로 보인다.

  ## 검증

  - `npm run build` — 정적 export 성공, 카드 PNG 1200×630 정상 생성
  - 빌드 산출물(`out/`)의 HTML에서 4개 경로 메타태그 직접 확인 (크롤러가 읽는 것이 이 HTML이다)
  - `npm run test:run` — 25파일 325테스트 통과
  - ESLint·`tsc --noEmit` — 변경 파일 클린

  ## 참고

  - 정적 export(`output: 'export'`) 제약상 **초대 코드별 동적 프리뷰(동아리 이름 등)는 불가**하다.
    식별자가 쿼리스트링(`?code=`)에 있어 모든 코드가 같은 HTML로 수렴하고, 크롤러는 JS를 실행하지
    않는다. 동적 프리뷰가 필요해지면 웹 빌드만 SSR로 분리하거나 백엔드가 프리뷰 링크를 담당하는
    방식이 필요하다.
  - 워드마크에 한글을 넣으면 안 된다 — satori는 시스템 폰트 폴백이 없어 Inter latin 서브셋에 없는
    글리프가 빈칸으로 렌더된다. `wordmarkCard.tsx` 주석에 남겨뒀다.
  - 카카오 프리뷰 캐시는 URL 단위다. 초대 링크는 `?code=`가 팀마다 달라 새로 발급되는 링크는
    캐시 영향이 없고, 과거에 뿌린 동일 URL만 카카오 디버거로 초기화하면 된다.
  - 실물 카드 확인은 **beta에서 가능하다**. dev는 Cloudflare Access 뒤라 크롤러가 로그인 페이지를
    받는다.