### PR TITLE
feat(타임라인): 팀 일정 링크 비멤버 가입 확인 화면 + '일정 잡기' 문구 변경

### DIFF
--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -337,7 +337,7 @@ export default function TeamDetailView() {
                 <LuChevronLeft size={22} strokeWidth={2.5} className="transition-transform group-hover:-translate-x-0.5" />
               </button>
               <span className="text-base font-bold text-gray-800">
-                {view === 'create' ? '동아리 친바 만들기' : team.name}
+                {view === 'create' ? '일정 잡기' : team.name}
               </span>
             </div>
             <div className="flex min-h-0 flex-1 flex-col pt-2">

--- a/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
@@ -20,7 +20,7 @@ interface TeamEventCreateBodyProps {
   onSuccess: () => void;
 }
 
-// 동아리 친바 만들기 폼 본문 — 풀페이지(/chinba/team/event-create)와
+// 동아리 '일정 잡기' 폼 본문 — 풀페이지(/chinba/team/event-create)와
 // 팀 상세 임베드(?view=create) 양쪽에서 재사용한다.
 export default function TeamEventCreateBody({
   teamId,

--- a/app/(main)/chinba/_components/team/TeamEventCreateView.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateView.tsx
@@ -20,7 +20,7 @@ export default function TeamEventCreateView() {
   const goBack = useSmartBack(`/chinba/team/detail?id=${teamId}&tab=mannaja`);
 
   return (
-    <FullPageModal isOpen={true} onClose={goBack} title="동아리 친바 만들기">
+    <FullPageModal isOpen={true} onClose={goBack} title="일정 잡기">
       <TeamEventCreateBody
         teamId={teamId}
         preSetId={preSetId}

--- a/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
@@ -119,7 +119,7 @@ export default function TeamOpsPanel({
         {/* 3) 그냥 있는 페이지 = 바로가기 */}
         <section className="flex flex-col border-t border-gray-100 pt-5">
           <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">바로가기</span>
-          <PanelButton icon={FiCalendar} label="일정 만들기" onClick={onCreateEvent} />
+          <PanelButton icon={FiCalendar} label="일정 잡기" onClick={onCreateEvent} />
           <PanelButton icon={FiEdit3} label="활동 기록하기" onClick={onRecordActivity} />
         </section>
       </div>

--- a/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
@@ -13,6 +13,7 @@ import { useUser } from '@/_lib/hooks/useUser';
 import { formatDateRanges } from '@/_lib/utils/dateRange';
 
 import MyScheduleTab from './MyScheduleTab';
+import TeamJoinGate from './TeamJoinGate';
 import TeamScheduleTab from './TeamScheduleTab';
 
 interface ChinbaEventDetailBodyProps {
@@ -205,6 +206,12 @@ export default function ChinbaEventDetailBody({
         <LoadingSpinner size="lg" />
       </div>
     );
+  }
+
+  // 동아리 일정인데 아직 멤버가 아님 — 공유 링크만 받고 들어온 경우.
+  // 여기서 끝내므로 헤더의 공유·삭제 버튼과 탭이 아예 렌더되지 않는다.
+  if (event && event.team_id && !event.is_team_member) {
+    return <TeamJoinGate eventId={eventId} event={event} />;
   }
 
   // Error state

--- a/app/(main)/chinba/event/_components/TeamJoinGate.tsx
+++ b/app/(main)/chinba/event/_components/TeamJoinGate.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { FiUsers } from 'react-icons/fi';
+
+import Button from '@/_components/ui/Button';
+import { useToast } from '@/_context/ToastContext';
+import { hasAccessToken } from '@/_lib/auth/tokenStore';
+import { useJoinChinbaEventTeam } from '@/_lib/hooks/useChinba';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { formatDateRanges } from '@/_lib/utils/dateRange';
+import { getLoginUrl } from '@/_lib/utils/requireLogin';
+import type { ChinbaEventDetail } from '@/_types/chinba';
+
+interface TeamJoinGateProps {
+  eventId: string;
+  event: ChinbaEventDetail;
+}
+
+// 동아리 초대 링크 없이 일정 링크만 받은 사람이 보는 화면.
+// 백엔드가 비멤버에게는 제목·동아리명·기간만 내려주므로(participants·heatmap은 빈 배열)
+// 여기서 가입 동의를 받고 나서야 일정 상세가 열린다.
+export default function TeamJoinGate({ eventId, event }: TeamJoinGateProps) {
+  const router = useRouter();
+  const goBack = useSmartBack('/chinba');
+  const { showToast } = useToast();
+  const joinMutation = useJoinChinbaEventTeam(eventId);
+
+  const handleJoin = useCallback(async () => {
+    // 비로그인이면 로그인 후 이 화면으로 돌아와 다시 누르게 한다 (/invite와 같은 방식)
+    if (!hasAccessToken()) {
+      router.replace(getLoginUrl(`/chinba/event?id=${encodeURIComponent(eventId)}&tab=team`));
+      return;
+    }
+
+    try {
+      const result = await joinMutation.mutateAsync();
+      showToast(result.message, 'success');
+    } catch (err: unknown) {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      showToast(detail || '가입에 실패했습니다', 'error');
+    }
+  }, [eventId, joinMutation, router, showToast]);
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-6 py-10 text-center">
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+        <FiUsers size={28} className="text-gray-400" />
+      </div>
+
+      <h2 className="text-lg font-bold text-gray-800">{event.title}</h2>
+      <p className="mt-1 text-sm text-gray-500">{formatDateRanges(event.dates)}</p>
+
+      <p className="mt-6 text-sm text-gray-700">
+        이 일정은{' '}
+        <span className="font-bold text-gray-900">
+          {event.team_name ? `'${event.team_name}'` : '동아리'}
+        </span>
+        의 일정입니다
+      </p>
+      <p className="mt-1 text-sm text-gray-500">참여하려면 동아리에 가입해야 해요</p>
+
+      <div className="mt-8 flex w-full max-w-xs flex-col gap-2">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleJoin}
+          disabled={joinMutation.isPending}
+        >
+          {joinMutation.isPending ? '가입하는 중...' : '가입하고 참여하기'}
+        </Button>
+        <Button variant="secondary" size="lg" fullWidth onClick={goBack}>
+          돌아가기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -148,7 +148,7 @@ export default function MannajaTab({
           className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-4 text-sm font-medium text-gray-400 transition-colors hover:border-gray-300 hover:text-gray-500 active:scale-[0.98]"
         >
           <FiPlus size={18} />
-          <span>{terminology === 'club' ? '동아리 친바 만들기' : '팀 친바 만들기'}</span>
+          <span>일정 잡기</span>
         </button>
       )}
 

--- a/app/_lib/api/chinba.test.ts
+++ b/app/_lib/api/chinba.test.ts
@@ -1,0 +1,88 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('./client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import api from './client';
+import { getChinbaEventDetail, joinChinbaEventTeam } from './chinba';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getChinbaEventDetail', () => {
+  it('비멤버 응답의 동아리 정보를 그대로 넘긴다', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: {
+        event_id: 'ev123456',
+        title: '정기 모임',
+        dates: ['2026-04-01'],
+        start_hour: 8,
+        end_hour: 24,
+        status: 'active',
+        creator_id: 10,
+        creator_nickname: '팀장',
+        category: null,
+        participants: [],
+        heatmap: [],
+        recommended_times: [],
+        created_at: '2026-03-15',
+        team_id: 7,
+        team_name: '컴공 알고리즘 동아리',
+        is_team_member: false,
+      },
+    });
+
+    const result = await getChinbaEventDetail('ev123456');
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/events/ev123456');
+    expect(result.team_id).toBe(7);
+    expect(result.team_name).toBe('컴공 알고리즘 동아리');
+    expect(result.is_team_member).toBe(false);
+    expect(result.participants).toEqual([]);
+  });
+});
+
+describe('joinChinbaEventTeam', () => {
+  it('sends POST /chinba/events/:eventId/join-team', async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        team_id: 7,
+        team_name: '컴공 알고리즘 동아리',
+        my_role: 'member',
+        already_member: false,
+        message: '컴공 알고리즘 동아리에 가입했습니다',
+      },
+    });
+
+    const result = await joinChinbaEventTeam('ev123456');
+
+    expect(api.post).toHaveBeenCalledWith('/chinba/events/ev123456/join-team');
+    expect(result.team_id).toBe(7);
+    expect(result.my_role).toBe('member');
+    expect(result.already_member).toBe(false);
+  });
+
+  it('이미 멤버여도 성공 응답을 그대로 반환한다', async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        team_id: 7,
+        team_name: '컴공 알고리즘 동아리',
+        my_role: 'captain',
+        already_member: true,
+        message: '이미 가입한 동아리입니다',
+      },
+    });
+
+    const result = await joinChinbaEventTeam('ev123456');
+
+    expect(result.already_member).toBe(true);
+  });
+});

--- a/app/_lib/api/chinba.ts
+++ b/app/_lib/api/chinba.ts
@@ -5,6 +5,7 @@ import type {
   ChinbaEventListItem,
   ChinbaEventCreateRequest,
   ChinbaEventCreateResponse,
+  ChinbaEventTeamJoinResponse,
   ChinbaUnavailabilityUpdateRequest,
 } from '@/_types/chinba';
 
@@ -15,6 +16,13 @@ export async function createChinbaEvent(data: ChinbaEventCreateRequest): Promise
 
 export async function getChinbaEventDetail(eventId: string): Promise<ChinbaEventDetail> {
   const res = await api.get(`/chinba/events/${eventId}`);
+  return res.data;
+}
+
+// 동아리 일정 링크만 받은 사람이 그 동아리에 가입하고 일정에 참여한다.
+// 초대 코드 없이 event_id로 가입 대상이 정해지며, 이미 멤버여도 200(already_member=true)이다.
+export async function joinChinbaEventTeam(eventId: string): Promise<ChinbaEventTeamJoinResponse> {
+  const res = await api.post(`/chinba/events/${eventId}/join-team`);
   return res.data;
 }
 

--- a/app/_lib/hooks/useChinba.ts
+++ b/app/_lib/hooks/useChinba.ts
@@ -10,6 +10,7 @@ import {
   importChinbaTimetable,
   deleteChinbaEvent,
   completeChinbaEvent,
+  joinChinbaEventTeam,
 } from '@/_lib/api/chinba';
 import type {
   ChinbaEventCreateRequest,
@@ -75,6 +76,21 @@ export function useImportTimetable(eventId: string) {
       queryClient.invalidateQueries({ queryKey: ['chinba', 'event', eventId] });
       queryClient.invalidateQueries({ queryKey: ['chinba', 'participation', eventId] });
       queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+    },
+  });
+}
+
+// 동아리 일정 링크에서 가입 확인 -> 가입 + 그 일정 참여가 한 번에 끝난다.
+// 가입으로 동아리 목록·상세가 바뀌므로 teams 캐시도 함께 비운다.
+export function useJoinChinbaEventTeam(eventId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => joinChinbaEventTeam(eventId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chinba', 'event', eventId] });
+      queryClient.invalidateQueries({ queryKey: ['chinba', 'participation', eventId] });
+      queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
     },
   });
 }

--- a/app/_types/chinba.ts
+++ b/app/_types/chinba.ts
@@ -32,6 +32,20 @@ export interface ChinbaEventDetail {
   heatmap: ChinbaHeatmapSlot[];
   recommended_times: ChinbaRecommendedTime[];
   created_at: string;
+  // 동아리(팀) 일정 여부 — 개인 친바는 null
+  team_id: number | null;
+  team_name: string | null;
+  // false면 동아리 일정인데 아직 멤버가 아니라는 뜻 — participants·heatmap이 비어 오고
+  // 가입 확인 화면(TeamJoinGate)을 띄운다
+  is_team_member: boolean;
+}
+
+export interface ChinbaEventTeamJoinResponse {
+  team_id: number;
+  team_name: string;
+  my_role: string;
+  already_member: boolean;
+  message: string;
 }
 
 export interface ChinbaMyParticipation {


### PR DESCRIPTION
## 1. 팀 일정 링크 비멤버 가입 확인 화면 (a7cdb0e)

  동아리 초대 링크 없이 일정 링크만 받은 사람이 동아리 방에 못 들어오던 문제를 해결합니다.
  백엔드가 비멤버에게 `is_team_member: false`와 동아리명만 내려주므로, 그 상태에서
  가입 확인 화면을 띄우고 확인 시 가입 + 참여를 한 번에 처리합니다.

  - `TeamJoinGate` 신규 — "이 일정은 '○○'의 일정입니다 / 참여하려면 동아리에 가입해야 해요"
    + `[가입하고 참여하기]` `[돌아가기]`
  - `ChinbaEventDetailBody`에서 early return이라 공유·삭제 버튼과 탭이 아예 렌더되지 않습니다
  - 비로그인이면 `/login`으로 보냈다가 같은 화면으로 복귀 (`/invite`와 동일 패턴)
  - 가입 성공 시 이벤트·내 일정·팀 캐시를 무효화해 같은 링크가 바로 정상 상세로 열립니다

  ## 2. '일정 잡기' 문구 변경 (dd4b6cb)
  동아리 상세 **일정 탭**의 `+ 동아리 친바 만들기` 버튼 문구를 `일정 잡기`로 바꿉니다.
  '친바'는 내부에서 굳어진 이름이라 사용자에게 기능이 전달되지 않고, 개인 일정 생성은
  이미 '새 일정 만들기'로 되어 있어 용어도 어긋나 있었습니다.

  같은 생성 흐름의 진입점 4곳을 모두 맞췄습니다 — 버튼만 바꾸면 누른 다음 화면 제목이
  여전히 '동아리 친바 만들기'로 뜹니다.

  | 위치 | 변경 |
  |---|---|
  | 일정 탭 점선 버튼 | `동아리 친바 만들기` → `일정 잡기` (팀/동아리 삼항 제거) |
  | 모바일 생성 화면 제목 | `동아리 친바 만들기` → `일정 잡기` |
  | 데스크톱 임베드 헤더 | `동아리 친바 만들기` → `일정 잡기` |
  | 데스크톱 바로가기 버튼 | `일정 만들기` → `일정 잡기` (같은 동작인데 이름이 달랐음) |

  API 경로·JSON 키·DB·코드 식별자는 그대로입니다 (adr-014 — UI 문구까지만).
  동아리가 직접 만든 '친바' 해시태그는 사용자 데이터라 그대로 남습니다.

  ## 검증
  
  유닛 328 통과 / lint 에러 0 / 정적 export 빌드 성공.
  비주얼 회귀 스냅샷은 재생성 불필요 — 변경된 화면(`/chinba/team/detail`)이 캡처 대상이 아닙니다.
  
  백엔드 PR과 함께 봐야 합니다: zeroone-2025/zerotime-back#225