### PR TITLE
Feat/timeline manual time input

### DIFF
--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -374,9 +374,12 @@ export default function TeamDetailView() {
   }
 
   return (
+    // 동아리 메인은 하단 탭바(홈·동아리·MY)가 떠 있는 경로라 뒤로가기가 없어도 나갈 수 있다
+    // (chinba/layout.tsx의 BOTTOM_TAB_PATHS). 일정 상세·일정 잡기는 탭바가 없으므로 그대로 둔다.
     <FullPageModal
       isOpen={true}
       onClose={goBack}
+      showBackButton={false}
       title={<ClubSwitcher currentTeamId={teamId} currentName={team.name} />}
       headerRight={settingsButton}
     >

--- a/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
+++ b/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '@/_components/ui/Button';
 import Modal from '@/_components/ui/Modal';
 
-import {
-  buildEndOptions,
-  buildStartOptions,
-  toMinutes,
-  type TimeRange,
-} from './chinbaSlotRanges';
+import { buildEndOptions, buildStartOptions, toMinutes, type TimeRange } from './chinbaSlotRanges';
 
 interface AddTimeRangeModalProps {
   isOpen: boolean;
@@ -23,12 +18,77 @@ interface AddTimeRangeModalProps {
   onClose: () => void;
 }
 
-const SELECT_CLASS =
-  'w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-gray-900 bg-white';
+function formatDuration(start: string, end: string): string {
+  const minutes = toMinutes(end) - toMinutes(start);
+  if (minutes <= 0) return '';
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}분`;
+  if (m === 0) return `${h}시간`;
+  return `${h}시간 ${m}분`;
+}
+
+interface TimeColumnProps {
+  label: string;
+  options: string[];
+  value: string;
+  onChange: (time: string) => void;
+}
+
+/**
+ * 시각 목록 한 열.
+ *
+ * 네이티브 <select>를 안 쓴다 — OS가 그리는 목록(파란 하이라이트·각진 모서리·시스템 폰트)이
+ * 앱과 따로 놀아서다. 목록을 직접 그리면 앱 폰트·초록 강조가 그대로 적용된다.
+ * 모달 카드가 overflow-hidden이라 띄우는 팝업 대신 자리를 차지하는 스크롤 목록으로 둔다.
+ */
+function TimeColumn({ label, options, value, onChange }: TimeColumnProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // 열릴 때·값이 바뀔 때 선택된 항목을 가운데로 — 스크롤을 손으로 찾아 내리지 않게
+  useEffect(() => {
+    const selected = listRef.current?.querySelector('[data-selected="true"]');
+    if (selected instanceof HTMLElement && typeof selected.scrollIntoView === 'function') {
+      selected.scrollIntoView({ block: 'center' });
+    }
+  }, [value, options]);
+
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="mb-1.5 text-center text-[11px] font-medium text-gray-500">{label}</p>
+      <div
+        ref={listRef}
+        role="listbox"
+        aria-label={label}
+        className="no-scrollbar h-44 snap-y overflow-y-auto rounded-xl border border-gray-200 bg-gray-50 p-1"
+      >
+        {options.map((time) => {
+          const isSelected = time === value;
+          return (
+            <button
+              key={time}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              data-selected={isSelected}
+              onClick={() => onChange(time)}
+              className={`w-full snap-center rounded-lg py-2 text-sm tabular-nums transition-colors ${
+                isSelected
+                  ? 'bg-emerald-600 font-bold text-white'
+                  : 'font-medium text-gray-600 hover:bg-gray-200/70'
+              }`}
+            >
+              {time}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 /**
  * 불가능 시간 구간 하나를 추가하는 모달.
- * 30분 눈금 단일 select 두 개 — 시/분을 나누지 않는 이유는 분이 00/30 두 가지뿐이기 때문.
  * 선택지는 이벤트 범위(startHour~endHour) 안으로 제한된다 — 범위 밖 슬롯은 히트맵에서 무시되므로
  * 애초에 만들 수 없게 한다.
  */
@@ -74,46 +134,23 @@ export default function AddTimeRangeModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={`${dateLabel} 시간 추가`} maxWidth="max-w-xs">
-      <div className="space-y-3 px-5 py-4">
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-start">
-            시작
-          </label>
-          <select
-            id="range-start"
-            value={start}
-            onChange={(e) => setStart(e.target.value)}
-            className={SELECT_CLASS}
-          >
-            {startOptions.map((time) => (
-              <option key={time} value={time}>
-                {time}
-              </option>
-            ))}
-          </select>
+      <div className="px-5 py-4">
+        {/* 고른 결과를 크게 — 목록 두 열만 보면 무엇을 고른 건지 한눈에 안 들어온다 */}
+        <div className="mb-3 text-center">
+          <p className="text-lg font-bold tabular-nums text-gray-900">
+            {start} <span className="text-gray-300">→</span> {end}
+          </p>
+          <p className="mt-0.5 text-xs font-medium text-emerald-700">{formatDuration(start, end)}</p>
         </div>
 
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-end">
-            종료
-          </label>
-          <select
-            id="range-end"
-            value={end}
-            onChange={(e) => setEnd(e.target.value)}
-            className={SELECT_CLASS}
-          >
-            {endOptions.map((time) => (
-              <option key={time} value={time}>
-                {time}
-              </option>
-            ))}
-          </select>
+        <div className="flex gap-2">
+          <TimeColumn label="시작" options={startOptions} value={start} onChange={setStart} />
+          <TimeColumn label="종료" options={endOptions} value={end} onChange={setEnd} />
         </div>
 
-        <p className="text-[11px] text-gray-400">30분 단위로 선택할 수 있습니다.</p>
+        <p className="mt-2 text-center text-[11px] text-gray-400">30분 단위로 선택할 수 있습니다.</p>
 
-        <div className="flex gap-2 pt-1">
+        <div className="flex gap-2 pt-3">
           <Button variant="outline" size="md" fullWidth onClick={onClose}>
             취소
           </Button>

--- a/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
+++ b/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import Button from '@/_components/ui/Button';
+import Modal from '@/_components/ui/Modal';
+
+import {
+  buildEndOptions,
+  buildStartOptions,
+  toMinutes,
+  type TimeRange,
+} from './chinbaSlotRanges';
+
+interface AddTimeRangeModalProps {
+  isOpen: boolean;
+  /** "YYYY-MM-DD" — 어느 날짜에 추가하는지 (제목에 표시) */
+  dateStr: string;
+  dateLabel: string;
+  startHour: number;
+  endHour: number;
+  onSubmit: (range: TimeRange) => void;
+  onClose: () => void;
+}
+
+const SELECT_CLASS =
+  'w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-gray-900 bg-white';
+
+/**
+ * 불가능 시간 구간 하나를 추가하는 모달.
+ * 30분 눈금 단일 select 두 개 — 시/분을 나누지 않는 이유는 분이 00/30 두 가지뿐이기 때문.
+ * 선택지는 이벤트 범위(startHour~endHour) 안으로 제한된다 — 범위 밖 슬롯은 히트맵에서 무시되므로
+ * 애초에 만들 수 없게 한다.
+ */
+export default function AddTimeRangeModal({
+  isOpen,
+  dateStr,
+  dateLabel,
+  startHour,
+  endHour,
+  onSubmit,
+  onClose,
+}: AddTimeRangeModalProps) {
+  const startOptions = useMemo(() => buildStartOptions(startHour, endHour), [startHour, endHour]);
+  const [start, setStart] = useState(startOptions[0] ?? '');
+  const [end, setEnd] = useState('');
+
+  const endOptions = useMemo(
+    () => buildEndOptions(startHour, endHour, start),
+    [startHour, endHour, start]
+  );
+
+  // 열릴 때마다 기본값으로 되돌린다 — 이전 날짜의 선택이 남아 있으면 헷갈린다
+  useEffect(() => {
+    if (!isOpen) return;
+    const first = startOptions[0] ?? '';
+    setStart(first);
+    setEnd(buildEndOptions(startHour, endHour, first)[0] ?? '');
+  }, [isOpen, dateStr, startOptions, startHour, endHour]);
+
+  // 시작을 늦추면 종료가 그보다 앞설 수 있다 → 유효한 첫 값으로 당긴다
+  useEffect(() => {
+    if (!end || toMinutes(end) > toMinutes(start)) return;
+    setEnd(endOptions[0] ?? '');
+  }, [start, end, endOptions]);
+
+  const isValid = !!start && !!end && toMinutes(end) > toMinutes(start);
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    onSubmit({ start, end });
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`${dateLabel} 시간 추가`} maxWidth="max-w-xs">
+      <div className="space-y-3 px-5 py-4">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-start">
+            시작
+          </label>
+          <select
+            id="range-start"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            {startOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-end">
+            종료
+          </label>
+          <select
+            id="range-end"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            {endOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <p className="text-[11px] text-gray-400">30분 단위로 선택할 수 있습니다.</p>
+
+        <div className="flex gap-2 pt-1">
+          <Button variant="outline" size="md" fullWidth onClick={onClose}>
+            취소
+          </Button>
+          <Button variant="primary" size="md" fullWidth onClick={handleSubmit} disabled={!isValid}>
+            추가
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 import { buildChinbaGridLayout } from './chinbaGridColumns';
+import { getSlotKey } from './chinbaSlotRanges';
 
 const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -93,8 +94,6 @@ export default function ChinbaScheduleGrid({
     }
     onSlotsChange(newSlots);
   }, [selectedSlots, onSlotsChange]);
-
-  const getSlotKey = (dateStr: string, time: string) => `${dateStr}T${time}:00`;
 
   const handlePointerDown = (
     event: ReactPointerEvent<HTMLDivElement>,

--- a/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import ChinbaScheduleList from './ChinbaScheduleList';
+import { getSlotKey } from './chinbaSlotRanges';
+
+const DATES = ['2026-08-02', '2026-08-03']; // 일, 월
+const slotsOf = (dateStr: string, ...times: string[]) =>
+  new Set(times.map((t) => getSlotKey(dateStr, t)));
+
+function renderList(selectedSlots: Set<string>, onSlotsChange = vi.fn()) {
+  render(
+    <ChinbaScheduleList
+      dates={DATES}
+      startHour={8}
+      endHour={24}
+      selectedSlots={selectedSlots}
+      onSlotsChange={onSlotsChange}
+    />
+  );
+  return onSlotsChange;
+}
+
+describe('ChinbaScheduleList', () => {
+  it('드래그로 칠한 슬롯이 병합된 구간으로 보인다', () => {
+    renderList(slotsOf('2026-08-02', '09:00', '09:30', '10:00'));
+
+    expect(screen.getByText('09:00 ~ 10:30')).toBeInTheDocument();
+    expect(screen.getByText('8/2 (일)')).toBeInTheDocument();
+  });
+
+  it('구간이 없는 날짜는 빈 상태를 보여준다', () => {
+    renderList(new Set());
+
+    expect(screen.getAllByText('등록된 시간 없음')).toHaveLength(2);
+  });
+
+  it('✕을 누르면 그 구간의 슬롯만 빠진 Set을 올려준다', () => {
+    const slots = new Set([
+      ...slotsOf('2026-08-02', '09:00', '09:30'),
+      ...slotsOf('2026-08-03', '14:00'),
+    ]);
+    const onSlotsChange = renderList(slots);
+
+    fireEvent.click(screen.getByLabelText('8/2 (일) 09:00~10:00 삭제'));
+
+    const next: Set<string> = onSlotsChange.mock.calls[0][0];
+    expect([...next]).toEqual(['2026-08-03T14:00:00']);
+  });
+
+  it('추가 모달로 구간을 넣으면 30분 슬롯으로 펼쳐 올려준다', () => {
+    const onSlotsChange = renderList(new Set());
+
+    fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
+
+    const start = screen.getByLabelText('시작') as HTMLSelectElement;
+    const end = screen.getByLabelText('종료') as HTMLSelectElement;
+    fireEvent.change(start, { target: { value: '09:00' } });
+    fireEvent.change(end, { target: { value: '10:30' } });
+    fireEvent.click(screen.getByRole('button', { name: '추가' }));
+
+    const next: Set<string> = onSlotsChange.mock.calls.at(-1)![0];
+    expect([...next].sort()).toEqual([
+      '2026-08-02T09:00:00',
+      '2026-08-02T09:30:00',
+      '2026-08-02T10:00:00',
+    ]);
+  });
+
+  it('이벤트 범위 밖 시각은 선택지에 없다', () => {
+    render(
+      <ChinbaScheduleList
+        dates={DATES}
+        startHour={10}
+        endHour={14}
+        selectedSlots={new Set()}
+        onSlotsChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
+
+    const start = screen.getByLabelText('시작');
+    expect(within(start).queryByText('09:30')).not.toBeInTheDocument();
+    expect(within(start).getByText('10:00')).toBeInTheDocument();
+
+    const end = screen.getByLabelText('종료');
+    expect(within(end).queryByText('14:30')).not.toBeInTheDocument();
+    expect(within(end).getByText('14:00')).toBeInTheDocument();
+  });
+
+  it('날짜 헤더를 누르면 접히고 다시 누르면 펼쳐진다', () => {
+    renderList(slotsOf('2026-08-02', '09:00'));
+
+    const header = screen.getByRole('button', { name: '8/2 (일) 시간 목록' });
+    expect(screen.getByText('09:00 ~ 09:30')).toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(screen.queryByText('09:00 ~ 09:30')).not.toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(screen.getByText('09:00 ~ 09:30')).toBeInTheDocument();
+  });
+});

--- a/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
@@ -53,10 +53,10 @@ describe('ChinbaScheduleList', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
 
-    const start = screen.getByLabelText('시작') as HTMLSelectElement;
-    const end = screen.getByLabelText('종료') as HTMLSelectElement;
-    fireEvent.change(start, { target: { value: '09:00' } });
-    fireEvent.change(end, { target: { value: '10:30' } });
+    const start = screen.getByRole('listbox', { name: '시작' });
+    const end = screen.getByRole('listbox', { name: '종료' });
+    fireEvent.click(within(start).getByRole('option', { name: '09:00' }));
+    fireEvent.click(within(end).getByRole('option', { name: '10:30' }));
     fireEvent.click(screen.getByRole('button', { name: '추가' }));
 
     const next: Set<string> = onSlotsChange.mock.calls.at(-1)![0];
@@ -79,13 +79,13 @@ describe('ChinbaScheduleList', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
 
-    const start = screen.getByLabelText('시작');
-    expect(within(start).queryByText('09:30')).not.toBeInTheDocument();
-    expect(within(start).getByText('10:00')).toBeInTheDocument();
+    const start = screen.getByRole('listbox', { name: '시작' });
+    expect(within(start).queryByRole('option', { name: '09:30' })).not.toBeInTheDocument();
+    expect(within(start).getByRole('option', { name: '10:00' })).toBeInTheDocument();
 
-    const end = screen.getByLabelText('종료');
-    expect(within(end).queryByText('14:30')).not.toBeInTheDocument();
-    expect(within(end).getByText('14:00')).toBeInTheDocument();
+    const end = screen.getByRole('listbox', { name: '종료' });
+    expect(within(end).queryByRole('option', { name: '14:30' })).not.toBeInTheDocument();
+    expect(within(end).getByRole('option', { name: '14:00' })).toBeInTheDocument();
   });
 
   it('날짜 헤더를 누르면 접히고 다시 누르면 펼쳐진다', () => {

--- a/app/(main)/chinba/event/_components/ChinbaScheduleList.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleList.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { FiChevronDown, FiChevronRight, FiPlus, FiX } from 'react-icons/fi';
+
+import AddTimeRangeModal from './AddTimeRangeModal';
+import { addRange, removeRange, slotsToRangesByDate, type TimeRange } from './chinbaSlotRanges';
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+
+interface ChinbaScheduleListProps {
+  dates: string[];
+  startHour: number;
+  endHour: number;
+  selectedSlots: Set<string>;
+  onSlotsChange: (slots: Set<string>) => void;
+}
+
+function formatDateLabel(dateStr: string): string {
+  const dt = new Date(dateStr);
+  return `${dt.getMonth() + 1}/${dt.getDate()} (${DAY_LABELS[dt.getDay()]})`;
+}
+
+/**
+ * 직접 입력 모드 — 날짜별 불가능 시간 구간 목록.
+ *
+ * 구간은 selectedSlots에서 파생될 뿐 자체 상태를 갖지 않는다. 그래서 드래그 모드에서 칠한 시간이
+ * 여기 구간으로 그대로 나타나고, 여기서 지운 구간은 그리드에서도 사라진다.
+ */
+export default function ChinbaScheduleList({
+  dates,
+  startHour,
+  endHour,
+  selectedSlots,
+  onSlotsChange,
+}: ChinbaScheduleListProps) {
+  const sortedDates = useMemo(
+    () => [...new Set(dates.map((d) => d.slice(0, 10)))].sort(),
+    [dates]
+  );
+  const rangesByDate = useMemo(
+    () => slotsToRangesByDate(selectedSlots, sortedDates),
+    [selectedSlots, sortedDates]
+  );
+
+  // 접힘은 사용자가 명시적으로 접은 날짜만 — 기본은 펼침이라 구간이 생기면 바로 보인다
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [addTarget, setAddTarget] = useState<string | null>(null);
+
+  const toggleCollapse = (dateStr: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(dateStr)) next.delete(dateStr);
+      else next.add(dateStr);
+      return next;
+    });
+  };
+
+  const handleAdd = (dateStr: string, range: TimeRange) => {
+    onSlotsChange(addRange(selectedSlots, dateStr, range));
+    setCollapsed((prev) => {
+      if (!prev.has(dateStr)) return prev;
+      const next = new Set(prev);
+      next.delete(dateStr); // 추가한 구간이 접힌 채로 숨어버리지 않게 펼친다
+      return next;
+    });
+  };
+
+  const handleRemove = (dateStr: string, range: TimeRange) => {
+    onSlotsChange(removeRange(selectedSlots, dateStr, range));
+  };
+
+  return (
+    <div className="divide-y divide-gray-100 rounded-xl border border-gray-200">
+      {sortedDates.map((dateStr) => {
+        const ranges = rangesByDate.get(dateStr) ?? [];
+        const isCollapsed = collapsed.has(dateStr);
+        const dateLabel = formatDateLabel(dateStr);
+        return (
+          <div key={dateStr}>
+            <div className="flex items-center justify-between px-3 py-2.5">
+              {/* 날짜마다 같은 문구가 반복되므로 aria-label로 어느 날짜인지 구분해준다 */}
+              <button
+                type="button"
+                onClick={() => toggleCollapse(dateStr)}
+                aria-expanded={!isCollapsed}
+                aria-label={`${dateLabel} 시간 목록`}
+                className="flex items-center gap-1.5 text-sm font-medium text-gray-800"
+              >
+                {isCollapsed ? (
+                  <FiChevronRight size={14} className="text-gray-400" />
+                ) : (
+                  <FiChevronDown size={14} className="text-gray-400" />
+                )}
+                {dateLabel}
+                {ranges.length > 0 && (
+                  <span className="text-[11px] font-normal text-gray-400">{ranges.length}개</span>
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => setAddTarget(dateStr)}
+                aria-label={`${dateLabel} 시간 추가`}
+                className="flex items-center gap-1 rounded-lg px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-100 active:scale-95"
+              >
+                <FiPlus size={12} />
+                추가
+              </button>
+            </div>
+
+            {!isCollapsed && (
+              <div className="px-3 pb-2.5">
+                {ranges.length === 0 ? (
+                  <p className="py-1 text-[11px] text-gray-400">등록된 시간 없음</p>
+                ) : (
+                  <ul className="space-y-1">
+                    {ranges.map((range) => (
+                      <li
+                        key={`${range.start}-${range.end}`}
+                        className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2"
+                      >
+                        <span className="text-sm text-gray-800">
+                          {range.start} ~ {range.end}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(dateStr, range)}
+                          aria-label={`${dateLabel} ${range.start}~${range.end} 삭제`}
+                          className="rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 active:scale-95"
+                        >
+                          <FiX size={14} />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <AddTimeRangeModal
+        isOpen={addTarget !== null}
+        dateStr={addTarget ?? ''}
+        dateLabel={addTarget ? formatDateLabel(addTarget) : ''}
+        startHour={startHour}
+        endHour={endHour}
+        onSubmit={(range) => {
+          if (addTarget) handleAdd(addTarget, range);
+        }}
+        onClose={() => setAddTarget(null)}
+      />
+    </div>
+  );
+}

--- a/app/(main)/chinba/event/_components/MyScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/MyScheduleTab.tsx
@@ -190,22 +190,18 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
     <div className="px-4 pb-20">
       {/* Info + Actions */}
       <div className="mb-4 space-y-2">
-        {/* Instruction banner */}
-        <div className="rounded-xl bg-blue-50 border border-blue-100 px-3 py-2.5">
-          <p className="text-[11px] text-blue-700 font-medium leading-tight">
-            {mode === 'drag'
-              ? '불가능한 시간을 드래그로 선택해주세요'
-              : '불가능한 시간을 직접 입력해주세요'}
-          </p>
-          <p className="text-[10px] text-blue-500 mt-0.5">
-            {mode === 'drag'
-              ? '빨간색으로 표시된 시간이 불가능한 시간입니다'
-              : '날짜별로 시작·종료 시각을 추가합니다'}
-          </p>
+        {/* Instruction banner + 입력 방식 전환 — 문구는 세그먼트 라벨과 겹치지 않게 짧게 둔다 */}
+        <div className="flex items-center justify-between gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-3 py-2.5">
+          <div className="min-w-0">
+            <p className="text-[11px] text-emerald-800 font-medium leading-tight">
+              {mode === 'drag' ? '불가능한 시간을 칠하세요' : '불가능한 시간을 추가하세요'}
+            </p>
+            <p className="text-[10px] text-emerald-600 mt-0.5">
+              {mode === 'drag' ? '빨간색이 불가능한 시간입니다' : '날짜별 30분 단위로 넣습니다'}
+            </p>
+          </div>
+          <ScheduleInputModeTabs mode={mode} onModeChange={handleModeChange} />
         </div>
-
-        {/* Input mode */}
-        <ScheduleInputModeTabs mode={mode} onModeChange={handleModeChange} />
 
         {/* Action buttons */}
         <div className="flex items-stretch gap-2">

--- a/app/(main)/chinba/event/_components/MyScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/MyScheduleTab.tsx
@@ -8,6 +8,8 @@ import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Toast from '@/_components/ui/Toast';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import ChinbaScheduleGrid from './ChinbaScheduleGrid';
+import ChinbaScheduleList from './ChinbaScheduleList';
+import ScheduleInputModeTabs, { type ScheduleInputMode } from './ScheduleInputModeTabs';
 import { getLoginUrl } from '@/_lib/utils/requireLogin';
 import { useMyParticipation, useUpdateUnavailability, useImportTimetable } from '@/_lib/hooks/useChinba';
 
@@ -29,7 +31,9 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
   const importMutation = useImportTimetable(eventId);
 
   const draftKey = `chinba:event:${eventId}:draft-unavailable`;
+  const modeKey = `chinba:event:${eventId}:input-mode`;
   const [selectedSlots, setSelectedSlots] = useState<Set<string>>(new Set());
+  const [mode, setMode] = useState<ScheduleInputMode>('drag');
   const [hasDraft, setHasDraft] = useState(false);
   const [draftLoaded, setDraftLoaded] = useState(false);
   const [showNoTimetableModal, setShowNoTimetableModal] = useState(false);
@@ -63,6 +67,25 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
       setDraftLoaded(true);
     }
   }, [draftKey]);
+
+  // 입력 방식은 마지막 선택을 기억한다 (탭 복원과 같은 방식)
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(modeKey);
+      if (stored === 'drag' || stored === 'manual') setMode(stored);
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [modeKey]);
+
+  const handleModeChange = useCallback((next: ScheduleInputMode) => {
+    setMode(next);
+    try {
+      localStorage.setItem(modeKey, next);
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [modeKey]);
 
   const handleSlotsChange = useCallback((slots: Set<string>) => {
     setSelectedSlots(slots);
@@ -170,10 +193,19 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
         {/* Instruction banner */}
         <div className="rounded-xl bg-blue-50 border border-blue-100 px-3 py-2.5">
           <p className="text-[11px] text-blue-700 font-medium leading-tight">
-            불가능한 시간을 드래그로 선택해주세요
+            {mode === 'drag'
+              ? '불가능한 시간을 드래그로 선택해주세요'
+              : '불가능한 시간을 직접 입력해주세요'}
           </p>
-          <p className="text-[10px] text-blue-500 mt-0.5">빨간색으로 표시된 시간이 불가능한 시간입니다</p>
+          <p className="text-[10px] text-blue-500 mt-0.5">
+            {mode === 'drag'
+              ? '빨간색으로 표시된 시간이 불가능한 시간입니다'
+              : '날짜별로 시작·종료 시각을 추가합니다'}
+          </p>
         </div>
+
+        {/* Input mode */}
+        <ScheduleInputModeTabs mode={mode} onModeChange={handleModeChange} />
 
         {/* Action buttons */}
         <div className="flex items-stretch gap-2">
@@ -203,16 +235,28 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
         </div>
       </div>
 
-      {/* Schedule Grid */}
-      <div className="mb-4 rounded-xl border border-gray-200 p-2 overflow-hidden">
-        <ChinbaScheduleGrid
-          dates={dates}
-          startHour={startHour}
-          endHour={endHour}
-          selectedSlots={selectedSlots}
-          onSlotsChange={handleSlotsChange}
-        />
-      </div>
+      {/* Schedule input — 두 모드가 같은 selectedSlots를 읽고 쓴다 */}
+      {mode === 'drag' ? (
+        <div className="mb-4 rounded-xl border border-gray-200 p-2 overflow-hidden">
+          <ChinbaScheduleGrid
+            dates={dates}
+            startHour={startHour}
+            endHour={endHour}
+            selectedSlots={selectedSlots}
+            onSlotsChange={handleSlotsChange}
+          />
+        </div>
+      ) : (
+        <div className="mb-4">
+          <ChinbaScheduleList
+            dates={dates}
+            startHour={startHour}
+            endHour={endHour}
+            selectedSlots={selectedSlots}
+            onSlotsChange={handleSlotsChange}
+          />
+        </div>
+      )}
 
       {/* Sticky bottom bar with save button */}
       <div className="sticky bottom-0 z-10 -mx-4 border-t border-gray-100 bg-white px-4 py-3 pb-safe">

--- a/app/(main)/chinba/event/_components/MyScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/MyScheduleTab.tsx
@@ -191,12 +191,12 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
       {/* Info + Actions */}
       <div className="mb-4 space-y-2">
         {/* Instruction banner + 입력 방식 전환 — 문구는 세그먼트 라벨과 겹치지 않게 짧게 둔다 */}
-        <div className="flex items-center justify-between gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-3 py-2.5">
+        <div className="flex items-center justify-between gap-2 rounded-xl bg-emerald-100 border border-emerald-200 px-3 py-2.5">
           <div className="min-w-0">
-            <p className="text-[11px] text-emerald-800 font-medium leading-tight">
+            <p className="text-[11px] text-emerald-900 font-semibold leading-tight">
               {mode === 'drag' ? '불가능한 시간을 칠하세요' : '불가능한 시간을 추가하세요'}
             </p>
-            <p className="text-[10px] text-emerald-600 mt-0.5">
+            <p className="text-[10px] text-emerald-700 mt-0.5">
               {mode === 'drag' ? '빨간색이 불가능한 시간입니다' : '날짜별 30분 단위로 넣습니다'}
             </p>
           </div>

--- a/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
+++ b/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
@@ -15,10 +15,13 @@ interface ScheduleInputModeTabsProps {
 /**
  * "내 일정"의 입력 방식 전환. 안내 배너 안 오른쪽에 들어가므로 폭을 차지하지 않는 알약형이다
  * (밑줄형 TeamSegmentTabs는 flex-1로 가로를 다 먹어 배너 안에서 쓸 수 없다).
+ *
+ * 트랙(emerald-200)은 배너 바탕(emerald-100)보다 한 단계 짙게 둔다 — 선택된 흰 알약과
+ * 트랙, 배너가 3단으로 갈려야 어느 쪽이 켜져 있는지 한눈에 보인다.
  */
 export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleInputModeTabsProps) {
   return (
-    <div className="inline-flex shrink-0 rounded-lg bg-white/70 p-0.5" role="group">
+    <div className="inline-flex shrink-0 rounded-lg bg-emerald-200 p-0.5" role="group">
       {TABS.map((tab) => {
         const isActive = mode === tab.key;
         return (
@@ -29,8 +32,8 @@ export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleIn
             aria-pressed={isActive}
             className={`rounded-md px-2.5 py-1 text-[11px] whitespace-nowrap transition-colors ${
               isActive
-                ? 'bg-white font-bold text-emerald-700 shadow-sm'
-                : 'font-medium text-emerald-600/70 hover:text-emerald-700'
+                ? 'bg-white font-bold text-emerald-800 shadow-sm'
+                : 'font-medium text-emerald-700/80 hover:text-emerald-900'
             }`}
           >
             {tab.label}

--- a/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
+++ b/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import type { IconType } from 'react-icons';
-import { FiClock, FiEdit2 } from 'react-icons/fi';
-
 export type ScheduleInputMode = 'drag' | 'manual';
 
-const TABS: { key: ScheduleInputMode; label: string; icon: IconType }[] = [
-  { key: 'drag', label: '드래그', icon: FiEdit2 },
-  { key: 'manual', label: '직접 입력', icon: FiClock },
+const TABS: { key: ScheduleInputMode; label: string }[] = [
+  { key: 'drag', label: '드래그' },
+  { key: 'manual', label: '직접 입력' },
 ];
 
 interface ScheduleInputModeTabsProps {
@@ -15,30 +12,28 @@ interface ScheduleInputModeTabsProps {
   onModeChange: (mode: ScheduleInputMode) => void;
 }
 
-/** "내 일정"의 입력 방식 전환. 스타일은 teams/TeamSegmentTabs의 밑줄형 세그먼트와 맞춘다. */
+/**
+ * "내 일정"의 입력 방식 전환. 안내 배너 안 오른쪽에 들어가므로 폭을 차지하지 않는 알약형이다
+ * (밑줄형 TeamSegmentTabs는 flex-1로 가로를 다 먹어 배너 안에서 쓸 수 없다).
+ */
 export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleInputModeTabsProps) {
   return (
-    <div className="flex border-b border-gray-100">
+    <div className="inline-flex shrink-0 rounded-lg bg-white/70 p-0.5" role="group">
       {TABS.map((tab) => {
         const isActive = mode === tab.key;
-        const Icon = tab.icon;
         return (
           <button
             key={tab.key}
             type="button"
             onClick={() => onModeChange(tab.key)}
             aria-pressed={isActive}
-            className={`relative flex-1 py-2.5 text-center text-[13px] font-medium transition-colors ${
-              isActive ? 'font-bold text-gray-900' : 'text-gray-400 hover:text-gray-600'
+            className={`rounded-md px-2.5 py-1 text-[11px] whitespace-nowrap transition-colors ${
+              isActive
+                ? 'bg-white font-bold text-emerald-700 shadow-sm'
+                : 'font-medium text-emerald-600/70 hover:text-emerald-700'
             }`}
           >
-            <span className="inline-flex items-center justify-center gap-1.5">
-              <Icon size={14} />
-              {tab.label}
-            </span>
-            {isActive && (
-              <span className="absolute bottom-0 left-1/2 h-0.5 w-12 -translate-x-1/2 rounded-full bg-gray-900" />
-            )}
+            {tab.label}
           </button>
         );
       })}

--- a/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
+++ b/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { IconType } from 'react-icons';
+import { FiClock, FiEdit2 } from 'react-icons/fi';
+
+export type ScheduleInputMode = 'drag' | 'manual';
+
+const TABS: { key: ScheduleInputMode; label: string; icon: IconType }[] = [
+  { key: 'drag', label: '드래그', icon: FiEdit2 },
+  { key: 'manual', label: '직접 입력', icon: FiClock },
+];
+
+interface ScheduleInputModeTabsProps {
+  mode: ScheduleInputMode;
+  onModeChange: (mode: ScheduleInputMode) => void;
+}
+
+/** "내 일정"의 입력 방식 전환. 스타일은 teams/TeamSegmentTabs의 밑줄형 세그먼트와 맞춘다. */
+export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleInputModeTabsProps) {
+  return (
+    <div className="flex border-b border-gray-100">
+      {TABS.map((tab) => {
+        const isActive = mode === tab.key;
+        const Icon = tab.icon;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onModeChange(tab.key)}
+            aria-pressed={isActive}
+            className={`relative flex-1 py-2.5 text-center text-[13px] font-medium transition-colors ${
+              isActive ? 'font-bold text-gray-900' : 'text-gray-400 hover:text-gray-600'
+            }`}
+          >
+            <span className="inline-flex items-center justify-center gap-1.5">
+              <Icon size={14} />
+              {tab.label}
+            </span>
+            {isActive && (
+              <span className="absolute bottom-0 left-1/2 h-0.5 w-12 -translate-x-1/2 rounded-full bg-gray-900" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(main)/chinba/event/_components/chinbaSlotRanges.test.ts
+++ b/app/(main)/chinba/event/_components/chinbaSlotRanges.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  addRange,
+  buildEndOptions,
+  buildStartOptions,
+  getSlotKey,
+  rangeToSlotKeys,
+  removeRange,
+  slotsToRangesByDate,
+} from './chinbaSlotRanges';
+
+const D = '2026-08-02';
+const OTHER = '2026-08-03';
+
+// 구간 목록을 "09:00~11:00" 문자열 배열로 — 기대값을 눈으로 읽기 쉽게
+const fmt = (map: Map<string, { start: string; end: string }[]>, dateStr: string) =>
+  (map.get(dateStr) ?? []).map((r) => `${r.start}~${r.end}`);
+
+const setOf = (dateStr: string, ...times: string[]) =>
+  new Set(times.map((t) => getSlotKey(dateStr, t)));
+
+describe('rangeToSlotKeys', () => {
+  it('end는 exclusive — 09:00~10:00은 슬롯 두 개', () => {
+    expect(rangeToSlotKeys(D, { start: '09:00', end: '10:00' })).toEqual([
+      `${D}T09:00:00`,
+      `${D}T09:30:00`,
+    ]);
+  });
+
+  it('start === end면 슬롯 없음', () => {
+    expect(rangeToSlotKeys(D, { start: '09:00', end: '09:00' })).toEqual([]);
+  });
+
+  it('자정 넘김 없이 24:00까지 만든다', () => {
+    expect(rangeToSlotKeys(D, { start: '23:00', end: '24:00' })).toEqual([
+      `${D}T23:00:00`,
+      `${D}T23:30:00`,
+    ]);
+  });
+});
+
+describe('slotsToRangesByDate', () => {
+  it('연속 슬롯은 한 구간으로 병합된다', () => {
+    const slots = setOf(D, '09:00', '09:30', '10:00', '10:30');
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~11:00']);
+  });
+
+  it('끊긴 슬롯은 별개 구간으로 나뉜다', () => {
+    const slots = setOf(D, '09:00', '09:30', '14:00');
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~10:00', '14:00~14:30']);
+  });
+
+  it('입력 순서와 무관하게 시각순으로 정렬된다', () => {
+    const slots = setOf(D, '14:00', '09:30', '09:00');
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~10:00', '14:00~14:30']);
+  });
+
+  it('날짜별로 분리된다', () => {
+    const slots = new Set([...setOf(D, '09:00'), ...setOf(OTHER, '13:00', '13:30')]);
+    const map = slotsToRangesByDate(slots, [D, OTHER]);
+    expect(fmt(map, D)).toEqual(['09:00~09:30']);
+    expect(fmt(map, OTHER)).toEqual(['13:00~14:00']);
+  });
+
+  it('dates 밖 날짜의 슬롯은 목록에서 빠지되 원본 Set은 그대로다', () => {
+    const slots = new Set([...setOf(D, '09:00'), ...setOf('2026-01-01', '09:00')]);
+    const map = slotsToRangesByDate(slots, [D]);
+    expect([...map.keys()]).toEqual([D]);
+    expect(slots.has('2026-01-01T09:00:00')).toBe(true); // 저장 시 보존돼야 한다
+  });
+
+  it('슬롯이 없으면 빈 맵', () => {
+    expect(slotsToRangesByDate(new Set(), [D]).size).toBe(0);
+  });
+});
+
+describe('addRange / removeRange', () => {
+  it('겹치는 구간을 추가하면 한 구간으로 병합돼 보인다', () => {
+    let slots = new Set<string>();
+    slots = addRange(slots, D, { start: '09:00', end: '12:00' });
+    slots = addRange(slots, D, { start: '11:00', end: '13:00' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~13:00']);
+  });
+
+  it('붙어 있는(끝=시작) 구간도 한 구간이 된다', () => {
+    let slots = new Set<string>();
+    slots = addRange(slots, D, { start: '09:00', end: '10:00' });
+    slots = addRange(slots, D, { start: '10:00', end: '11:00' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~11:00']);
+  });
+
+  it('떨어진 구간을 추가하면 두 구간으로 남는다', () => {
+    let slots = new Set<string>();
+    slots = addRange(slots, D, { start: '09:00', end: '10:00' });
+    slots = addRange(slots, D, { start: '14:00', end: '15:00' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~10:00', '14:00~15:00']);
+  });
+
+  it('구간 중간을 지우면 두 구간으로 쪼개진다', () => {
+    let slots = addRange(new Set<string>(), D, { start: '09:00', end: '13:00' });
+    slots = removeRange(slots, D, { start: '11:00', end: '11:30' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~11:00', '11:30~13:00']);
+  });
+
+  it('삭제는 같은 날짜에만 적용된다', () => {
+    let slots = addRange(new Set<string>(), D, { start: '09:00', end: '10:00' });
+    slots = addRange(slots, OTHER, { start: '09:00', end: '10:00' });
+    slots = removeRange(slots, D, { start: '09:00', end: '10:00' });
+    const map = slotsToRangesByDate(slots, [D, OTHER]);
+    expect(fmt(map, D)).toEqual([]);
+    expect(fmt(map, OTHER)).toEqual(['09:00~10:00']);
+  });
+
+  it('원본 Set을 변형하지 않는다', () => {
+    const original = new Set<string>();
+    const added = addRange(original, D, { start: '09:00', end: '10:00' });
+    expect(original.size).toBe(0);
+    expect(added.size).toBe(2);
+  });
+});
+
+describe('buildStartOptions / buildEndOptions', () => {
+  it('시작 선택지는 endHour 정각을 포함하지 않는다', () => {
+    const options = buildStartOptions(8, 24);
+    expect(options[0]).toBe('08:00');
+    expect(options[options.length - 1]).toBe('23:30');
+    expect(options).not.toContain('24:00');
+  });
+
+  it('종료 선택지는 endHour 정각까지 포함한다', () => {
+    const options = buildEndOptions(8, 24);
+    expect(options[0]).toBe('08:30');
+    expect(options[options.length - 1]).toBe('24:00');
+  });
+
+  it('이벤트 범위 밖 시각은 선택지에 없다', () => {
+    expect(buildStartOptions(10, 14)).not.toContain('09:30');
+    expect(buildEndOptions(10, 14)).not.toContain('14:30');
+  });
+
+  it('after를 주면 그보다 늦은 종료 시각만 남는다', () => {
+    const options = buildEndOptions(8, 24, '13:00');
+    expect(options[0]).toBe('13:30');
+    expect(options).not.toContain('13:00');
+  });
+});

--- a/app/(main)/chinba/event/_components/chinbaSlotRanges.ts
+++ b/app/(main)/chinba/event/_components/chinbaSlotRanges.ts
@@ -1,0 +1,122 @@
+// 친바 "내 일정"의 슬롯 Set ↔ 시간 구간 변환.
+//
+// 드래그 모드와 직접 입력 모드는 같은 데이터(불가능 슬롯 Set)를 본다.
+// 두 모드가 어긋나지 않도록 목록은 상태를 따로 갖지 않고 이 파일의 함수로 Set에서 파생시킨다.
+//
+// 슬롯 키는 "YYYY-MM-DDTHH:MM:00" — 백엔드 unavailable_slots(30분 단위 ISO datetime)와 같은 형식이라
+// 변환 없이 그대로 PUT /chinba/events/{id}/my-unavailability 로 보낸다.
+
+/** 슬롯 키 — 그리드 셀과 구간 목록이 같은 키를 쓰도록 여기 한 곳에서만 만든다. */
+export const getSlotKey = (dateStr: string, time: string) => `${dateStr}T${time}:00`;
+
+/** 시각 구간. end는 exclusive — "09:00"~"10:00"은 09:00·09:30 슬롯 두 개다. */
+export interface TimeRange {
+  start: string; // "HH:MM"
+  end: string; // "HH:MM"
+}
+
+const SLOT_MINUTES = 30;
+
+/** "HH:MM" → 자정 기준 분 */
+export function toMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** 자정 기준 분 → "HH:MM" */
+export function toTimeString(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/**
+ * 시작 시각 선택지 — startHour ~ endHour 사이의 30분 눈금.
+ * 마지막 슬롯의 시작(endHour - 30분)까지만 만든다. endHour 정각은 시작이 될 수 없다.
+ */
+export function buildStartOptions(startHour: number, endHour: number): string[] {
+  const options: string[] = [];
+  for (let m = startHour * 60; m < endHour * 60; m += SLOT_MINUTES) {
+    options.push(toTimeString(m));
+  }
+  return options;
+}
+
+/**
+ * 종료 시각 선택지 — after 이후의 30분 눈금. endHour 정각까지 포함한다(exclusive end라 필요).
+ * after를 주면 그보다 늦은 시각만 남겨, 종료가 시작보다 앞서는 조합 자체를 못 만들게 한다.
+ */
+export function buildEndOptions(startHour: number, endHour: number, after?: string): string[] {
+  const from = after ? toMinutes(after) + SLOT_MINUTES : startHour * 60 + SLOT_MINUTES;
+  const options: string[] = [];
+  for (let m = Math.max(from, startHour * 60 + SLOT_MINUTES); m <= endHour * 60; m += SLOT_MINUTES) {
+    options.push(toTimeString(m));
+  }
+  return options;
+}
+
+/** 구간 → 슬롯 키 배열 (start 포함, end 제외) */
+export function rangeToSlotKeys(dateStr: string, range: TimeRange): string[] {
+  const keys: string[] = [];
+  for (let m = toMinutes(range.start); m < toMinutes(range.end); m += SLOT_MINUTES) {
+    keys.push(getSlotKey(dateStr, toTimeString(m)));
+  }
+  return keys;
+}
+
+/**
+ * 슬롯 Set → 날짜별 연속 구간 목록.
+ *
+ * dates에 없는 날짜의 슬롯은 목록에서 빠진다(이벤트 후보일이 아니므로 보여줄 자리가 없다).
+ * 다만 Set 자체는 건드리지 않는다 — 저장 시 그대로 보존돼야 조용한 데이터 손실이 없다.
+ */
+export function slotsToRangesByDate(
+  slots: Set<string>,
+  dates: string[]
+): Map<string, TimeRange[]> {
+  const dateSet = new Set(dates.map((d) => d.slice(0, 10)));
+  const minutesByDate = new Map<string, number[]>();
+
+  for (const key of slots) {
+    const dateStr = key.slice(0, 10);
+    if (!dateSet.has(dateStr)) continue;
+    const time = key.slice(11, 16); // "HH:MM"
+    const list = minutesByDate.get(dateStr);
+    if (list) list.push(toMinutes(time));
+    else minutesByDate.set(dateStr, [toMinutes(time)]);
+  }
+
+  const result = new Map<string, TimeRange[]>();
+  for (const [dateStr, minutes] of minutesByDate) {
+    const sorted = [...new Set(minutes)].sort((a, b) => a - b);
+    const ranges: TimeRange[] = [];
+    let blockStart = sorted[0];
+    let prev = sorted[0];
+    for (let i = 1; i < sorted.length; i++) {
+      if (sorted[i] === prev + SLOT_MINUTES) {
+        prev = sorted[i]; // 직전 슬롯과 붙어 있음 → 같은 구간
+      } else {
+        ranges.push({ start: toTimeString(blockStart), end: toTimeString(prev + SLOT_MINUTES) });
+        blockStart = sorted[i];
+        prev = sorted[i];
+      }
+    }
+    ranges.push({ start: toTimeString(blockStart), end: toTimeString(prev + SLOT_MINUTES) });
+    result.set(dateStr, ranges);
+  }
+  return result;
+}
+
+/** 구간 추가. Set union이라 기존 구간과 겹치면 목록에서 자연히 한 구간으로 병합된다. */
+export function addRange(slots: Set<string>, dateStr: string, range: TimeRange): Set<string> {
+  const next = new Set(slots);
+  for (const key of rangeToSlotKeys(dateStr, range)) next.add(key);
+  return next;
+}
+
+/** 구간 삭제. 긴 구간의 중간을 지우면 목록에서 두 구간으로 쪼개진다. */
+export function removeRange(slots: Set<string>, dateStr: string, range: TimeRange): Set<string> {
+  const next = new Set(slots);
+  for (const key of rangeToSlotKeys(dateStr, range)) next.delete(key);
+  return next;
+}

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -50,8 +50,8 @@ export default function ChinbaHomePage() {
         {/* 제목 카드 */}
         <header className="rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-1.5">
-            <span className="text-lg font-bold tracking-tight text-blue-700">TIMELINE</span>
-            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            <span className="text-lg font-bold tracking-tight text-emerald-500">TIMELINE</span>
+            <span className="h-1.5 w-1.5 rounded-full bg-blue-700" />
           </div>
 
           {!isAuthLoaded ? (
@@ -76,7 +76,7 @@ export default function ChinbaHomePage() {
           )}
 
           {typeof stats?.total_teams === 'number' && (
-            <p className="mt-3 inline-flex rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+            <p className="mt-3 inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
               {stats.total_teams.toLocaleString('ko-KR')}개의 동아리가 함께하고 있어요
             </p>
           )}

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -155,20 +155,6 @@ export default function MannajaTab({
       {hasGroups ? (
         /* 섹션 분리 레이아웃 */
         <>
-          <SectionHeader icon={FiUsers} label={terminology === 'club' ? '동아리 전체 일정' : '팀 전체 일정'} />
-          {teamWideEvents.length > 0 ? (
-            teamWideEvents.map((event) => (
-              <EventCard
-                key={event.event_id}
-                event={event}
-                groupSetNameMap={groupSetNameMap}
-                onClick={() => openEvent(event.event_id)}
-              />
-            ))
-          ) : (
-            <SectionEmptyState message={terminology === 'club' ? '동아리 전체 일정이 없습니다' : '팀 전체 일정이 없습니다'} />
-          )}
-
           <SectionHeader icon={FiLayers} label="조별 일정" />
           {groupEvents.length > 0 ? (
             groupEvents.map((event) => (
@@ -184,6 +170,20 @@ export default function MannajaTab({
               message="아직 조별 일정이 없습니다"
               submessage={canCreate ? '조별 일정을 만들어 보세요' : undefined}
             />
+          )}
+
+          <SectionHeader icon={FiUsers} label={terminology === 'club' ? '동아리 전체 일정' : '팀 전체 일정'} />
+          {teamWideEvents.length > 0 ? (
+            teamWideEvents.map((event) => (
+              <EventCard
+                key={event.event_id}
+                event={event}
+                groupSetNameMap={groupSetNameMap}
+                onClick={() => openEvent(event.event_id)}
+              />
+            ))
+          ) : (
+            <SectionEmptyState message={terminology === 'club' ? '동아리 전체 일정이 없습니다' : '팀 전체 일정이 없습니다'} />
           )}
         </>
       ) : events.length === 0 ? (

--- a/app/(main)/teams/detail/_components/TeamSetupGuide.tsx
+++ b/app/(main)/teams/detail/_components/TeamSetupGuide.tsx
@@ -60,12 +60,12 @@ export default function TeamSetupGuide({
   };
 
   return (
-    <div className="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 p-4 space-y-3">
+    <div className="rounded-xl bg-gradient-to-r from-emerald-100 to-teal-50 p-4 space-y-3">
       {/* Step 1 */}
       {!isStep1Done ? (
         <div className="flex items-start gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100">
-            <span className="text-xs font-bold text-blue-600">①</span>
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-200">
+            <span className="text-xs font-bold text-emerald-700">①</span>
           </div>
           <div className="flex-1">
             <p className="text-sm font-medium text-gray-700">
@@ -96,8 +96,9 @@ export default function TeamSetupGuide({
         </div>
       ) : (
         <div className="flex items-center gap-2">
-          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-green-100">
-            <FiCheck size={12} className="text-green-600" />
+          {/* 카드 자체가 초록이라 완료 표시는 흰 원으로 띄운다 */}
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white">
+            <FiCheck size={12} className="text-emerald-600" />
           </div>
           <p className="text-sm font-medium text-gray-500">
             {terminology === 'club' ? '회원' : '팀원'} 초대 완료 ({memberCount}명)
@@ -114,8 +115,8 @@ export default function TeamSetupGuide({
         </div>
       ) : (
         <div className="flex items-start gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100">
-            <FiUsers size={14} className="text-blue-600" />
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-200">
+            <FiUsers size={14} className="text-emerald-700" />
           </div>
           <div className="flex-1">
             <p className="text-sm font-medium text-gray-700">조를 편성해보세요</p>
@@ -124,7 +125,7 @@ export default function TeamSetupGuide({
             </p>
             <button
               onClick={() => router.push(`/chinba/team/groups?id=${teamId}`)}
-              className="mt-1.5 text-xs font-semibold text-blue-600 hover:text-blue-700"
+              className="mt-1.5 text-xs font-semibold text-emerald-700 hover:text-emerald-800"
             >
               조 편성하러 가기 →
             </button>


### PR DESCRIPTION
## 요약

  친바 "내 일정"에서 불가능한 시간을 **드래그 말고 직접 입력으로도** 넣을 수 있게 했습니다.
  겸사겸사 파란색으로 남아 있던 UI를 친바 강조색(emerald)으로 정리하고, 동아리 화면의
  자잘한 UX 문제를 고쳤습니다.

  **백엔드 변경 없음** — 저장 형식(30분 슬롯 ISO 배열)이 그대로라 프론트만 바뀝니다.

  ## 1. 드래그 / 직접 입력 모드 전환 (핵심)

  기존에는 22px짜리 그리드 셀을 드래그해서 칠하는 방법뿐이라, 정확한 시각(9시~12시)을
  알고 있어도 손으로 더듬어야 했습니다.

  - 안내 배너 오른쪽에 `[ 드래그 | 직접 입력 ]` 세그먼트를 넣었습니다
  - **직접 입력**: 날짜별 아코디언 목록에서 `+ 추가` → 시작·종료 시각 선택 → 구간이 생기고,
    각 구간은 `✕`로 삭제
  - 마지막에 쓴 모드를 기억합니다 (localStorage, 기존 탭 복원과 같은 방식)

  ### 두 모드가 어긋나지 않는 이유

  상태를 **`selectedSlots: Set<string>` 하나로 유지**하고, 구간 목록은 거기서 파생만 합니다
  (`slotsToRangesByDate`). 그래서:

  - 드래그로 칠한 시간 → 직접 입력 목록에 병합된 구간으로 나타남
  - 목록에서 지운 구간 → 그리드에서 빨간 칸이 사라짐
  - 겹치는 구간을 추가하면 Set union이라 자동으로 한 구간으로 병합
  - 긴 구간의 중간을 지우면 두 구간으로 쪼개짐



  - 안내 배너 오른쪽에 `[ 드래그 | 직접 입력 ]` 세그먼트를 넣었습니다
  - **직접 입력**: 날짜별 아코디언 목록에서 `+ 추가` → 시작·종료 시각 선택 → 구간이 생기고,
    각 구간은 `✕`로 삭제
  - 마지막에 쓴 모드를 기억합니다 (localStorage, 기존 탭 복원과 같은 방식)

  ### 두 모드가 어긋나지 않는 이유

  상태를 **`selectedSlots: Set<string>` 하나로 유지**하고, 구간 목록은 거기서 파생만 합니다
  (`slotsToRangesByDate`). 그래서:

  - 드래그로 칠한 시간 → 직접 입력 목록에 병합된 구간으로 나타남
  - 목록에서 지운 구간 → 그리드에서 빨간 칸이 사라짐
  - 겹치는 구간을 추가하면 Set union이라 자동으로 한 구간으로 병합
  - 긴 구간의 중간을 지우면 두 구간으로 쪼개짐


  ### 시간 선택 UI

  네이티브 `<select>`를 쓰지 않습니다. select를 열면 OS가 자기 목록을 그려서
  (파란 하이라이트·각진 모서리·시스템 폰트) 앱과 따로 놀고, 그 팝업은 CSS로 손댈 수 없습니다.
  대신 앱이 직접 그리는 스크롤 목록 두 열(시작/종료)을 모달 안에 깔았습니다.
  선택된 항목은 열릴 때 가운데로 자동 스크롤되고, 위에 `09:00 → 12:00 · 3시간` 요약이 뜹니다.

  이벤트 범위(`start_hour`~`end_hour`) 밖 시각은 선택지에 아예 없습니다 — 백엔드가 범위 밖
  슬롯을 저장은 하되 히트맵에서 조용히 무시하기 때문에 만들 수 없게 막았습니다.

  ## 2. 색상 정리 (파랑 → emerald)

  친바 화면의 강조색이 전부 emerald 계열인데 몇 군데만 파랑으로 남아 튀고 있었습니다.

  | 대상 | 변경 |
  |---|---|
  | "내 일정" 안내 배너 | `blue-50` → `emerald-100` |
  | 회원 초대 / 조 편성 안내 카드 (`TeamSetupGuide`) | blue→indigo 그라데이션 → emerald→teal |
  | 친바 홈 "N개의 동아리가 함께하고 있어요" 배지 | `blue-50/700` → `emerald-100/800` |
  | TIMELINE 워드마크와 옆 점 | 서로 색 교체 (글씨 emerald, 점 blue) |

  `TeamSetupGuide`의 "초대 완료" 체크는 카드가 초록이 되면서 묻혀 흰 원으로 바꿨습니다.

  ## 3. 동아리 화면 UX

  - **일정 탭 섹션 순서**: 조별 일정을 동아리 전체 일정 **위로** 올렸습니다
  - **동아리 메인 뒤로가기 제거**: `/chinba/team/detail`은 하단 탭바(홈·동아리·MY)가 뜨는
    경로(`chinba/layout.tsx`의 `BOTTOM_TAB_PATHS`)라 뒤로가기가 없어도 나갈 수 있습니다.
    히스토리 기반 뒤로가기가 엉뚱한 곳으로 가는 문제가 있었습니다.
    일정 상세·일정 잡기는 탭바가 없는 경로라 **그대로 뒀습니다.**

  ## 테스트

  - `chinbaSlotRanges.test.ts` (19개) — 구간 병합/분리, end exclusive, 겹침 union,
    중간 삭제 시 분할, 범위 클램프, 후보일 밖 슬롯 보존
  - `ChinbaScheduleList.test.tsx` (6개) — 파생 렌더, 추가/삭제 왕복, 범위 밖 시각 미노출, 접기
  - 전체 353개 통과 / 린트 에러 0 / `tsc --noEmit` 오류 0


  ## 별건 — 발견한 백엔드 버그

  작업 중 `zerotime-back`에서 확인했지만 범위 밖.

  1. **저장하면 시간표 꼬리표가 떨어진다** — `PUT /my-unavailability`가 모든 슬롯을
     `source="manual"`로 덮어씁니다(`chinba.py:497`). 그러면 다음 "내 시간표 불러오기"가
     `source=="timetable"` 행만 지우므로 **이미 뺀 수업 시간이 계속 남습니다.**
     시간표 불러오고 저장 누른 사람이면 누구나 걸립니다.
  2. **같은 시각이 중복 저장될 수 있다** — `chinba_unavailabilities`에 unique 제약이 없고
     import 루프가 방금 자기가 추가한 슬롯을 중복 검사에 넣지 않습니다(`chinba.py:571-609`).
     같은 요일 같은 30분 칸을 두 수업이 차지하면 한 사람이 두 명으로 세어져
     히트맵 인원수가 부풀고 명단에 이름이 두 번 나옵니다. (수강편람은 교시제라 :00/:30만
     나오므로, 수업을 손으로 추가했거나 수강편람 매칭에 실패한 경우에만 발생)