### PR TITLE
feat(timeline): 해시태그 숨김 · 하이라이트 입력 일원화 · 사이드바 접힘 버그 수정

### DIFF
--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -23,7 +23,7 @@ import MannajaTab from '@/(main)/teams/detail/_components/MannajaTab';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
-import { CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
+import { CHINBA_HASHTAG_ENABLED, CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
@@ -82,7 +82,9 @@ export default function TeamDetailView() {
   const groupSets = groupSetsData?.group_sets ?? [];
   const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
 
-  const { data: categoriesData } = useEventCategories(teamId || undefined);
+  const { data: categoriesData } = useEventCategories(
+    CHINBA_HASHTAG_ENABLED && teamId ? teamId : undefined
+  );
   const categories = categoriesData?.categories ?? [];
 
   // 선택 중이던 카테고리가 삭제되면 필터 자동 해제 (로딩 중 오리셋 방지 위해 데이터 존재 가드)
@@ -309,12 +311,14 @@ export default function TeamDetailView() {
             teamId={teamId}
             myRole={team.my_role}
           />
-          <TeamCategoriesModal
-            isOpen={showCategories}
-            onClose={() => setShowCategories(false)}
-            teamId={teamId}
-            myRole={team.my_role}
-          />
+          {CHINBA_HASHTAG_ENABLED && (
+            <TeamCategoriesModal
+              isOpen={showCategories}
+              onClose={() => setShowCategories(false)}
+              teamId={teamId}
+              myRole={team.my_role}
+            />
+          )}
         </>
       )}
     </>

--- a/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
@@ -6,6 +6,7 @@ import { FiPlus, FiXCircle } from 'react-icons/fi';
 
 import DateSelector from '@/(main)/chinba/create/_components/DateSelector';
 import Button from '@/_components/ui/Button';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useCreateEventCategory, useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroups, useGroupSets } from '@/_lib/hooks/useGroups';
 import { useTeamDetail } from '@/_lib/hooks/useTeam';
@@ -32,12 +33,14 @@ export default function TeamEventCreateBody({
   const { data: groupsData } = useGroups(teamId);
   const { data: groupSetsData } = useGroupSets(teamId);
   const { data: team } = useTeamDetail(teamId || undefined);
-  const { data: categoriesData } = useEventCategories(teamId || undefined);
+  const { data: categoriesData } = useEventCategories(
+    CHINBA_HASHTAG_ENABLED && teamId ? teamId : undefined
+  );
   const createEvent = useCreateTeamEvent(teamId);
   const createCategory = useCreateEventCategory(teamId);
 
   const categories = categoriesData?.categories ?? [];
-  const canManageCategory = team ? canEditTeam(team.my_role) : false;
+  const canManageCategory = CHINBA_HASHTAG_ENABLED && !!team && canEditTeam(team.my_role);
 
   const allGroups = groupsData?.groups ?? [];
   const groupSets = groupSetsData?.group_sets ?? [];
@@ -61,7 +64,9 @@ export default function TeamEventCreateBody({
   const [title, setTitle] = useState('');
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
   const [selectedGroupIds, setSelectedGroupIds] = useState<number[]>([]);
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(preCategoryId);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
+    CHINBA_HASHTAG_ENABLED ? preCategoryId : null
+  );
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [quickAddName, setQuickAddName] = useState('');
   const [quickAddError, setQuickAddError] = useState<string | null>(null);

--- a/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
@@ -15,6 +15,7 @@ import {
 
 import TeamResponsePanel from '@/(main)/chinba/_components/team/TeamResponsePanel';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { formatInviteUrl } from '@/_lib/utils/teamDisplay';
 
 const COLLAPSE_KEY = 'team_ops_panel_collapsed';
@@ -109,7 +110,9 @@ export default function TeamOpsPanel({
           <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">운영 도구</span>
           <PanelButton icon={FiUsers} label="멤버 관리" onClick={onOpenMembers} trailing="modal" />
           <PanelButton icon={FiGrid} label="조 / 그룹 관리" onClick={onOpenGroups} trailing="modal" />
-          <PanelButton icon={FiTag} label="해시태그 관리" onClick={onOpenCategories} trailing="modal" />
+          {CHINBA_HASHTAG_ENABLED && (
+            <PanelButton icon={FiTag} label="해시태그 관리" onClick={onOpenCategories} trailing="modal" />
+          )}
           <PanelButton icon={FiLink} label="초대링크 복사" onClick={handleCopyInvite} trailing="copy" />
         </section>
 

--- a/app/(main)/chinba/_components/team/TeamSettingsView.tsx
+++ b/app/(main)/chinba/_components/team/TeamSettingsView.tsx
@@ -9,6 +9,7 @@ import ConfirmModal from '@/_components/ui/ConfirmModal';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import {
   useTeamDetail,
@@ -310,11 +311,13 @@ export default function TeamSettingsView() {
           canManage={canEditTeam(myRole)}
         />
 
-        {/* 일정 카테고리 관리 */}
-        <EventCategorySection
-          teamId={teamId}
-          canManage={canEditTeam(myRole)}
-        />
+        {/* 일정 카테고리(해시태그) 관리 */}
+        {CHINBA_HASHTAG_ENABLED && (
+          <EventCategorySection
+            teamId={teamId}
+            canManage={canEditTeam(myRole)}
+          />
+        )}
 
         {/* Section 5: 회장 위임 */}
         {!isEditing && (

--- a/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
@@ -8,6 +8,7 @@ import { FiShare2, FiTrash2, FiCheckCircle, FiLink } from 'react-icons/fi';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Toast from '@/_components/ui/Toast';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useChinbaEventDetail, useDeleteChinbaEvent, useCompleteChinbaEvent } from '@/_lib/hooks/useChinba';
 import { useUser } from '@/_lib/hooks/useUser';
 import { formatDateRanges } from '@/_lib/utils/dateRange';
@@ -192,7 +193,7 @@ export default function ChinbaEventDetailBody({
       recordParams.set('recordEventId', eventId);
       if (event.title) recordParams.set('recordTitle', event.title);
       if (event.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
-      if (event.category) recordParams.set('recordCategoryId', String(event.category.id));
+      if (CHINBA_HASHTAG_ENABLED && event.category) recordParams.set('recordCategoryId', String(event.category.id));
       onCompleted(recordParams.toString());
       return;
     }

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -9,7 +9,7 @@ import MemberPickerSheet from '@/(main)/chinba/_components/team/groups/MemberPic
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Modal from '@/_components/ui/Modal';
 import { useToast } from '@/_context/ToastContext';
-import { CHINBA_GROUP_SCORING_ENABLED } from '@/_lib/constants/features';
+import { CHINBA_GROUP_SCORING_ENABLED, CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import {
   useActivities,
   useCreateActivity,
@@ -52,7 +52,7 @@ export default function ActivityTab({
     category_id: selectedCategoryId ?? undefined,
   });
   const { data: groupsData } = useGroups(teamId);
-  const { data: categoriesData } = useEventCategories(teamId);
+  const { data: categoriesData } = useEventCategories(CHINBA_HASHTAG_ENABLED ? teamId : undefined);
   const { data: membersData } = useTeamMembers(teamId);
   const teamMembers = useMemo(() => membersData?.members ?? [], [membersData]);
   const categories = categoriesData?.categories ?? [];
@@ -135,7 +135,7 @@ export default function ActivityTab({
       setFormData({
         title: recordTitle ?? '',
         activity_date: recordDate || new Date().toISOString().slice(0, 10),
-        category_id: recordCategoryId,
+        category_id: CHINBA_HASHTAG_ENABLED ? recordCategoryId : undefined,
       });
       setFormScores([]);
       setCompletingEventId(recordEventId);
@@ -600,7 +600,7 @@ function ActivityCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
             <h3 className="text-sm font-semibold text-gray-800 truncate">{activity.title}</h3>
-            {activity.category && (
+            {CHINBA_HASHTAG_ENABLED && activity.category && (
               <span className="shrink-0 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
                 #{activity.category.name}
               </span>

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -183,7 +183,6 @@ export default function ActivityTab({
       start_time: activity.start_time ?? undefined,
       end_time: activity.end_time ?? undefined,
       description: activity.description ?? undefined,
-      highlight: activity.highlight ?? undefined,
       total_cost: activity.total_cost ?? undefined,
       cost_note: activity.cost_note ?? undefined,
     });
@@ -224,8 +223,8 @@ export default function ActivityTab({
           data: {
             ...formData,
             // 비워둔 항목은 빈 문자열로 보내야 서버에서 지워진다 (undefined는 기존 값 유지)
+            // highlight는 입력 UI 폐지로 아예 보내지 않는다 — 기존 값은 서버에 그대로 남는다
             description: formData.description ?? '',
-            highlight: formData.highlight ?? '',
             start_time: formData.start_time ?? '',
             end_time: formData.end_time ?? '',
             cost_note: formData.cost_note ?? '',
@@ -348,22 +347,6 @@ export default function ActivityTab({
               onChange={(e) => setFormData({ ...formData, description: e.target.value || undefined })}
               className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none resize-none"
               rows={2}
-            />
-          </div>
-
-          {/* Highlight — 자유 텍스트 칸이 둘이라 무엇을 어디에 쓰는지 라벨·예시로 구분한다 */}
-          <div className="space-y-2">
-            <div>
-              <p className="text-xs font-medium text-gray-500">하이라이트 (선택)</p>
-              <p className="text-[11px] text-gray-400">카드 맨 위에 강조되어 보입니다</p>
-            </div>
-            <input
-              type="text"
-              placeholder="예: 장소 예약은 2주 전에"
-              aria-label="하이라이트"
-              value={formData.highlight ?? ''}
-              onChange={(e) => setFormData({ ...formData, highlight: e.target.value || undefined })}
-              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
             />
           </div>
 
@@ -642,16 +625,9 @@ function ActivityCard({
         </div>
       </div>
 
-      {/* Highlight */}
-      {activity.highlight && (
-        <p className="mt-2 text-xs text-gray-500 bg-yellow-50 rounded-lg px-2.5 py-1.5 border border-yellow-100">
-          {activity.highlight}
-        </p>
-      )}
-
-      {/* Description */}
+      {/* Description — 하이라이트 입력 폐지로 유일한 자유 텍스트: 검정에 가까운 초록으로 본문 대접 */}
       {activity.description && (
-        <p className="mt-2 text-xs text-gray-500 line-clamp-2">{activity.description}</p>
+        <p className="mt-2 text-xs text-emerald-950 line-clamp-2">{activity.description}</p>
       )}
 
       {/* Cost */}

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -8,6 +8,7 @@ import type { IconType } from 'react-icons';
 import { FiPlus, FiCalendar, FiUsers, FiLayers } from 'react-icons/fi';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useTeamEvents } from '@/_lib/hooks/useTeamEvents';
 import { formatDateRanges } from '@/_lib/utils/dateRange';
@@ -252,7 +253,7 @@ function EventCard({ event, groupSetNameMap, onClick }: { event: TeamEvent; grou
 
       {/* Target groups - 항상 표시 */}
       <div className="flex flex-wrap gap-1 mb-2">
-        {event.category && (
+        {CHINBA_HASHTAG_ENABLED && event.category && (
           <span className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[10px] font-medium text-gray-500">
             #{event.category.name}
           </span>

--- a/app/(main)/teams/detail/_components/TeamDetailClient.tsx
+++ b/app/(main)/teams/detail/_components/TeamDetailClient.tsx
@@ -8,7 +8,7 @@ import { LuChevronLeft } from 'react-icons/lu';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
-import { CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
+import { CHINBA_HASHTAG_ENABLED, CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
@@ -55,7 +55,7 @@ export default function TeamDetailClient() {
   // 세트 1개일 때 자동 선택
   const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
 
-  const { data: categoriesData } = useEventCategories(teamId);
+  const { data: categoriesData } = useEventCategories(CHINBA_HASHTAG_ENABLED ? teamId : undefined);
   const categories = categoriesData?.categories ?? [];
 
   // 선택 중이던 카테고리가 삭제되면 필터 자동 해제 (로딩 중 오리셋 방지 위해 데이터 존재 가드)

--- a/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
+++ b/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
@@ -9,6 +9,7 @@ import { LuChevronLeft } from 'react-icons/lu';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import {
   useTeamDetail,
@@ -322,11 +323,13 @@ export default function TeamSettingsClient() {
           canManage={canEditTeam(myRole)}
         />
 
-        {/* 일정 카테고리 관리 */}
-        <EventCategorySection
-          teamId={teamId}
-          canManage={canEditTeam(myRole)}
-        />
+        {/* 일정 카테고리(해시태그) 관리 */}
+        {CHINBA_HASHTAG_ENABLED && (
+          <EventCategorySection
+            teamId={teamId}
+            canManage={canEditTeam(myRole)}
+          />
+        )}
 
         {/* Section 5: 구독 관리 */}
         <SubscriptionSection

--- a/app/_components/layout/DesktopSidebar.tsx
+++ b/app/_components/layout/DesktopSidebar.tsx
@@ -54,6 +54,7 @@ export default function DesktopSidebar({ collapsed, onToggle }: DesktopSidebarPr
 
   return (
     <aside
+      data-app-sidebar
       className={`hidden md:flex md:shrink-0 h-full border-r border-gray-100 bg-white overflow-hidden relative${
         transitionEnabled ? ' transition-[width] duration-300 ease-in-out' : ''
       } ${collapsed ? 'md:w-[60px]' : 'md:w-[260px]'}`}

--- a/app/_lib/constants/features.ts
+++ b/app/_lib/constants/features.ts
@@ -20,3 +20,10 @@ export const CHINBA_GROUP_SCORING_ENABLED: boolean = false;
  * "추후 업데이트 예정입니다" 안내만 띄운다. 백엔드 랭킹 API·데이터는 그대로 살아 있다.
  */
 export const CHINBA_RANKING_TAB_ENABLED: boolean = false;
+
+/**
+ * 해시태그(일정 카테고리) — 관리 모달·일정/활동 폼의 선택·필터바·배지 전부.
+ * 조/그룹 기능과 역할이 겹쳐 숨김(2026-08 결정). 백엔드 event-categories API와
+ * 이미 기록된 해시태그 데이터는 그대로 살아 있다.
+ */
+export const CHINBA_HASHTAG_ENABLED: boolean = false;

--- a/app/globals.css
+++ b/app/globals.css
@@ -135,15 +135,17 @@ body {
   animation: slideInLeft 0.25s ease-out;
 }
 
-/* 사이드바 FOUC 방지 — React 로딩 전 인라인 스크립트가 클래스 추가 */
+/* 사이드바 FOUC 방지 — React 로딩 전 인라인 스크립트가 클래스 추가.
+   data-app-sidebar(왼쪽 앱 사이드바)로 한정 — 맨 aside 선택자는 오른쪽 운영 패널 같은
+   다른 aside까지 강제 접힘시켜 왼쪽이 접힌 동안 오른쪽이 안 펴지는 버그가 있었다 */
 @media (min-width: 52rem) {
-  .sidebar-collapsed aside {
+  .sidebar-collapsed aside[data-app-sidebar] {
     width: 60px !important;
   }
-  .sidebar-collapsed aside > div:first-child {
+  .sidebar-collapsed aside[data-app-sidebar] > div:first-child {
     opacity: 1 !important;
   }
-  .sidebar-collapsed aside > div:last-child {
+  .sidebar-collapsed aside[data-app-sidebar] > div:last-child {
     opacity: 0 !important;
     pointer-events: none !important;
   }


### PR DESCRIPTION
  ## 요약

  타임라인(친바) UI 정리 3건 — 조/그룹 기능과 겹치는 해시태그 기능 숨김, 활동 기록의
  자유 텍스트 입력 일원화, 좌우 사이드바 접힘 간섭 버그 수정. 백엔드 변경 없음.

  ## 1. 해시태그 기능을 토글로 숨김 (359f7cb)

  조/그룹 기능이 생기면서 해시태그(일정 카테고리)와 역할이 겹쳐, 기능을 제거하는 대신
  빌드타임 토글로 숨긴다. `app/_lib/constants/features.ts`에 `CHINBA_HASHTAG_ENABLED = false`
  추가 (기존 랭킹 탭 토글과 같은 패턴) — 값만 `true`로 바꾸면 전부 복구된다.

  숨긴 지점:
  - 운영 패널(`TeamOpsPanel`)의 "해시태그 관리" 버튼과 관리 모달(`TeamCategoriesModal`)
  - 동아리 설정의 해시태그 관리 섹션(`TeamSettingsView`/`TeamSettingsClient`의 `EventCategorySection`)
  - 일정 잡기 폼(`TeamEventCreateBody`)의 해시태그 선택·빠른 추가 (URL로 넘어온 `categoryId`도 무시)
  - 활동 기록 폼(`ActivityTab`)의 해시태그 선택, 일정 완료→기록 흐름의 `recordCategoryId` 전달 차단
  - 카테고리 필터바(`CategoryFilterBar` — 조회 쿼리를 꺼서 자동 미렌더)와
    일정 목록(`MannajaTab`)·활동 카드(`ActivityTab`)의 `#태그` 배지

  백엔드 event-categories API와 기존 해시태그 데이터는 그대로 유지된다.

  ## 2. 활동 기록의 하이라이트 입력·표시 제거 (1d6367d)

  활동 기록 폼에 자유 텍스트 칸이 둘(활동 설명 / 하이라이트)이라 역할이 겹쳐
  활동 설명 하나로 합친다.

  - 폼에서 하이라이트 입력 블록 제거
  - 카드에서 노란 하이라이트 박스 제거, 활동 설명 글씨를 `text-gray-500` →
    `text-emerald-950`(브랜드 초록 계열의 짙은 색)으로 올려 본문 대접
  - 수정 요청에서 `highlight` 필드를 아예 보내지 않아 서버에 저장된 기존 값은 보존
    (화면에만 안 보임) — DB 컬럼·API 무변경

  ## 3. 왼쪽 사이드바 접힘 CSS가 오른쪽 운영 패널까지 접던 버그 수정 (6bad63d)

  왼쪽 앱 사이드바를 접으면 `<html>`에 `sidebar-collapsed` 클래스가 붙는데,
  FOUC 방지용 CSS 규칙이 맨 `aside` 선택자라 페이지의 모든 aside에
  `width:60px !important` + `opacity:0` + `pointer-events:none`을 강제했다.
  오른쪽 운영 패널도 `<aside>`라서 왼쪽이 접힌 동안 오른쪽을 펼쳐도 화면에
  나타나지 않고, 왼쪽을 펴는 순간에야 나타나는 증상이 발생.

  왼쪽 사이드바에 `data-app-sidebar` 속성을 달고 선택자를
  `aside[data-app-sidebar]`로 한정해 좌우가 독립적으로 접히도록 수정.

  ## 검증

  - ESLint: 변경 파일 에러 0 (신규 import 순서 경고 정리 포함)
  - `npm run test:run`: 353개 전부 통과
  - `npm run build`: 정적 export 성공
  - 사이드바 버그는 dev 서버에서 좌/우 독립 접힘 수동 확인