### PR TITLE
feat(chinba): 랭킹 탭 버튼과 미제출자 알림 버튼을 토글로 숨김 — 애플 앱 심사 대비

### DIFF
--- a/app/(main)/chinba/_components/team/TeamResponsePanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamResponsePanel.tsx
@@ -6,6 +6,7 @@ import { FiChevronDown, FiChevronUp, FiCopy, FiBell } from 'react-icons/fi';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_UNSUBMITTED_NOTIFY_ENABLED } from '@/_lib/constants/features';
 import { useTeamEvents, useTeamEventDetail } from '@/_lib/hooks/useTeamEvents';
 
 interface TeamResponsePanelProps {
@@ -126,13 +127,15 @@ export default function TeamResponsePanel({ teamId }: TeamResponsePanelProps) {
                                 <FiCopy size={11} />
                                 복사
                               </button>
-                              <button
-                                onClick={handleNotify}
-                                className="flex flex-1 items-center justify-center gap-1 rounded-lg bg-gray-900 py-1.5 text-[11px] font-medium text-white transition-colors hover:bg-gray-800"
-                              >
-                                <FiBell size={11} />
-                                알림
-                              </button>
+                              {CHINBA_UNSUBMITTED_NOTIFY_ENABLED && (
+                                <button
+                                  onClick={handleNotify}
+                                  className="flex flex-1 items-center justify-center gap-1 rounded-lg bg-gray-900 py-1.5 text-[11px] font-medium text-white transition-colors hover:bg-gray-800"
+                                >
+                                  <FiBell size={11} />
+                                  알림
+                                </button>
+                              )}
                             </div>
                           </>
                         )}

--- a/app/(main)/teams/_components/TeamSegmentTabs.tsx
+++ b/app/(main)/teams/_components/TeamSegmentTabs.tsx
@@ -3,6 +3,8 @@
 import type { IconType } from 'react-icons';
 import { LuCalendar, LuPencil, LuMedal } from 'react-icons/lu';
 
+import { CHINBA_RANKING_TAB_VISIBLE } from '@/_lib/constants/features';
+
 export type TeamSegment = 'mannaja' | 'mwoheni' | 'jabahbwa';
 
 interface TeamSegmentTabsProps {
@@ -13,7 +15,9 @@ interface TeamSegmentTabsProps {
 const TABS: { key: TeamSegment; label: string; icon: IconType }[] = [
   { key: 'mannaja', label: '일정', icon: LuCalendar },
   { key: 'mwoheni', label: '기록', icon: LuPencil },
-  { key: 'jabahbwa', label: '랭킹', icon: LuMedal },
+  ...(CHINBA_RANKING_TAB_VISIBLE
+    ? [{ key: 'jabahbwa' as const, label: '랭킹', icon: LuMedal }]
+    : []),
 ];
 
 export default function TeamSegmentTabs({ activeTab, onTabChange }: TeamSegmentTabsProps) {

--- a/app/_lib/constants/features.ts
+++ b/app/_lib/constants/features.ts
@@ -22,6 +22,21 @@ export const CHINBA_GROUP_SCORING_ENABLED: boolean = false;
 export const CHINBA_RANKING_TAB_ENABLED: boolean = false;
 
 /**
+ * 팀 상세의 '랭킹' 탭 버튼 노출 자체.
+ * 애플 앱 심사는 미완성 기능 노출을 불허해 버튼까지 숨김(2026-08 결정) —
+ * 심사 통과 후 dev에서 true로 되돌려 버튼(+진입 차단 안내)을 복구한다.
+ * false면 CHINBA_RANKING_TAB_ENABLED와 무관하게 탭이 렌더되지 않는다.
+ */
+export const CHINBA_RANKING_TAB_VISIBLE: boolean = false;
+
+/**
+ * 응답 현황(운영 패널)의 미제출자 '알림' 버튼.
+ * 백엔드 미비로 "준비 중" 토스트만 띄우는 빈껍데기라 앱 심사 대비 숨김(2026-08 결정) —
+ * 심사 통과 후 dev에서 true로 되돌린다. '복사' 버튼은 완성 기능이라 그대로 노출.
+ */
+export const CHINBA_UNSUBMITTED_NOTIFY_ENABLED: boolean = false;
+
+/**
  * 해시태그(일정 카테고리) — 관리 모달·일정/활동 폼의 선택·필터바·배지 전부.
  * 조/그룹 기능과 역할이 겹쳐 숨김(2026-08 결정). 백엔드 event-categories API와
  * 이미 기록된 해시태그 데이터는 그대로 살아 있다.


### PR DESCRIPTION
미완성 기능 노출을 불허하는 앱 심사 요건에 맞춰 프론트에서만 가림:
- 팀 상세 상단 '랭킹' 탭 버튼 미노출 (CHINBA_RANKING_TAB_VISIBLE)
- 운영 패널 응답 현황의 '알림' 버튼 미노출 (CHINBA_UNSUBMITTED_NOTIFY_ENABLED) — '복사' 버튼은 완성 기능이라 유지

심사 통과 후 dev에서 두 상수를 true로 되돌려 복구한다.

