### PR TITLE
Fix/chinba complete record flow

### DIFF
--- a/app/(main)/chinba/_components/ChinbaEventListItem.tsx
+++ b/app/(main)/chinba/_components/ChinbaEventListItem.tsx
@@ -6,8 +6,8 @@ import type { ChinbaEventListItem } from '@/_types/chinba';
 
 const STATUS_BADGE: Record<string, { label: string; className: string }> = {
   active: { label: '진행중', className: 'bg-blue-100 text-blue-700' },
-  completed: { label: '완료', className: 'bg-emerald-100 text-emerald-700' },
-  expired: { label: '만료', className: 'bg-gray-100 text-gray-500' },
+  completed: { label: '완료됨', className: 'bg-emerald-100 text-emerald-700' },
+  expired: { label: '지난 일정', className: 'bg-gray-100 text-gray-500' },
 };
 
 interface ChinbaEventListItemProps {

--- a/app/(main)/chinba/_components/MyTabContent.tsx
+++ b/app/(main)/chinba/_components/MyTabContent.tsx
@@ -12,19 +12,9 @@ import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { useUser } from '@/_lib/hooks/useUser';
+import { selectUpcoming } from '@/_lib/utils/chinbaUpcoming';
 
 import { ChinbaEventListItem } from './ChinbaEventListItem';
-
-/** dates 배열에서 오늘(자정) 이후의 가장 이른 날짜를 ms로 반환. 없으면 null. */
-function earliestUpcoming(dates: string[], todayMs: number): number | null {
-  let min: number | null = null;
-  for (const d of dates) {
-    const t = new Date(d).getTime();
-    if (Number.isNaN(t) || t < todayMs) continue;
-    if (min === null || t < min) min = t;
-  }
-  return min;
-}
 
 export default function MyTabContent() {
   const router = useRouter();
@@ -43,15 +33,10 @@ export default function MyTabContent() {
   );
 
   // 다가오는 일정: 오늘 이후 날짜를 가진 active 일정, 가장 이른 날짜 오름차순
-  const upcoming = useMemo(() => {
-    const todayMs = new Date(new Date().toDateString()).getTime();
-    return (events ?? [])
-      .filter((e) => e.status === 'active')
-      .map((e) => ({ event: e, when: earliestUpcoming(e.dates, todayMs) }))
-      .filter((x): x is { event: (typeof x)['event']; when: number } => x.when !== null)
-      .sort((a, b) => a.when - b.when)
-      .map((x) => x.event);
-  }, [events]);
+  const upcoming = useMemo(
+    () => selectUpcoming(events ?? []).map((x) => x.event),
+    [events],
+  );
 
   const teams = teamsData?.teams ?? [];
   const isLoading = !isAuthLoaded || (isLoggedIn && (isEventsLoading || isTeamsLoading));

--- a/app/(main)/chinba/_components/team/ClubSwitcher.tsx
+++ b/app/(main)/chinba/_components/team/ClubSwitcher.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
-import { LuCheck, LuChevronDown } from 'react-icons/lu';
+import { LuCheck, LuChevronDown, LuX } from 'react-icons/lu';
 
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { setLastTeamId } from '@/_lib/utils/chinbaSelection';
+
+// 동아리가 처음으로 2개 이상이 됐을 때 드롭다운 안내를 1회 보여주기 위한 플래그
+// (게시판 필터의 hasSeenFilterTooltip과 같은 패턴)
+const HINT_STORAGE_KEY = 'hasSeenClubSwitcherHint';
 
 interface ClubSwitcherProps {
   currentTeamId: number;
@@ -16,9 +20,36 @@ interface ClubSwitcherProps {
 export default function ClubSwitcher({ currentTeamId, currentName }: ClubSwitcherProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [showHint, setShowHint] = useState(false);
 
   const { data } = useMyTeams();
   const teams = data?.teams ?? [];
+
+  // 동아리가 2개 이상이 된 뒤 처음 이 화면을 보면 드롭다운 안내를 띄운다
+  useEffect(() => {
+    if (teams.length <= 1) return;
+    try {
+      if (!localStorage.getItem(HINT_STORAGE_KEY)) setShowHint(true);
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [teams.length]);
+
+  const dismissHint = useCallback(() => {
+    setShowHint(false);
+    try {
+      localStorage.setItem(HINT_STORAGE_KEY, 'true');
+    } catch {
+      // ignore localStorage errors
+    }
+  }, []);
+
+  // 10초 지나면 자동으로 닫는다 (닫힘 = 봤음 처리 — 다시 안 뜸)
+  useEffect(() => {
+    if (!showHint) return;
+    const timer = setTimeout(dismissHint, 10_000);
+    return () => clearTimeout(timer);
+  }, [showHint, dismissHint]);
 
   // 전환할 다른 동아리가 없으면 이름만 표시 (드롭다운 미노출)
   // 제목 태그·스타일은 FullPageModal 헤더가 소유한다 — 여기서 h1을 쓰면 h1 중첩이 된다
@@ -38,7 +69,10 @@ export default function ClubSwitcher({ currentTeamId, currentName }: ClubSwitche
     <div className="relative">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (showHint) dismissHint();
+          setOpen((v) => !v);
+        }}
         className="flex items-center gap-1 rounded-lg px-2 py-1 text-base font-bold text-gray-800 transition-colors hover:bg-gray-100 active:scale-95"
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -50,6 +84,28 @@ export default function ClubSwitcher({ currentTeamId, currentName }: ClubSwitche
           className={`shrink-0 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
+
+      {/* 동아리 전환 안내 툴팁 — 처음으로 동아리가 2개 이상이 됐을 때 1회 노출 */}
+      {showHint && !open && (
+        <div className="absolute left-1/2 top-full z-[70] mt-2 -translate-x-1/2 animate-fadeIn">
+          <div className="relative flex items-center gap-2 whitespace-nowrap rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white shadow-lg">
+            <span>다른 동아리로 바꾸고 싶다면 클릭하세요</span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                dismissHint();
+              }}
+              className="rounded-full p-0.5 hover:bg-gray-700"
+              aria-label="안내 닫기"
+            >
+              <LuX size={12} />
+            </button>
+            {/* 화살표 (위쪽 동아리 이름을 향함) */}
+            <div className="absolute -top-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-gray-900" />
+          </div>
+        </div>
+      )}
 
       {open && (
         <>

--- a/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
@@ -20,11 +20,17 @@ export default function ChinbaDetailClient() {
   const { data: event } = useChinbaEventDetail(eventId);
 
   const handleCompleted = (recordQuery: string) => {
-    // 완료 처리 후, 넘어온 경로(팀 상세 '기록' 탭)로 이동하면서
-    // 완료된 일정 정보를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
+    // 팀 상세 '기록' 탭으로 이동하면서 일정 정보를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
+    // 완료는 그 폼에서 '기록하기/기록하지 않기'를 선택해야 확정된다.
+    // returnTo 없이 진입한 경우(공유 링크·사이드바 등)도 팀 일정이면 팀 상세로 보낸다 —
+    // 여기서 끊기면 완료를 확정할 경로가 없다.
     const returnTo = searchParams.get('returnTo');
-    if (!returnTo) return;
-    const dest = decodeURIComponent(returnTo);
+    const dest = returnTo
+      ? decodeURIComponent(returnTo)
+      : event?.team_id
+        ? `/chinba/team/detail?id=${event.team_id}&tab=mwoheni`
+        : null;
+    if (!dest) return;
     router.replace(recordQuery ? `${dest}${dest.includes('?') ? '&' : '?'}${recordQuery}` : dest);
   };
 

--- a/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
@@ -183,16 +183,22 @@ export default function ChinbaEventDetailBody({
   };
 
   const handleComplete = async () => {
-    try {
-      await completeMutation.mutateAsync(eventId);
+    // 팀 일정: 여기서 완료를 확정하지 않는다. 활동 기록 화면으로 넘기고,
+    // 거기서 '기록하기/기록하지 않기'를 선택하는 시점에 완료 API가 호출된다.
+    // (버튼 없이 이탈하면 아무것도 확정되지 않아 일정이 진행중으로 보존된다)
+    if (event?.team_id) {
       setShowCompleteModal(false);
-      // 완료된 일정 정보(제목/날짜)를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
       const recordParams = new URLSearchParams();
-      if (event?.title) recordParams.set('recordTitle', event.title);
-      if (event?.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
-      if (event?.category) recordParams.set('recordCategoryId', String(event.category.id));
+      recordParams.set('recordEventId', eventId);
+      if (event.title) recordParams.set('recordTitle', event.title);
+      if (event.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
+      if (event.category) recordParams.set('recordCategoryId', String(event.category.id));
       onCompleted(recordParams.toString());
       return;
+    }
+    // 개인 친바: 활동 기록 개념이 없으므로 즉시 완료 확정
+    try {
+      await completeMutation.mutateAsync(eventId);
     } catch {
       alert('완료 처리에 실패했습니다');
     }
@@ -245,7 +251,7 @@ export default function ChinbaEventDetailBody({
           )}
 
           <div className="flex items-center gap-1 shrink-0">
-            {isCreator && isActive && (
+            {isCreator && (isActive || isExpired) && (
               <button
                 onClick={() => setShowCompleteModal(true)}
                 className="rounded-full p-2 text-emerald-600 hover:bg-emerald-50 transition-colors"
@@ -288,7 +294,9 @@ export default function ChinbaEventDetailBody({
       )}
       {isExpired && (
         <div className="px-4 py-2 bg-gray-50 border-b border-gray-100">
-          <p className="text-xs text-gray-500 text-center font-medium">만료된 일정입니다</p>
+          <p className="text-xs text-gray-500 text-center font-medium">
+            날짜가 지난 일정입니다{isCreator ? ' — 완료 처리하고 활동을 기록할 수 있습니다' : ''}
+          </p>
         </div>
       )}
 
@@ -386,7 +394,11 @@ export default function ChinbaEventDetailBody({
       >
         이 일정을 완료 처리하시겠습니까?
         <br />
-        <span className="text-xs text-gray-400">완료 후에는 일정 수정이 불가합니다</span>
+        <span className="text-xs text-gray-400">
+          {event?.team_id
+            ? '다음 화면에서 기록 여부를 선택하면 완료가 확정됩니다'
+            : '완료 후에는 일정 수정이 불가합니다'}
+        </span>
       </ConfirmModal>
     </>
   );

--- a/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
@@ -18,6 +18,8 @@ interface ChinbaHeatmapGridProps {
   startHour: number;
   endHour: number;
   totalParticipants: number;
+  // 특정 참여자의 불가능 슬롯 — 지정되면 해당 슬롯만 강조하고 나머지 히트맵은 흐리게 표시
+  focusSlots?: Set<string>;
 }
 
 function getHeatColor(unavailCount: number, total: number): string {
@@ -42,7 +44,9 @@ export default function ChinbaHeatmapGrid({
   startHour,
   endHour,
   totalParticipants,
+  focusSlots,
 }: ChinbaHeatmapGridProps) {
+  const isFocusMode = focusSlots !== undefined;
   const [tooltip, setTooltip] = useState<{ dt: string; members: string[]; count: number } | null>(null);
 
   // Build heatmap lookup
@@ -177,7 +181,13 @@ export default function ChinbaHeatmapGrid({
                 const dtKey = `${info.dateStr}T${time}:00`;
                 const slot = heatmapMap.get(dtKey);
                 const unavailCount = slot?.unavailable_count ?? 0;
-                const bgColor = getHeatColor(unavailCount, totalParticipants);
+                // focus 모드: 대상 참여자의 불가능 슬롯만 빨간색, 나머지는 기존 히트맵을 흐리게
+                const isFocusUnavailable = focusSlots?.has(dtKey) ?? false;
+                const bgColor = isFocusMode
+                  ? isFocusUnavailable
+                    ? 'bg-red-400'
+                    : `${getHeatColor(unavailCount, totalParticipants)} opacity-30`
+                  : getHeatColor(unavailCount, totalParticipants);
                 const txtColor = getTextColor(unavailCount, totalParticipants);
 
                 return (
@@ -198,7 +208,7 @@ export default function ChinbaHeatmapGrid({
                       }
                     }}
                   >
-                    {totalParticipants > 0 && (() => {
+                    {!isFocusMode && totalParticipants > 0 && (() => {
                       const availCount = totalParticipants - unavailCount;
                       return availCount > 0 ? (
                         <span className={`text-[9px] font-bold ${txtColor}`}>{availCount}</span>

--- a/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
@@ -95,6 +95,39 @@ export default function ChinbaScheduleGrid({
     onSlotsChange(newSlots);
   }, [selectedSlots, onSlotsChange]);
 
+  // 열/행 머리글 클릭용 일괄 토글 — 묶음이 전부 선택돼 있으면 모두 해제, 아니면 모두 선택
+  const toggleKeys = useCallback(
+    (keys: string[]) => {
+      if (keys.length === 0) return;
+      const allSelected = keys.every((k) => selectedSlots.has(k));
+      const newSlots = new Set(selectedSlots);
+      if (allSelected) {
+        keys.forEach((k) => newSlots.delete(k));
+      } else {
+        keys.forEach((k) => newSlots.add(k));
+      }
+      onSlotsChange(newSlots);
+    },
+    [selectedSlots, onSlotsChange],
+  );
+
+  // 날짜 머리글 클릭 → 그 날짜의 전체 시간 토글
+  const toggleColumn = (dateStr: string) => {
+    toggleKeys(timeSlots.map((time) => getSlotKey(dateStr, time)));
+  };
+
+  // 'N시' 라벨 클릭 → 그 시각(:00 + :30) × 선택 가능한 모든 날짜 토글
+  const toggleHourRow = (time: string) => {
+    const hh = time.slice(0, 2);
+    const keys: string[] = [];
+    for (const info of columnInfos) {
+      if (info.gap || !info.selectable) continue;
+      keys.push(getSlotKey(info.dateStr, `${hh}:00`));
+      keys.push(getSlotKey(info.dateStr, `${hh}:30`));
+    }
+    toggleKeys(keys);
+  };
+
   const handlePointerDown = (
     event: ReactPointerEvent<HTMLDivElement>,
     dateStr: string,
@@ -153,18 +186,27 @@ export default function ChinbaScheduleGrid({
               >
                 <span className="text-[10px] text-gray-300">⋯</span>
               </div>
+            ) : info.selectable ? (
+              // 날짜 머리글 클릭 = 해당 열 전체 선택/해제
+              <button
+                key={info.key}
+                type="button"
+                onClick={() => toggleColumn(info.dateStr)}
+                className="flex cursor-pointer flex-col items-center justify-center rounded py-1 transition-colors hover:bg-gray-100 active:scale-95"
+                style={{ width: cellWidth }}
+                title="이 날짜 전체 선택/해제"
+              >
+                <span className="text-[10px] text-gray-400">{info.day}</span>
+                <span className="text-xs font-medium text-gray-700">{info.label}</span>
+              </button>
             ) : (
               <div
                 key={info.key}
                 className="flex flex-col items-center justify-center py-1"
                 style={{ width: cellWidth }}
               >
-                <span className={`text-[10px] ${info.selectable ? 'text-gray-400' : 'text-gray-300'}`}>
-                  {info.day}
-                </span>
-                <span className={`text-xs font-medium ${info.selectable ? 'text-gray-700' : 'text-gray-300'}`}>
-                  {info.label}
-                </span>
+                <span className="text-[10px] text-gray-300">{info.day}</span>
+                <span className="text-xs font-medium text-gray-300">{info.label}</span>
               </div>
             )
           )}
@@ -175,10 +217,17 @@ export default function ChinbaScheduleGrid({
           const isHourBorder = time.endsWith(':00');
           return (
             <div key={time} className="flex">
-              {/* Time label */}
+              {/* Time label — 클릭 = 그 시간대(1시간) × 전체 날짜 선택/해제 */}
               <div className={`${timeLabelClass} flex items-center justify-start`}>
                 {isHourBorder && (
-                  <span className="text-[10px] text-gray-400 -mt-2">{parseInt(time)}시</span>
+                  <button
+                    type="button"
+                    onClick={() => toggleHourRow(time)}
+                    className="-mt-2 cursor-pointer rounded px-0.5 text-[10px] text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="이 시간대 전체 선택/해제"
+                  >
+                    {parseInt(time)}시
+                  </button>
                 )}
               </div>
               {/* Cells */}

--- a/app/(main)/chinba/event/_components/TeamScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/TeamScheduleTab.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
 import { FiCheck, FiClock, FiChevronDown, FiChevronUp } from 'react-icons/fi';
-import ChinbaHeatmapGrid from './ChinbaHeatmapGrid';
+
+import { useParticipantUnavailability } from '@/_lib/hooks/useChinba';
 import type { ChinbaEventDetail, ChinbaRecommendedTime } from '@/_types/chinba';
+
+import ChinbaHeatmapGrid from './ChinbaHeatmapGrid';
 
 const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -21,6 +25,22 @@ export default function TeamScheduleTab({ event }: TeamScheduleTabProps) {
   const [showParticipants, setShowParticipants] = useState(true);
   const submittedCount = event.participants.filter((p) => p.has_submitted).length;
   const totalCount = event.participants.length;
+
+  // 참여자 클릭 → 그 사람의 불가능 시간을 히트맵 위에 강조 (재클릭 = 해제, 다른 사람 = 전환)
+  // 선택 표시는 참여자 알약이 검정으로 바뀌는 것으로 충분하다 — 별도 배지 없음
+  const [focusedUserId, setFocusedUserId] = useState<number | null>(null);
+  const { data: focusData } = useParticipantUnavailability(event.event_id, focusedUserId);
+  const focusSlots = useMemo(
+    () =>
+      focusedUserId !== null && focusData?.user_id === focusedUserId
+        ? new Set(focusData.unavailable_slots)
+        : undefined,
+    [focusedUserId, focusData],
+  );
+
+  const handleParticipantClick = (userId: number) => {
+    setFocusedUserId((prev) => (prev === userId ? null : userId));
+  };
 
   return (
     <div className="px-4 pb-6">
@@ -40,18 +60,28 @@ export default function TeamScheduleTab({ event }: TeamScheduleTabProps) {
 
         {showParticipants && (
           <div className="flex flex-wrap gap-2 animate-fadeIn">
-            {event.participants.map((p) => (
-              <div
-                key={p.user_id}
-                className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs ${p.has_submitted
-                  ? 'bg-emerald-50 text-emerald-700'
-                  : 'bg-gray-100 text-gray-500'
+            {event.participants.map((p) => {
+              const isFocused = focusedUserId === p.user_id;
+              return (
+                <button
+                  key={p.user_id}
+                  type="button"
+                  onClick={() => handleParticipantClick(p.user_id)}
+                  disabled={!p.has_submitted}
+                  title={p.has_submitted ? '클릭하면 이 사람의 일정을 히트맵에 표시합니다' : '아직 일정을 제출하지 않았어요'}
+                  className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs transition-colors ${
+                    isFocused
+                      ? 'bg-gray-900 text-white'
+                      : p.has_submitted
+                        ? 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100 active:scale-95 cursor-pointer'
+                        : 'bg-gray-100 text-gray-500 cursor-default'
                   }`}
-              >
-                {p.has_submitted && <FiCheck size={10} />}
-                <span>{p.nickname || `유저${p.user_id}`}</span>
-              </div>
-            ))}
+                >
+                  {p.has_submitted && <FiCheck size={10} />}
+                  <span>{p.nickname || `유저${p.user_id}`}</span>
+                </button>
+              );
+            })}
           </div>
         )}
       </div>
@@ -72,6 +102,7 @@ export default function TeamScheduleTab({ event }: TeamScheduleTabProps) {
               startHour={event.start_hour}
               endHour={event.end_hour}
               totalParticipants={submittedCount}
+              focusSlots={focusSlots}
             />
           </div>
         )}

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { useRouter } from 'next/navigation';
 import { FiCalendar, FiClock, FiGrid, FiLink, FiPlus, FiUsers } from 'react-icons/fi';
 
+import { ChinbaEventListItem } from '@/(main)/chinba/_components/ChinbaEventListItem';
 import TeamCard from '@/(main)/teams/_components/TeamCard';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { useTeamStats } from '@/_lib/hooks/useTeamStats';
 import { useUser } from '@/_lib/hooks/useUser';
+import { selectUpcoming, formatUpcomingDate } from '@/_lib/utils/chinbaUpcoming';
 import type { TeamListItem } from '@/_types/team';
 
 const CONCEPTS = [
@@ -35,6 +40,14 @@ export default function ChinbaHomePage() {
   const { isAuthLoaded, isLoggedIn } = useUser();
   const { data: stats } = useTeamStats();
   const { data: teamsData, isLoading: isTeamsLoading } = useMyTeams();
+  // 다가오는 일정 카드 — my-events 기반이라 동아리 일정과 '동아리 없이 잡은' 개인 일정을 모두 포함
+  const { data: myEvents } = useMyChinbaEvents(isAuthLoaded && isLoggedIn);
+  const upcoming = useMemo(() => selectUpcoming(myEvents ?? []), [myEvents]);
+  // 동아리 없이 잡은 개인 일정 — 완료 처리 전(진행중·지난 일정)까지 목록에 보여준다
+  const personalEvents = useMemo(
+    () => (myEvents ?? []).filter((e) => e.team_id == null && e.status !== 'completed'),
+    [myEvents],
+  );
 
   const teams = teamsData?.teams ?? [];
 
@@ -47,8 +60,9 @@ export default function ChinbaHomePage() {
   return (
     <div className="h-full overflow-y-auto bg-gray-50">
       <div className="space-y-5 px-5 pt-6 pb-10">
-        {/* 제목 카드 */}
-        <header className="rounded-2xl bg-white p-4 shadow-sm">
+        {/* 제목 카드 + 다가오는 일정 카드 (로그인 시) */}
+        <div className="flex items-stretch gap-3">
+        <header className="min-w-0 flex-1 rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-1.5">
             <span className="text-lg font-bold tracking-tight text-emerald-500">TIMELINE</span>
             <span className="h-1.5 w-1.5 rounded-full bg-blue-700" />
@@ -81,6 +95,58 @@ export default function ChinbaHomePage() {
             </p>
           )}
         </header>
+
+        {/* 다가오는 일정 — 데스크톱 전용(모바일 홈에는 표시하지 않음).
+            앱 폴더처럼 2×2 미니 타일: 일정 최대 3개는 각각 상세로, 남으면 +N이 MY로 이동 */}
+        {isAuthLoaded && isLoggedIn && (
+          <div className="hidden w-44 shrink-0 flex-col rounded-2xl bg-white p-3.5 shadow-sm md:flex">
+            <button
+              type="button"
+              onClick={() => router.push('/chinba/my')}
+              className="flex items-center gap-1 text-xs font-bold text-gray-900 transition active:scale-[0.98]"
+            >
+              <FiClock size={13} className="shrink-0 text-emerald-500" />
+              다가오는 일정
+            </button>
+            {upcoming.length > 0 ? (
+              <div className="mt-2 grid flex-1 grid-cols-2 gap-1.5">
+                {upcoming.slice(0, 3).map(({ event, when }) => (
+                  <button
+                    key={event.event_id}
+                    type="button"
+                    onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                    className="flex aspect-square flex-col rounded-lg bg-gray-50 p-1.5 text-left transition hover:bg-gray-100 active:scale-95"
+                  >
+                    <span className="line-clamp-2 text-[10px] font-semibold leading-tight text-gray-700 break-keep">
+                      {event.title}
+                    </span>
+                    <span className="mt-auto text-[10px] font-semibold text-emerald-600">
+                      {formatUpcomingDate(when)}
+                    </span>
+                  </button>
+                ))}
+                {upcoming.length > 3 ? (
+                  <button
+                    type="button"
+                    onClick={() => router.push('/chinba/my')}
+                    className="flex aspect-square items-center justify-center rounded-lg bg-gray-50 text-xs font-bold text-gray-500 transition hover:bg-gray-100 active:scale-95"
+                  >
+                    +{upcoming.length - 3}
+                  </button>
+                ) : (
+                  Array.from({ length: 4 - upcoming.length }).map((_, i) => (
+                    <div key={i} className="aspect-square rounded-lg bg-gray-50/60" />
+                  ))
+                )}
+              </div>
+            ) : (
+              <p className="my-auto text-center text-[11px] leading-relaxed text-gray-400 break-keep">
+                예정된 일정이 없어요
+              </p>
+            )}
+          </div>
+        )}
+        </div>
 
         {/* 타임라인 동아리 선택 — 목록을 펼친 채로 + 만들기/참여 */}
         <section className="rounded-2xl bg-white p-4 shadow-sm">
@@ -133,14 +199,43 @@ export default function ChinbaHomePage() {
           </div>
         </section>
 
-        {/* 동아리 없이 일정 잡기 — 항상 노출 (텍스트 버튼) */}
-        <button
-          type="button"
-          onClick={() => router.push('/chinba/create')}
-          className="w-full py-1 text-center text-sm font-bold text-gray-900 transition active:scale-[0.99]"
-        >
-          동아리 없이 일정 잡기 →
-        </button>
+        {/* 동아리 없이 잡은 일정 — 동아리 선택 섹션과 같은 형태로 목록 노출 + 잡기 버튼 */}
+        <section className="rounded-2xl bg-white p-4 shadow-sm">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-sm font-bold text-gray-900">동아리 없이 잡은 일정</h2>
+            <button
+              type="button"
+              onClick={() => router.push('/chinba/create')}
+              className="flex shrink-0 items-center gap-1 rounded-lg bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+            >
+              <FiPlus size={13} />
+              일정 잡기
+            </button>
+          </div>
+
+          <div className="mt-3">
+            {!isAuthLoaded ? null : !isLoggedIn ? (
+              <p className="py-6 text-center text-xs text-gray-400 break-keep">
+                로그인하면 동아리 없이 잡은 일정을 모아볼 수 있어요.
+              </p>
+            ) : personalEvents.length === 0 ? (
+              <p className="py-6 text-center text-xs text-gray-400 break-keep">
+                동아리 없이 잡은 일정이 없어요. 링크 공유로 누구와도 시간을 맞출 수 있어요.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {personalEvents.map((event) => (
+                  <ChinbaEventListItem
+                    key={event.event_id}
+                    event={event}
+                    compact
+                    onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
 
         {/* 소개 모드일 때만: 친바가 하는 일 / 이럴 때 써요 */}
         {isAuthLoaded && isNewcomer && (

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -7,6 +7,7 @@ import { LuPlus, LuClock, LuCalendar, LuTrash2, LuPencil, LuX, LuUsers } from 'r
 
 import MemberPickerSheet from '@/(main)/chinba/_components/team/groups/MemberPickerSheet';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import Modal from '@/_components/ui/Modal';
 import { useToast } from '@/_context/ToastContext';
 import { CHINBA_GROUP_SCORING_ENABLED } from '@/_lib/constants/features';
 import {
@@ -297,12 +298,16 @@ export default function ActivityTab({
         </p>
       )}
 
-      {/* Create / Edit Form */}
-      {showForm && (
-        <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3">
-          <p className="text-xs font-medium text-gray-500">
-            {isEditing ? '활동 기록 수정' : '활동 기록하기'}
-          </p>
+      {/* Create / Edit Form — 팝업 모달. X/배경 클릭으로 닫으면 아무것도 확정하지 않는다
+          (완료 흐름에서 온 경우에도 일정은 진행중 상태로 보존 — '기록하지 않기'와 다름) */}
+      <Modal
+        isOpen={showForm}
+        onClose={closeForm}
+        title={isEditing ? '활동 기록 수정' : '활동 기록하기'}
+        // 모바일은 기본 폭, 데스크톱(md+)은 기존 인라인 카드처럼 넓게 — 세로 스크롤을 줄인다
+        maxWidth="max-w-md md:max-w-2xl"
+      >
+        <div className="p-4 space-y-3">
           <input
             type="text"
             placeholder="활동 제목"
@@ -512,7 +517,7 @@ export default function ActivityTab({
             </button>
           </div>
         </div>
-      )}
+      </Modal>
 
       {/* 참여 인원 선택 시트 — 기존 선택을 이어받고, 제외는 폼의 칩에서 한다 */}
       {showMemberPicker && (

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -15,6 +15,7 @@ import {
   useUpdateActivity,
   useDeleteActivity,
 } from '@/_lib/hooks/useActivities';
+import { useCompleteChinbaEvent } from '@/_lib/hooks/useChinba';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroups, useGroupSets } from '@/_lib/hooks/useGroups';
 import { useTeamMembers } from '@/_lib/hooks/useTeam';
@@ -57,10 +58,14 @@ export default function ActivityTab({
   const createMutation = useCreateActivity(teamId);
   const updateMutation = useUpdateActivity(teamId);
   const deleteMutation = useDeleteActivity(teamId);
+  const completeEventMutation = useCompleteChinbaEvent();
   const { showToast } = useToast();
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
+  // 일정 완료 처리 흐름에서 넘어온 경우의 대상 일정 id — 이 값이 있으면
+  // '기록하기/기록하지 않기' 선택 시점에 해당 일정의 완료가 확정된다.
+  const [completingEventId, setCompletingEventId] = useState<string | null>(null);
   const [formData, setFormData] = useState<ActivityCreateRequest>({
     title: '',
     activity_date: new Date().toISOString().slice(0, 10),
@@ -109,11 +114,14 @@ export default function ActivityTab({
     setEditingId(null);
   }, [selectedGroupId]);
 
-  // 일정 완료 처리에서 넘어온 경우: 활동 기록 폼을 완료된 일정 정보로 미리 채워 자동 오픈.
-  // (URL의 recordTitle/recordDate 파라미터를 1회 소비하고 즉시 제거해 재오픈 방지)
+  // 일정 완료 처리에서 넘어온 경우: 활동 기록 폼을 일정 정보로 미리 채워 자동 오픈.
+  // 이 시점에 일정은 아직 완료되지 않았다 — 폼의 '기록하기/기록하지 않기'를 눌러야 완료가
+  // 확정되고, 아무 버튼 없이 이탈하면 일정은 이전 상태 그대로 보존된다.
+  // (URL의 record* 파라미터를 1회 소비하고 즉시 제거해 재오픈 방지)
   useEffect(() => {
     const recordTitle = searchParams.get('recordTitle');
-    if (recordTitle === null) return;
+    const recordEventId = searchParams.get('recordEventId');
+    if (recordTitle === null && recordEventId === null) return;
 
     if (hasRole) {
       const recordDate = searchParams.get('recordDate');
@@ -124,11 +132,12 @@ export default function ActivityTab({
           ? Number(recordCategoryIdRaw)
           : undefined;
       setFormData({
-        title: recordTitle,
+        title: recordTitle ?? '',
         activity_date: recordDate || new Date().toISOString().slice(0, 10),
         category_id: recordCategoryId,
       });
       setFormScores([]);
+      setCompletingEventId(recordEventId);
       setShowForm(true);
     }
 
@@ -136,6 +145,7 @@ export default function ActivityTab({
     params.delete('recordTitle');
     params.delete('recordDate');
     params.delete('recordCategoryId');
+    params.delete('recordEventId');
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,6 +166,7 @@ export default function ActivityTab({
   const closeForm = () => {
     setShowForm(false);
     setEditingId(null);
+    setCompletingEventId(null);
     setFormData({ title: '', activity_date: new Date().toISOString().slice(0, 10) });
     setFormScores([]);
     setParticipantIds([]);
@@ -164,6 +175,7 @@ export default function ActivityTab({
 
   const handleEdit = (activity: Activity) => {
     setEditingId(activity.id);
+    setCompletingEventId(null);
     setFormData({
       title: activity.title,
       activity_date: activity.activity_date,
@@ -179,6 +191,20 @@ export default function ActivityTab({
     setFormScores(activity.scores.map((s) => ({ group_id: s.group_id, score: s.score })));
     setParticipantIds(activity.participants.map((p) => p.member_id));
     setShowForm(true);
+  };
+
+  const isCompletionMode = completingEventId !== null && !isEditing;
+
+  // '기록하지 않기' — 기록 없이 일정 완료만 확정
+  const handleSkipRecord = async () => {
+    if (!completingEventId) return;
+    try {
+      await completeEventMutation.mutateAsync(completingEventId);
+      showToast('일정이 완료 처리되었습니다');
+      closeForm();
+    } catch {
+      showToast('일정 완료 처리에 실패했어요', 'error');
+    }
   };
 
   const handleSubmit = async () => {
@@ -217,6 +243,15 @@ export default function ActivityTab({
           category_id: submitCategoryId,
           participant_member_ids: participantIds.length > 0 ? participantIds : undefined,
         });
+        // 일정 완료 흐름에서 온 기록이면 이 시점에 일정 완료를 확정한다
+        if (completingEventId) {
+          try {
+            await completeEventMutation.mutateAsync(completingEventId);
+          } catch {
+            // 기록은 이미 저장됨 — 완료만 실패했으니 일정 상세에서 다시 완료 처리하면 된다
+            showToast('기록은 저장됐지만 일정 완료 처리에 실패했어요', 'error');
+          }
+        }
       }
       closeForm();
     } catch {
@@ -450,10 +485,15 @@ export default function ActivityTab({
 
           <div className="flex gap-2 pt-1">
             <button
-              onClick={closeForm}
-              className="flex-1 rounded-lg bg-gray-200 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-300"
+              onClick={isCompletionMode ? handleSkipRecord : closeForm}
+              disabled={isCompletionMode && completeEventMutation.isPending}
+              className="flex-1 rounded-lg bg-gray-200 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-300 disabled:opacity-50"
             >
-              취소
+              {isCompletionMode
+                ? completeEventMutation.isPending
+                  ? '처리 중...'
+                  : '기록하지 않기'
+                : '취소'}
             </button>
             <button
               onClick={handleSubmit}

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -238,7 +238,7 @@ function EventCard({ event, groupSetNameMap, onClick }: { event: TeamEvent; grou
                 : 'bg-gray-50 text-gray-400'
           }`}
         >
-          {event.status === 'active' ? '진행 중' : event.status === 'completed' ? '완료' : '만료'}
+          {event.status === 'active' ? '진행 중' : event.status === 'completed' ? '완료됨' : '지난 일정'}
         </span>
       </div>
 

--- a/app/_lib/api/chinba.ts
+++ b/app/_lib/api/chinba.ts
@@ -6,6 +6,7 @@ import type {
   ChinbaEventCreateRequest,
   ChinbaEventCreateResponse,
   ChinbaEventTeamJoinResponse,
+  ChinbaParticipantUnavailability,
   ChinbaUnavailabilityUpdateRequest,
 } from '@/_types/chinba';
 
@@ -28,6 +29,14 @@ export async function joinChinbaEventTeam(eventId: string): Promise<ChinbaEventT
 
 export async function getChinbaMyParticipation(eventId: string): Promise<ChinbaMyParticipation> {
   const res = await api.get(`/chinba/events/${eventId}/my-participation`);
+  return res.data;
+}
+
+export async function getChinbaParticipantUnavailability(
+  eventId: string,
+  userId: number,
+): Promise<ChinbaParticipantUnavailability> {
+  const res = await api.get(`/chinba/events/${eventId}/participants/${userId}/unavailability`);
   return res.data;
 }
 

--- a/app/_lib/hooks/useChinba.ts
+++ b/app/_lib/hooks/useChinba.ts
@@ -95,12 +95,15 @@ export function useJoinChinbaEventTeam(eventId: string) {
   });
 }
 
+// 삭제·완료는 팀 상세의 일정 탭 목록(['teams', teamId, 'events', ...])에도 반영되어야 한다 —
+// teams 캐시를 함께 비우지 않으면 목록이 옛 상태(진행중/존재)로 남는다.
 export function useDeleteChinbaEvent() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (eventId: string) => deleteChinbaEvent(eventId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
     },
   });
 }
@@ -112,6 +115,7 @@ export function useCompleteChinbaEvent() {
     onSuccess: (_data, eventId) => {
       queryClient.invalidateQueries({ queryKey: ['chinba', 'event', eventId] });
       queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
     },
   });
 }

--- a/app/_lib/hooks/useChinba.ts
+++ b/app/_lib/hooks/useChinba.ts
@@ -5,6 +5,7 @@ import {
   getMyChinbaEvents,
   getChinbaEventDetail,
   getChinbaMyParticipation,
+  getChinbaParticipantUnavailability,
   createChinbaEvent,
   updateChinbaUnavailability,
   importChinbaTimetable,
@@ -41,6 +42,19 @@ export function useMyParticipation(eventId: string | undefined) {
     queryKey: ['chinba', 'participation', eventId],
     queryFn: () => getChinbaMyParticipation(eventId!),
     enabled: !!eventId,
+    staleTime: 1000 * 30,
+  });
+}
+
+// 전체 일정에서 참여자 클릭 시 그 사람의 불가능 시간을 조회한다 (userId가 없으면 비활성)
+export function useParticipantUnavailability(
+  eventId: string | undefined,
+  userId: number | null,
+) {
+  return useQuery({
+    queryKey: ['chinba', 'participant-unavailability', eventId, userId],
+    queryFn: () => getChinbaParticipantUnavailability(eventId!, userId!),
+    enabled: !!eventId && userId !== null,
     staleTime: 1000 * 30,
   });
 }

--- a/app/_lib/utils/chinbaUpcoming.ts
+++ b/app/_lib/utils/chinbaUpcoming.ts
@@ -1,0 +1,48 @@
+/** 친바 '다가오는 일정' 선별 — MY 탭과 타임라인 홈 카드가 같은 기준을 쓴다. */
+
+/** dates 배열에서 오늘(자정) 이후의 가장 이른 날짜를 ms로 반환. 없으면 null. */
+export function earliestUpcoming(dates: string[], todayMs: number): number | null {
+  let min: number | null = null;
+  for (const d of dates) {
+    const t = new Date(d).getTime();
+    if (Number.isNaN(t) || t < todayMs) continue;
+    if (min === null || t < min) min = t;
+  }
+  return min;
+}
+
+export interface UpcomingEntry<T> {
+  event: T;
+  /** 가장 이른 예정 날짜 (자정 기준 ms) */
+  when: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** 다가오는 일정으로 치는 기간 — 가장 이른 예정 날짜가 오늘부터 7일 이내(7일째 포함) */
+const UPCOMING_WINDOW_DAYS = 7;
+
+/**
+ * active 일정 중 가장 이른 예정 날짜가 오늘~7일 이내인 것을 날짜 오름차순으로 반환.
+ * 홈 카드와 MY 탭 '다가오는 일정'이 함께 쓴다.
+ */
+export function selectUpcoming<T extends { status: string; dates: string[] }>(
+  events: T[],
+): UpcomingEntry<T>[] {
+  const todayMs = new Date(new Date().toDateString()).getTime();
+  const limitMs = todayMs + UPCOMING_WINDOW_DAYS * DAY_MS;
+  return events
+    .filter((e) => e.status === 'active')
+    .map((event) => ({ event, when: earliestUpcoming(event.dates, todayMs) }))
+    .filter((x): x is UpcomingEntry<T> => x.when !== null && x.when <= limitMs)
+    .sort((a, b) => a.when - b.when);
+}
+
+/** 예정 날짜 표시용 라벨 — 오늘/내일/M월 D일 */
+export function formatUpcomingDate(whenMs: number): string {
+  const todayMs = new Date(new Date().toDateString()).getTime();
+  if (whenMs < todayMs + DAY_MS) return '오늘';
+  if (whenMs < todayMs + DAY_MS * 2) return '내일';
+  const d = new Date(whenMs);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+}

--- a/app/_types/chinba.ts
+++ b/app/_types/chinba.ts
@@ -58,6 +58,8 @@ export interface ChinbaEventListItem {
   title: string;
   dates: string[];
   status: 'active' | 'completed' | 'expired';
+  /** 동아리 일정이면 팀 id, 개인(동아리 없이 잡은) 일정이면 null */
+  team_id: number | null;
   creator_id: number;
   creator_nickname: string | null;
   participant_count: number;

--- a/app/_types/chinba.ts
+++ b/app/_types/chinba.ts
@@ -53,6 +53,14 @@ export interface ChinbaMyParticipation {
   unavailable_slots: string[];
 }
 
+/** 특정 참여자의 불가능 시간 — 전체 일정에서 참여자 클릭 시 개인 일정 강조용 */
+export interface ChinbaParticipantUnavailability {
+  user_id: number;
+  nickname: string | null;
+  has_submitted: boolean;
+  unavailable_slots: string[];
+}
+
 export interface ChinbaEventListItem {
   event_id: string;
   title: string;

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -153,6 +153,7 @@ export const MOCK_CHINBA_EVENTS = [
     title: '조별과제 회의',
     dates: ['2024-07-10', '2024-07-11', '2024-07-12'],
     status: 'active' as const,
+    team_id: null,
     creator_id: 1,
     creator_nickname: '테스트유저',
     participant_count: 3,


### PR DESCRIPTION
## 개요
  타임라인(친바)의 두 가지 버그 수정 — ① 완료 처리 후 기록 취소 시 상태 불일치·기록 경로 소실, ② 날짜 지난 일정이 기록 불가·목록에서 소실 — 과 함께 진행한 UX 개선 모음.

  ## 변경 사항
  
  ### 1. 일정 완료 확정을 기록 선택 시점으로 이연 (e49c0a6)
  - 기존: 완료 확인 시 즉시 완료 API 호출 → 기록창에서 취소해도 완료가 확정되어 기록 경로가 영구히 끊김.
  - 변경: 완료 확인 → 기록 폼이 열리고, 폼의 **기록하기**(기록+완료) / **기록하지 않기**(완료만) 버튼을 눌러야 완료가 확정된다. 버튼 없이 이탈(뒤로 가기·창 닫힘)하면 일정은 진행중 그대로 보존.
  - 완료·삭제 mutation이 `teams` 캐시를 무효화하지 않아 일정 탭 목록이 옛 상태(진행중)로 남던 문제 수정.
  - 지난(expired) 일정에도 완료 버튼 노출 + 배너 문구 정리, returnTo 없이 진입해도 팀 상세 기록 탭으로 폴백.
  - 상태 배지 문구: 완료 → **완료됨**, 만료 → **지난 일정**.
  - 개인 친바(팀 없음)는 기록 개념이 없어 기존대로 즉시 완료.

  ### 2. 활동 기록 폼을 팝업 모달로 전환 (da82a2f)
  - 인라인 카드였던 기록 폼(생성·수정)을 범용 Modal 팝업으로 — 내용이 길어도 팝업 안에서만 스크롤. 데스크톱(md+)은 넓게(max-w-2xl) 표시.
  - X/배경/Esc로 닫으면 아무것도 확정하지 않음(완료 흐름에서도 일정 보존 — '기록하지 않기'와 구분).

  ### 3. 홈에 다가오는 일정 카드·개인 일정 섹션 추가 (821b2c3)
  - 제목 카드 옆 **다가오는 일정** 카드(데스크톱 전용, 모바일 숨김) — 앱 폴더처럼 2×2 미니 타일. 일정 최대 3개는 각각 상세로, 4개 이상이면 +N 타일이 MY로 이동.
  - 기준: 가장 이른 예정 날짜가 **오늘부터 7일 이내(포함)**인 진행중 일정 — MY 탭과 공용 유틸(`chinbaUpcoming.ts`)로 공유.
  - "동아리 없이 일정 잡기" 텍스트 버튼을 동아리 선택과 같은 **섹션 카드**로 교체 — 동아리 없이 잡은 개인 일정(team_id null) 목록 + 일정 잡기 버튼. 완료 전(진행중·지난 일정)까지 노출.

  ### 4. 동아리 전환 드롭다운 안내 툴팁 (56149f5)
  - 동아리가 처음으로 2개 이상이 된 뒤 팀 상세를 열면 상단 동아리 이름 아래 "다른 동아리로 바꾸고 싶다면 클릭하세요" 툴팁 1회 노출 (게시판 필터 툴팁과 같은 localStorage 패턴).
  - X 클릭·드롭다운 클릭·10초 경과 시 닫히고 다시 안 뜸.
  
  ### 5. 시간 그리드 일괄 선택·참여자별 일정 강조 (4584a05)
  - 내 일정 드래그 그리드: **날짜 머리글 클릭** = 그 열 전체, **'N시' 라벨 클릭** = 그 시간대(1시간)×전체 날짜 선택/해제 토글 (패딩 열 제외).
  - 전체 일정: 제출한 참여자 알약 클릭 시 그 사람의 불가능 시간을 히트맵에 빨간색 강조(나머지는 흐리게). 재클릭 해제·다른 사람 클릭 전환, 선택 표시는 알약 검정 강조. 신규 참여자별 조회 API 사용.

  ## 테스트
  - 유닛 테스트 353개 통과, ESLint 에러 0, `npm run build`(정적 export + 타입체크) 성공.
  - e2e 목 데이터에 `team_id` 반영.