### PR TITLE
release: beta → main (친바 일정 입력·팀 가입 흐름·OG 프리뷰 + 앱 심사 대비 기능 숨김 — 2026-08-09)

### DIFF
--- a/app/(main)/chinba/_components/ChinbaEventListItem.tsx
+++ b/app/(main)/chinba/_components/ChinbaEventListItem.tsx
@@ -6,8 +6,8 @@ import type { ChinbaEventListItem } from '@/_types/chinba';
 
 const STATUS_BADGE: Record<string, { label: string; className: string }> = {
   active: { label: '진행중', className: 'bg-blue-100 text-blue-700' },
-  completed: { label: '완료', className: 'bg-emerald-100 text-emerald-700' },
-  expired: { label: '만료', className: 'bg-gray-100 text-gray-500' },
+  completed: { label: '완료됨', className: 'bg-emerald-100 text-emerald-700' },
+  expired: { label: '지난 일정', className: 'bg-gray-100 text-gray-500' },
 };
 
 interface ChinbaEventListItemProps {

--- a/app/(main)/chinba/_components/MyTabContent.tsx
+++ b/app/(main)/chinba/_components/MyTabContent.tsx
@@ -12,19 +12,9 @@ import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { useUser } from '@/_lib/hooks/useUser';
+import { selectUpcoming } from '@/_lib/utils/chinbaUpcoming';
 
 import { ChinbaEventListItem } from './ChinbaEventListItem';
-
-/** dates 배열에서 오늘(자정) 이후의 가장 이른 날짜를 ms로 반환. 없으면 null. */
-function earliestUpcoming(dates: string[], todayMs: number): number | null {
-  let min: number | null = null;
-  for (const d of dates) {
-    const t = new Date(d).getTime();
-    if (Number.isNaN(t) || t < todayMs) continue;
-    if (min === null || t < min) min = t;
-  }
-  return min;
-}
 
 export default function MyTabContent() {
   const router = useRouter();
@@ -43,15 +33,10 @@ export default function MyTabContent() {
   );
 
   // 다가오는 일정: 오늘 이후 날짜를 가진 active 일정, 가장 이른 날짜 오름차순
-  const upcoming = useMemo(() => {
-    const todayMs = new Date(new Date().toDateString()).getTime();
-    return (events ?? [])
-      .filter((e) => e.status === 'active')
-      .map((e) => ({ event: e, when: earliestUpcoming(e.dates, todayMs) }))
-      .filter((x): x is { event: (typeof x)['event']; when: number } => x.when !== null)
-      .sort((a, b) => a.when - b.when)
-      .map((x) => x.event);
-  }, [events]);
+  const upcoming = useMemo(
+    () => selectUpcoming(events ?? []).map((x) => x.event),
+    [events],
+  );
 
   const teams = teamsData?.teams ?? [];
   const isLoading = !isAuthLoaded || (isLoggedIn && (isEventsLoading || isTeamsLoading));

--- a/app/(main)/chinba/_components/team/ClubSwitcher.tsx
+++ b/app/(main)/chinba/_components/team/ClubSwitcher.tsx
@@ -1,12 +1,16 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
-import { LuCheck, LuChevronDown } from 'react-icons/lu';
+import { LuCheck, LuChevronDown, LuX } from 'react-icons/lu';
 
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { setLastTeamId } from '@/_lib/utils/chinbaSelection';
+
+// 동아리가 처음으로 2개 이상이 됐을 때 드롭다운 안내를 1회 보여주기 위한 플래그
+// (게시판 필터의 hasSeenFilterTooltip과 같은 패턴)
+const HINT_STORAGE_KEY = 'hasSeenClubSwitcherHint';
 
 interface ClubSwitcherProps {
   currentTeamId: number;
@@ -16,9 +20,36 @@ interface ClubSwitcherProps {
 export default function ClubSwitcher({ currentTeamId, currentName }: ClubSwitcherProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [showHint, setShowHint] = useState(false);
 
   const { data } = useMyTeams();
   const teams = data?.teams ?? [];
+
+  // 동아리가 2개 이상이 된 뒤 처음 이 화면을 보면 드롭다운 안내를 띄운다
+  useEffect(() => {
+    if (teams.length <= 1) return;
+    try {
+      if (!localStorage.getItem(HINT_STORAGE_KEY)) setShowHint(true);
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [teams.length]);
+
+  const dismissHint = useCallback(() => {
+    setShowHint(false);
+    try {
+      localStorage.setItem(HINT_STORAGE_KEY, 'true');
+    } catch {
+      // ignore localStorage errors
+    }
+  }, []);
+
+  // 10초 지나면 자동으로 닫는다 (닫힘 = 봤음 처리 — 다시 안 뜸)
+  useEffect(() => {
+    if (!showHint) return;
+    const timer = setTimeout(dismissHint, 10_000);
+    return () => clearTimeout(timer);
+  }, [showHint, dismissHint]);
 
   // 전환할 다른 동아리가 없으면 이름만 표시 (드롭다운 미노출)
   // 제목 태그·스타일은 FullPageModal 헤더가 소유한다 — 여기서 h1을 쓰면 h1 중첩이 된다
@@ -38,7 +69,10 @@ export default function ClubSwitcher({ currentTeamId, currentName }: ClubSwitche
     <div className="relative">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (showHint) dismissHint();
+          setOpen((v) => !v);
+        }}
         className="flex items-center gap-1 rounded-lg px-2 py-1 text-base font-bold text-gray-800 transition-colors hover:bg-gray-100 active:scale-95"
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -50,6 +84,28 @@ export default function ClubSwitcher({ currentTeamId, currentName }: ClubSwitche
           className={`shrink-0 text-gray-500 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
+
+      {/* 동아리 전환 안내 툴팁 — 처음으로 동아리가 2개 이상이 됐을 때 1회 노출 */}
+      {showHint && !open && (
+        <div className="absolute left-1/2 top-full z-[70] mt-2 -translate-x-1/2 animate-fadeIn">
+          <div className="relative flex items-center gap-2 whitespace-nowrap rounded-lg bg-gray-900 px-3 py-2 text-xs font-medium text-white shadow-lg">
+            <span>다른 동아리로 바꾸고 싶다면 클릭하세요</span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                dismissHint();
+              }}
+              className="rounded-full p-0.5 hover:bg-gray-700"
+              aria-label="안내 닫기"
+            >
+              <LuX size={12} />
+            </button>
+            {/* 화살표 (위쪽 동아리 이름을 향함) */}
+            <div className="absolute -top-1 left-1/2 h-2 w-2 -translate-x-1/2 rotate-45 bg-gray-900" />
+          </div>
+        </div>
+      )}
 
       {open && (
         <>

--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -337,7 +337,7 @@ export default function TeamDetailView() {
                 <LuChevronLeft size={22} strokeWidth={2.5} className="transition-transform group-hover:-translate-x-0.5" />
               </button>
               <span className="text-base font-bold text-gray-800">
-                {view === 'create' ? '동아리 친바 만들기' : team.name}
+                {view === 'create' ? '일정 잡기' : team.name}
               </span>
             </div>
             <div className="flex min-h-0 flex-1 flex-col pt-2">

--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -23,7 +23,7 @@ import MannajaTab from '@/(main)/teams/detail/_components/MannajaTab';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
-import { CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
+import { CHINBA_HASHTAG_ENABLED, CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
@@ -82,7 +82,9 @@ export default function TeamDetailView() {
   const groupSets = groupSetsData?.group_sets ?? [];
   const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
 
-  const { data: categoriesData } = useEventCategories(teamId || undefined);
+  const { data: categoriesData } = useEventCategories(
+    CHINBA_HASHTAG_ENABLED && teamId ? teamId : undefined
+  );
   const categories = categoriesData?.categories ?? [];
 
   // 선택 중이던 카테고리가 삭제되면 필터 자동 해제 (로딩 중 오리셋 방지 위해 데이터 존재 가드)
@@ -309,12 +311,14 @@ export default function TeamDetailView() {
             teamId={teamId}
             myRole={team.my_role}
           />
-          <TeamCategoriesModal
-            isOpen={showCategories}
-            onClose={() => setShowCategories(false)}
-            teamId={teamId}
-            myRole={team.my_role}
-          />
+          {CHINBA_HASHTAG_ENABLED && (
+            <TeamCategoriesModal
+              isOpen={showCategories}
+              onClose={() => setShowCategories(false)}
+              teamId={teamId}
+              myRole={team.my_role}
+            />
+          )}
         </>
       )}
     </>

--- a/app/(main)/chinba/_components/team/TeamDetailView.tsx
+++ b/app/(main)/chinba/_components/team/TeamDetailView.tsx
@@ -374,9 +374,12 @@ export default function TeamDetailView() {
   }
 
   return (
+    // 동아리 메인은 하단 탭바(홈·동아리·MY)가 떠 있는 경로라 뒤로가기가 없어도 나갈 수 있다
+    // (chinba/layout.tsx의 BOTTOM_TAB_PATHS). 일정 상세·일정 잡기는 탭바가 없으므로 그대로 둔다.
     <FullPageModal
       isOpen={true}
       onClose={goBack}
+      showBackButton={false}
       title={<ClubSwitcher currentTeamId={teamId} currentName={team.name} />}
       headerRight={settingsButton}
     >

--- a/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
@@ -6,6 +6,7 @@ import { FiPlus, FiXCircle } from 'react-icons/fi';
 
 import DateSelector from '@/(main)/chinba/create/_components/DateSelector';
 import Button from '@/_components/ui/Button';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useCreateEventCategory, useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroups, useGroupSets } from '@/_lib/hooks/useGroups';
 import { useTeamDetail } from '@/_lib/hooks/useTeam';
@@ -32,12 +33,14 @@ export default function TeamEventCreateBody({
   const { data: groupsData } = useGroups(teamId);
   const { data: groupSetsData } = useGroupSets(teamId);
   const { data: team } = useTeamDetail(teamId || undefined);
-  const { data: categoriesData } = useEventCategories(teamId || undefined);
+  const { data: categoriesData } = useEventCategories(
+    CHINBA_HASHTAG_ENABLED && teamId ? teamId : undefined
+  );
   const createEvent = useCreateTeamEvent(teamId);
   const createCategory = useCreateEventCategory(teamId);
 
   const categories = categoriesData?.categories ?? [];
-  const canManageCategory = team ? canEditTeam(team.my_role) : false;
+  const canManageCategory = CHINBA_HASHTAG_ENABLED && !!team && canEditTeam(team.my_role);
 
   const allGroups = groupsData?.groups ?? [];
   const groupSets = groupSetsData?.group_sets ?? [];
@@ -61,7 +64,9 @@ export default function TeamEventCreateBody({
   const [title, setTitle] = useState('');
   const [selectedDates, setSelectedDates] = useState<string[]>([]);
   const [selectedGroupIds, setSelectedGroupIds] = useState<number[]>([]);
-  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(preCategoryId);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(
+    CHINBA_HASHTAG_ENABLED ? preCategoryId : null
+  );
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [quickAddName, setQuickAddName] = useState('');
   const [quickAddError, setQuickAddError] = useState<string | null>(null);

--- a/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateBody.tsx
@@ -20,7 +20,7 @@ interface TeamEventCreateBodyProps {
   onSuccess: () => void;
 }
 
-// 동아리 친바 만들기 폼 본문 — 풀페이지(/chinba/team/event-create)와
+// 동아리 '일정 잡기' 폼 본문 — 풀페이지(/chinba/team/event-create)와
 // 팀 상세 임베드(?view=create) 양쪽에서 재사용한다.
 export default function TeamEventCreateBody({
   teamId,

--- a/app/(main)/chinba/_components/team/TeamEventCreateView.tsx
+++ b/app/(main)/chinba/_components/team/TeamEventCreateView.tsx
@@ -20,7 +20,7 @@ export default function TeamEventCreateView() {
   const goBack = useSmartBack(`/chinba/team/detail?id=${teamId}&tab=mannaja`);
 
   return (
-    <FullPageModal isOpen={true} onClose={goBack} title="동아리 친바 만들기">
+    <FullPageModal isOpen={true} onClose={goBack} title="일정 잡기">
       <TeamEventCreateBody
         teamId={teamId}
         preSetId={preSetId}

--- a/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
@@ -15,6 +15,7 @@ import {
 
 import TeamResponsePanel from '@/(main)/chinba/_components/team/TeamResponsePanel';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { formatInviteUrl } from '@/_lib/utils/teamDisplay';
 
 const COLLAPSE_KEY = 'team_ops_panel_collapsed';
@@ -109,7 +110,9 @@ export default function TeamOpsPanel({
           <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">운영 도구</span>
           <PanelButton icon={FiUsers} label="멤버 관리" onClick={onOpenMembers} trailing="modal" />
           <PanelButton icon={FiGrid} label="조 / 그룹 관리" onClick={onOpenGroups} trailing="modal" />
-          <PanelButton icon={FiTag} label="해시태그 관리" onClick={onOpenCategories} trailing="modal" />
+          {CHINBA_HASHTAG_ENABLED && (
+            <PanelButton icon={FiTag} label="해시태그 관리" onClick={onOpenCategories} trailing="modal" />
+          )}
           <PanelButton icon={FiLink} label="초대링크 복사" onClick={handleCopyInvite} trailing="copy" />
         </section>
 

--- a/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamOpsPanel.tsx
@@ -119,7 +119,7 @@ export default function TeamOpsPanel({
         {/* 3) 그냥 있는 페이지 = 바로가기 */}
         <section className="flex flex-col border-t border-gray-100 pt-5">
           <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">바로가기</span>
-          <PanelButton icon={FiCalendar} label="일정 만들기" onClick={onCreateEvent} />
+          <PanelButton icon={FiCalendar} label="일정 잡기" onClick={onCreateEvent} />
           <PanelButton icon={FiEdit3} label="활동 기록하기" onClick={onRecordActivity} />
         </section>
       </div>

--- a/app/(main)/chinba/_components/team/TeamResponsePanel.tsx
+++ b/app/(main)/chinba/_components/team/TeamResponsePanel.tsx
@@ -6,6 +6,7 @@ import { FiChevronDown, FiChevronUp, FiCopy, FiBell } from 'react-icons/fi';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_UNSUBMITTED_NOTIFY_ENABLED } from '@/_lib/constants/features';
 import { useTeamEvents, useTeamEventDetail } from '@/_lib/hooks/useTeamEvents';
 
 interface TeamResponsePanelProps {
@@ -126,13 +127,15 @@ export default function TeamResponsePanel({ teamId }: TeamResponsePanelProps) {
                                 <FiCopy size={11} />
                                 복사
                               </button>
-                              <button
-                                onClick={handleNotify}
-                                className="flex flex-1 items-center justify-center gap-1 rounded-lg bg-gray-900 py-1.5 text-[11px] font-medium text-white transition-colors hover:bg-gray-800"
-                              >
-                                <FiBell size={11} />
-                                알림
-                              </button>
+                              {CHINBA_UNSUBMITTED_NOTIFY_ENABLED && (
+                                <button
+                                  onClick={handleNotify}
+                                  className="flex flex-1 items-center justify-center gap-1 rounded-lg bg-gray-900 py-1.5 text-[11px] font-medium text-white transition-colors hover:bg-gray-800"
+                                >
+                                  <FiBell size={11} />
+                                  알림
+                                </button>
+                              )}
                             </div>
                           </>
                         )}

--- a/app/(main)/chinba/_components/team/TeamSettingsView.tsx
+++ b/app/(main)/chinba/_components/team/TeamSettingsView.tsx
@@ -9,6 +9,7 @@ import ConfirmModal from '@/_components/ui/ConfirmModal';
 import FullPageModal from '@/_components/layout/FullPageModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import {
   useTeamDetail,
@@ -310,11 +311,13 @@ export default function TeamSettingsView() {
           canManage={canEditTeam(myRole)}
         />
 
-        {/* 일정 카테고리 관리 */}
-        <EventCategorySection
-          teamId={teamId}
-          canManage={canEditTeam(myRole)}
-        />
+        {/* 일정 카테고리(해시태그) 관리 */}
+        {CHINBA_HASHTAG_ENABLED && (
+          <EventCategorySection
+            teamId={teamId}
+            canManage={canEditTeam(myRole)}
+          />
+        )}
 
         {/* Section 5: 회장 위임 */}
         {!isEditing && (

--- a/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
+++ b/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import Button from '@/_components/ui/Button';
 import Modal from '@/_components/ui/Modal';
 
-import {
-  buildEndOptions,
-  buildStartOptions,
-  toMinutes,
-  type TimeRange,
-} from './chinbaSlotRanges';
+import { buildEndOptions, buildStartOptions, toMinutes, type TimeRange } from './chinbaSlotRanges';
 
 interface AddTimeRangeModalProps {
   isOpen: boolean;
@@ -23,12 +18,77 @@ interface AddTimeRangeModalProps {
   onClose: () => void;
 }
 
-const SELECT_CLASS =
-  'w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-gray-900 bg-white';
+function formatDuration(start: string, end: string): string {
+  const minutes = toMinutes(end) - toMinutes(start);
+  if (minutes <= 0) return '';
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}분`;
+  if (m === 0) return `${h}시간`;
+  return `${h}시간 ${m}분`;
+}
+
+interface TimeColumnProps {
+  label: string;
+  options: string[];
+  value: string;
+  onChange: (time: string) => void;
+}
+
+/**
+ * 시각 목록 한 열.
+ *
+ * 네이티브 <select>를 안 쓴다 — OS가 그리는 목록(파란 하이라이트·각진 모서리·시스템 폰트)이
+ * 앱과 따로 놀아서다. 목록을 직접 그리면 앱 폰트·초록 강조가 그대로 적용된다.
+ * 모달 카드가 overflow-hidden이라 띄우는 팝업 대신 자리를 차지하는 스크롤 목록으로 둔다.
+ */
+function TimeColumn({ label, options, value, onChange }: TimeColumnProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // 열릴 때·값이 바뀔 때 선택된 항목을 가운데로 — 스크롤을 손으로 찾아 내리지 않게
+  useEffect(() => {
+    const selected = listRef.current?.querySelector('[data-selected="true"]');
+    if (selected instanceof HTMLElement && typeof selected.scrollIntoView === 'function') {
+      selected.scrollIntoView({ block: 'center' });
+    }
+  }, [value, options]);
+
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="mb-1.5 text-center text-[11px] font-medium text-gray-500">{label}</p>
+      <div
+        ref={listRef}
+        role="listbox"
+        aria-label={label}
+        className="no-scrollbar h-44 snap-y overflow-y-auto rounded-xl border border-gray-200 bg-gray-50 p-1"
+      >
+        {options.map((time) => {
+          const isSelected = time === value;
+          return (
+            <button
+              key={time}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              data-selected={isSelected}
+              onClick={() => onChange(time)}
+              className={`w-full snap-center rounded-lg py-2 text-sm tabular-nums transition-colors ${
+                isSelected
+                  ? 'bg-emerald-600 font-bold text-white'
+                  : 'font-medium text-gray-600 hover:bg-gray-200/70'
+              }`}
+            >
+              {time}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 /**
  * 불가능 시간 구간 하나를 추가하는 모달.
- * 30분 눈금 단일 select 두 개 — 시/분을 나누지 않는 이유는 분이 00/30 두 가지뿐이기 때문.
  * 선택지는 이벤트 범위(startHour~endHour) 안으로 제한된다 — 범위 밖 슬롯은 히트맵에서 무시되므로
  * 애초에 만들 수 없게 한다.
  */
@@ -74,46 +134,23 @@ export default function AddTimeRangeModal({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={`${dateLabel} 시간 추가`} maxWidth="max-w-xs">
-      <div className="space-y-3 px-5 py-4">
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-start">
-            시작
-          </label>
-          <select
-            id="range-start"
-            value={start}
-            onChange={(e) => setStart(e.target.value)}
-            className={SELECT_CLASS}
-          >
-            {startOptions.map((time) => (
-              <option key={time} value={time}>
-                {time}
-              </option>
-            ))}
-          </select>
+      <div className="px-5 py-4">
+        {/* 고른 결과를 크게 — 목록 두 열만 보면 무엇을 고른 건지 한눈에 안 들어온다 */}
+        <div className="mb-3 text-center">
+          <p className="text-lg font-bold tabular-nums text-gray-900">
+            {start} <span className="text-gray-300">→</span> {end}
+          </p>
+          <p className="mt-0.5 text-xs font-medium text-emerald-700">{formatDuration(start, end)}</p>
         </div>
 
-        <div>
-          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-end">
-            종료
-          </label>
-          <select
-            id="range-end"
-            value={end}
-            onChange={(e) => setEnd(e.target.value)}
-            className={SELECT_CLASS}
-          >
-            {endOptions.map((time) => (
-              <option key={time} value={time}>
-                {time}
-              </option>
-            ))}
-          </select>
+        <div className="flex gap-2">
+          <TimeColumn label="시작" options={startOptions} value={start} onChange={setStart} />
+          <TimeColumn label="종료" options={endOptions} value={end} onChange={setEnd} />
         </div>
 
-        <p className="text-[11px] text-gray-400">30분 단위로 선택할 수 있습니다.</p>
+        <p className="mt-2 text-center text-[11px] text-gray-400">30분 단위로 선택할 수 있습니다.</p>
 
-        <div className="flex gap-2 pt-1">
+        <div className="flex gap-2 pt-3">
           <Button variant="outline" size="md" fullWidth onClick={onClose}>
             취소
           </Button>

--- a/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
+++ b/app/(main)/chinba/event/_components/AddTimeRangeModal.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import Button from '@/_components/ui/Button';
+import Modal from '@/_components/ui/Modal';
+
+import {
+  buildEndOptions,
+  buildStartOptions,
+  toMinutes,
+  type TimeRange,
+} from './chinbaSlotRanges';
+
+interface AddTimeRangeModalProps {
+  isOpen: boolean;
+  /** "YYYY-MM-DD" — 어느 날짜에 추가하는지 (제목에 표시) */
+  dateStr: string;
+  dateLabel: string;
+  startHour: number;
+  endHour: number;
+  onSubmit: (range: TimeRange) => void;
+  onClose: () => void;
+}
+
+const SELECT_CLASS =
+  'w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm outline-none focus:border-gray-900 bg-white';
+
+/**
+ * 불가능 시간 구간 하나를 추가하는 모달.
+ * 30분 눈금 단일 select 두 개 — 시/분을 나누지 않는 이유는 분이 00/30 두 가지뿐이기 때문.
+ * 선택지는 이벤트 범위(startHour~endHour) 안으로 제한된다 — 범위 밖 슬롯은 히트맵에서 무시되므로
+ * 애초에 만들 수 없게 한다.
+ */
+export default function AddTimeRangeModal({
+  isOpen,
+  dateStr,
+  dateLabel,
+  startHour,
+  endHour,
+  onSubmit,
+  onClose,
+}: AddTimeRangeModalProps) {
+  const startOptions = useMemo(() => buildStartOptions(startHour, endHour), [startHour, endHour]);
+  const [start, setStart] = useState(startOptions[0] ?? '');
+  const [end, setEnd] = useState('');
+
+  const endOptions = useMemo(
+    () => buildEndOptions(startHour, endHour, start),
+    [startHour, endHour, start]
+  );
+
+  // 열릴 때마다 기본값으로 되돌린다 — 이전 날짜의 선택이 남아 있으면 헷갈린다
+  useEffect(() => {
+    if (!isOpen) return;
+    const first = startOptions[0] ?? '';
+    setStart(first);
+    setEnd(buildEndOptions(startHour, endHour, first)[0] ?? '');
+  }, [isOpen, dateStr, startOptions, startHour, endHour]);
+
+  // 시작을 늦추면 종료가 그보다 앞설 수 있다 → 유효한 첫 값으로 당긴다
+  useEffect(() => {
+    if (!end || toMinutes(end) > toMinutes(start)) return;
+    setEnd(endOptions[0] ?? '');
+  }, [start, end, endOptions]);
+
+  const isValid = !!start && !!end && toMinutes(end) > toMinutes(start);
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    onSubmit({ start, end });
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`${dateLabel} 시간 추가`} maxWidth="max-w-xs">
+      <div className="space-y-3 px-5 py-4">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-start">
+            시작
+          </label>
+          <select
+            id="range-start"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            {startOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-gray-600" htmlFor="range-end">
+            종료
+          </label>
+          <select
+            id="range-end"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            {endOptions.map((time) => (
+              <option key={time} value={time}>
+                {time}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <p className="text-[11px] text-gray-400">30분 단위로 선택할 수 있습니다.</p>
+
+        <div className="flex gap-2 pt-1">
+          <Button variant="outline" size="md" fullWidth onClick={onClose}>
+            취소
+          </Button>
+          <Button variant="primary" size="md" fullWidth onClick={handleSubmit} disabled={!isValid}>
+            추가
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaDetailClient.tsx
@@ -20,11 +20,17 @@ export default function ChinbaDetailClient() {
   const { data: event } = useChinbaEventDetail(eventId);
 
   const handleCompleted = (recordQuery: string) => {
-    // 완료 처리 후, 넘어온 경로(팀 상세 '기록' 탭)로 이동하면서
-    // 완료된 일정 정보를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
+    // 팀 상세 '기록' 탭으로 이동하면서 일정 정보를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
+    // 완료는 그 폼에서 '기록하기/기록하지 않기'를 선택해야 확정된다.
+    // returnTo 없이 진입한 경우(공유 링크·사이드바 등)도 팀 일정이면 팀 상세로 보낸다 —
+    // 여기서 끊기면 완료를 확정할 경로가 없다.
     const returnTo = searchParams.get('returnTo');
-    if (!returnTo) return;
-    const dest = decodeURIComponent(returnTo);
+    const dest = returnTo
+      ? decodeURIComponent(returnTo)
+      : event?.team_id
+        ? `/chinba/team/detail?id=${event.team_id}&tab=mwoheni`
+        : null;
+    if (!dest) return;
     router.replace(recordQuery ? `${dest}${dest.includes('?') ? '&' : '?'}${recordQuery}` : dest);
   };
 

--- a/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
@@ -8,6 +8,7 @@ import { FiShare2, FiTrash2, FiCheckCircle, FiLink } from 'react-icons/fi';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Toast from '@/_components/ui/Toast';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useChinbaEventDetail, useDeleteChinbaEvent, useCompleteChinbaEvent } from '@/_lib/hooks/useChinba';
 import { useUser } from '@/_lib/hooks/useUser';
 import { formatDateRanges } from '@/_lib/utils/dateRange';
@@ -192,7 +193,7 @@ export default function ChinbaEventDetailBody({
       recordParams.set('recordEventId', eventId);
       if (event.title) recordParams.set('recordTitle', event.title);
       if (event.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
-      if (event.category) recordParams.set('recordCategoryId', String(event.category.id));
+      if (CHINBA_HASHTAG_ENABLED && event.category) recordParams.set('recordCategoryId', String(event.category.id));
       onCompleted(recordParams.toString());
       return;
     }

--- a/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
@@ -13,6 +13,7 @@ import { useUser } from '@/_lib/hooks/useUser';
 import { formatDateRanges } from '@/_lib/utils/dateRange';
 
 import MyScheduleTab from './MyScheduleTab';
+import TeamJoinGate from './TeamJoinGate';
 import TeamScheduleTab from './TeamScheduleTab';
 
 interface ChinbaEventDetailBodyProps {
@@ -205,6 +206,12 @@ export default function ChinbaEventDetailBody({
         <LoadingSpinner size="lg" />
       </div>
     );
+  }
+
+  // 동아리 일정인데 아직 멤버가 아님 — 공유 링크만 받고 들어온 경우.
+  // 여기서 끝내므로 헤더의 공유·삭제 버튼과 탭이 아예 렌더되지 않는다.
+  if (event && event.team_id && !event.is_team_member) {
+    return <TeamJoinGate eventId={eventId} event={event} />;
   }
 
   // Error state

--- a/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaEventDetailBody.tsx
@@ -183,16 +183,22 @@ export default function ChinbaEventDetailBody({
   };
 
   const handleComplete = async () => {
-    try {
-      await completeMutation.mutateAsync(eventId);
+    // 팀 일정: 여기서 완료를 확정하지 않는다. 활동 기록 화면으로 넘기고,
+    // 거기서 '기록하기/기록하지 않기'를 선택하는 시점에 완료 API가 호출된다.
+    // (버튼 없이 이탈하면 아무것도 확정되지 않아 일정이 진행중으로 보존된다)
+    if (event?.team_id) {
       setShowCompleteModal(false);
-      // 완료된 일정 정보(제목/날짜)를 넘겨 '활동 기록하기' 폼이 자동으로 열리게 한다.
       const recordParams = new URLSearchParams();
-      if (event?.title) recordParams.set('recordTitle', event.title);
-      if (event?.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
-      if (event?.category) recordParams.set('recordCategoryId', String(event.category.id));
+      recordParams.set('recordEventId', eventId);
+      if (event.title) recordParams.set('recordTitle', event.title);
+      if (event.dates?.[0]) recordParams.set('recordDate', String(event.dates[0]).slice(0, 10));
+      if (event.category) recordParams.set('recordCategoryId', String(event.category.id));
       onCompleted(recordParams.toString());
       return;
+    }
+    // 개인 친바: 활동 기록 개념이 없으므로 즉시 완료 확정
+    try {
+      await completeMutation.mutateAsync(eventId);
     } catch {
       alert('완료 처리에 실패했습니다');
     }
@@ -245,7 +251,7 @@ export default function ChinbaEventDetailBody({
           )}
 
           <div className="flex items-center gap-1 shrink-0">
-            {isCreator && isActive && (
+            {isCreator && (isActive || isExpired) && (
               <button
                 onClick={() => setShowCompleteModal(true)}
                 className="rounded-full p-2 text-emerald-600 hover:bg-emerald-50 transition-colors"
@@ -288,7 +294,9 @@ export default function ChinbaEventDetailBody({
       )}
       {isExpired && (
         <div className="px-4 py-2 bg-gray-50 border-b border-gray-100">
-          <p className="text-xs text-gray-500 text-center font-medium">만료된 일정입니다</p>
+          <p className="text-xs text-gray-500 text-center font-medium">
+            날짜가 지난 일정입니다{isCreator ? ' — 완료 처리하고 활동을 기록할 수 있습니다' : ''}
+          </p>
         </div>
       )}
 
@@ -386,7 +394,11 @@ export default function ChinbaEventDetailBody({
       >
         이 일정을 완료 처리하시겠습니까?
         <br />
-        <span className="text-xs text-gray-400">완료 후에는 일정 수정이 불가합니다</span>
+        <span className="text-xs text-gray-400">
+          {event?.team_id
+            ? '다음 화면에서 기록 여부를 선택하면 완료가 확정됩니다'
+            : '완료 후에는 일정 수정이 불가합니다'}
+        </span>
       </ConfirmModal>
     </>
   );

--- a/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaHeatmapGrid.tsx
@@ -18,6 +18,8 @@ interface ChinbaHeatmapGridProps {
   startHour: number;
   endHour: number;
   totalParticipants: number;
+  // 특정 참여자의 불가능 슬롯 — 지정되면 해당 슬롯만 강조하고 나머지 히트맵은 흐리게 표시
+  focusSlots?: Set<string>;
 }
 
 function getHeatColor(unavailCount: number, total: number): string {
@@ -42,7 +44,9 @@ export default function ChinbaHeatmapGrid({
   startHour,
   endHour,
   totalParticipants,
+  focusSlots,
 }: ChinbaHeatmapGridProps) {
+  const isFocusMode = focusSlots !== undefined;
   const [tooltip, setTooltip] = useState<{ dt: string; members: string[]; count: number } | null>(null);
 
   // Build heatmap lookup
@@ -177,7 +181,13 @@ export default function ChinbaHeatmapGrid({
                 const dtKey = `${info.dateStr}T${time}:00`;
                 const slot = heatmapMap.get(dtKey);
                 const unavailCount = slot?.unavailable_count ?? 0;
-                const bgColor = getHeatColor(unavailCount, totalParticipants);
+                // focus 모드: 대상 참여자의 불가능 슬롯만 빨간색, 나머지는 기존 히트맵을 흐리게
+                const isFocusUnavailable = focusSlots?.has(dtKey) ?? false;
+                const bgColor = isFocusMode
+                  ? isFocusUnavailable
+                    ? 'bg-red-400'
+                    : `${getHeatColor(unavailCount, totalParticipants)} opacity-30`
+                  : getHeatColor(unavailCount, totalParticipants);
                 const txtColor = getTextColor(unavailCount, totalParticipants);
 
                 return (
@@ -198,7 +208,7 @@ export default function ChinbaHeatmapGrid({
                       }
                     }}
                   >
-                    {totalParticipants > 0 && (() => {
+                    {!isFocusMode && totalParticipants > 0 && (() => {
                       const availCount = totalParticipants - unavailCount;
                       return availCount > 0 ? (
                         <span className={`text-[9px] font-bold ${txtColor}`}>{availCount}</span>

--- a/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 
 import { buildChinbaGridLayout } from './chinbaGridColumns';
+import { getSlotKey } from './chinbaSlotRanges';
 
 const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -93,8 +94,6 @@ export default function ChinbaScheduleGrid({
     }
     onSlotsChange(newSlots);
   }, [selectedSlots, onSlotsChange]);
-
-  const getSlotKey = (dateStr: string, time: string) => `${dateStr}T${time}:00`;
 
   const handlePointerDown = (
     event: ReactPointerEvent<HTMLDivElement>,

--- a/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleGrid.tsx
@@ -95,6 +95,39 @@ export default function ChinbaScheduleGrid({
     onSlotsChange(newSlots);
   }, [selectedSlots, onSlotsChange]);
 
+  // 열/행 머리글 클릭용 일괄 토글 — 묶음이 전부 선택돼 있으면 모두 해제, 아니면 모두 선택
+  const toggleKeys = useCallback(
+    (keys: string[]) => {
+      if (keys.length === 0) return;
+      const allSelected = keys.every((k) => selectedSlots.has(k));
+      const newSlots = new Set(selectedSlots);
+      if (allSelected) {
+        keys.forEach((k) => newSlots.delete(k));
+      } else {
+        keys.forEach((k) => newSlots.add(k));
+      }
+      onSlotsChange(newSlots);
+    },
+    [selectedSlots, onSlotsChange],
+  );
+
+  // 날짜 머리글 클릭 → 그 날짜의 전체 시간 토글
+  const toggleColumn = (dateStr: string) => {
+    toggleKeys(timeSlots.map((time) => getSlotKey(dateStr, time)));
+  };
+
+  // 'N시' 라벨 클릭 → 그 시각(:00 + :30) × 선택 가능한 모든 날짜 토글
+  const toggleHourRow = (time: string) => {
+    const hh = time.slice(0, 2);
+    const keys: string[] = [];
+    for (const info of columnInfos) {
+      if (info.gap || !info.selectable) continue;
+      keys.push(getSlotKey(info.dateStr, `${hh}:00`));
+      keys.push(getSlotKey(info.dateStr, `${hh}:30`));
+    }
+    toggleKeys(keys);
+  };
+
   const handlePointerDown = (
     event: ReactPointerEvent<HTMLDivElement>,
     dateStr: string,
@@ -153,18 +186,27 @@ export default function ChinbaScheduleGrid({
               >
                 <span className="text-[10px] text-gray-300">⋯</span>
               </div>
+            ) : info.selectable ? (
+              // 날짜 머리글 클릭 = 해당 열 전체 선택/해제
+              <button
+                key={info.key}
+                type="button"
+                onClick={() => toggleColumn(info.dateStr)}
+                className="flex cursor-pointer flex-col items-center justify-center rounded py-1 transition-colors hover:bg-gray-100 active:scale-95"
+                style={{ width: cellWidth }}
+                title="이 날짜 전체 선택/해제"
+              >
+                <span className="text-[10px] text-gray-400">{info.day}</span>
+                <span className="text-xs font-medium text-gray-700">{info.label}</span>
+              </button>
             ) : (
               <div
                 key={info.key}
                 className="flex flex-col items-center justify-center py-1"
                 style={{ width: cellWidth }}
               >
-                <span className={`text-[10px] ${info.selectable ? 'text-gray-400' : 'text-gray-300'}`}>
-                  {info.day}
-                </span>
-                <span className={`text-xs font-medium ${info.selectable ? 'text-gray-700' : 'text-gray-300'}`}>
-                  {info.label}
-                </span>
+                <span className="text-[10px] text-gray-300">{info.day}</span>
+                <span className="text-xs font-medium text-gray-300">{info.label}</span>
               </div>
             )
           )}
@@ -175,10 +217,17 @@ export default function ChinbaScheduleGrid({
           const isHourBorder = time.endsWith(':00');
           return (
             <div key={time} className="flex">
-              {/* Time label */}
+              {/* Time label — 클릭 = 그 시간대(1시간) × 전체 날짜 선택/해제 */}
               <div className={`${timeLabelClass} flex items-center justify-start`}>
                 {isHourBorder && (
-                  <span className="text-[10px] text-gray-400 -mt-2">{parseInt(time)}시</span>
+                  <button
+                    type="button"
+                    onClick={() => toggleHourRow(time)}
+                    className="-mt-2 cursor-pointer rounded px-0.5 text-[10px] text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="이 시간대 전체 선택/해제"
+                  >
+                    {parseInt(time)}시
+                  </button>
                 )}
               </div>
               {/* Cells */}

--- a/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import ChinbaScheduleList from './ChinbaScheduleList';
+import { getSlotKey } from './chinbaSlotRanges';
+
+const DATES = ['2026-08-02', '2026-08-03']; // 일, 월
+const slotsOf = (dateStr: string, ...times: string[]) =>
+  new Set(times.map((t) => getSlotKey(dateStr, t)));
+
+function renderList(selectedSlots: Set<string>, onSlotsChange = vi.fn()) {
+  render(
+    <ChinbaScheduleList
+      dates={DATES}
+      startHour={8}
+      endHour={24}
+      selectedSlots={selectedSlots}
+      onSlotsChange={onSlotsChange}
+    />
+  );
+  return onSlotsChange;
+}
+
+describe('ChinbaScheduleList', () => {
+  it('드래그로 칠한 슬롯이 병합된 구간으로 보인다', () => {
+    renderList(slotsOf('2026-08-02', '09:00', '09:30', '10:00'));
+
+    expect(screen.getByText('09:00 ~ 10:30')).toBeInTheDocument();
+    expect(screen.getByText('8/2 (일)')).toBeInTheDocument();
+  });
+
+  it('구간이 없는 날짜는 빈 상태를 보여준다', () => {
+    renderList(new Set());
+
+    expect(screen.getAllByText('등록된 시간 없음')).toHaveLength(2);
+  });
+
+  it('✕을 누르면 그 구간의 슬롯만 빠진 Set을 올려준다', () => {
+    const slots = new Set([
+      ...slotsOf('2026-08-02', '09:00', '09:30'),
+      ...slotsOf('2026-08-03', '14:00'),
+    ]);
+    const onSlotsChange = renderList(slots);
+
+    fireEvent.click(screen.getByLabelText('8/2 (일) 09:00~10:00 삭제'));
+
+    const next: Set<string> = onSlotsChange.mock.calls[0][0];
+    expect([...next]).toEqual(['2026-08-03T14:00:00']);
+  });
+
+  it('추가 모달로 구간을 넣으면 30분 슬롯으로 펼쳐 올려준다', () => {
+    const onSlotsChange = renderList(new Set());
+
+    fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
+
+    const start = screen.getByLabelText('시작') as HTMLSelectElement;
+    const end = screen.getByLabelText('종료') as HTMLSelectElement;
+    fireEvent.change(start, { target: { value: '09:00' } });
+    fireEvent.change(end, { target: { value: '10:30' } });
+    fireEvent.click(screen.getByRole('button', { name: '추가' }));
+
+    const next: Set<string> = onSlotsChange.mock.calls.at(-1)![0];
+    expect([...next].sort()).toEqual([
+      '2026-08-02T09:00:00',
+      '2026-08-02T09:30:00',
+      '2026-08-02T10:00:00',
+    ]);
+  });
+
+  it('이벤트 범위 밖 시각은 선택지에 없다', () => {
+    render(
+      <ChinbaScheduleList
+        dates={DATES}
+        startHour={10}
+        endHour={14}
+        selectedSlots={new Set()}
+        onSlotsChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
+
+    const start = screen.getByLabelText('시작');
+    expect(within(start).queryByText('09:30')).not.toBeInTheDocument();
+    expect(within(start).getByText('10:00')).toBeInTheDocument();
+
+    const end = screen.getByLabelText('종료');
+    expect(within(end).queryByText('14:30')).not.toBeInTheDocument();
+    expect(within(end).getByText('14:00')).toBeInTheDocument();
+  });
+
+  it('날짜 헤더를 누르면 접히고 다시 누르면 펼쳐진다', () => {
+    renderList(slotsOf('2026-08-02', '09:00'));
+
+    const header = screen.getByRole('button', { name: '8/2 (일) 시간 목록' });
+    expect(screen.getByText('09:00 ~ 09:30')).toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(screen.queryByText('09:00 ~ 09:30')).not.toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(screen.getByText('09:00 ~ 09:30')).toBeInTheDocument();
+  });
+});

--- a/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleList.test.tsx
@@ -53,10 +53,10 @@ describe('ChinbaScheduleList', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
 
-    const start = screen.getByLabelText('시작') as HTMLSelectElement;
-    const end = screen.getByLabelText('종료') as HTMLSelectElement;
-    fireEvent.change(start, { target: { value: '09:00' } });
-    fireEvent.change(end, { target: { value: '10:30' } });
+    const start = screen.getByRole('listbox', { name: '시작' });
+    const end = screen.getByRole('listbox', { name: '종료' });
+    fireEvent.click(within(start).getByRole('option', { name: '09:00' }));
+    fireEvent.click(within(end).getByRole('option', { name: '10:30' }));
     fireEvent.click(screen.getByRole('button', { name: '추가' }));
 
     const next: Set<string> = onSlotsChange.mock.calls.at(-1)![0];
@@ -79,13 +79,13 @@ describe('ChinbaScheduleList', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: '8/2 (일) 시간 추가' }));
 
-    const start = screen.getByLabelText('시작');
-    expect(within(start).queryByText('09:30')).not.toBeInTheDocument();
-    expect(within(start).getByText('10:00')).toBeInTheDocument();
+    const start = screen.getByRole('listbox', { name: '시작' });
+    expect(within(start).queryByRole('option', { name: '09:30' })).not.toBeInTheDocument();
+    expect(within(start).getByRole('option', { name: '10:00' })).toBeInTheDocument();
 
-    const end = screen.getByLabelText('종료');
-    expect(within(end).queryByText('14:30')).not.toBeInTheDocument();
-    expect(within(end).getByText('14:00')).toBeInTheDocument();
+    const end = screen.getByRole('listbox', { name: '종료' });
+    expect(within(end).queryByRole('option', { name: '14:30' })).not.toBeInTheDocument();
+    expect(within(end).getByRole('option', { name: '14:00' })).toBeInTheDocument();
   });
 
   it('날짜 헤더를 누르면 접히고 다시 누르면 펼쳐진다', () => {

--- a/app/(main)/chinba/event/_components/ChinbaScheduleList.tsx
+++ b/app/(main)/chinba/event/_components/ChinbaScheduleList.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { FiChevronDown, FiChevronRight, FiPlus, FiX } from 'react-icons/fi';
+
+import AddTimeRangeModal from './AddTimeRangeModal';
+import { addRange, removeRange, slotsToRangesByDate, type TimeRange } from './chinbaSlotRanges';
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+
+interface ChinbaScheduleListProps {
+  dates: string[];
+  startHour: number;
+  endHour: number;
+  selectedSlots: Set<string>;
+  onSlotsChange: (slots: Set<string>) => void;
+}
+
+function formatDateLabel(dateStr: string): string {
+  const dt = new Date(dateStr);
+  return `${dt.getMonth() + 1}/${dt.getDate()} (${DAY_LABELS[dt.getDay()]})`;
+}
+
+/**
+ * 직접 입력 모드 — 날짜별 불가능 시간 구간 목록.
+ *
+ * 구간은 selectedSlots에서 파생될 뿐 자체 상태를 갖지 않는다. 그래서 드래그 모드에서 칠한 시간이
+ * 여기 구간으로 그대로 나타나고, 여기서 지운 구간은 그리드에서도 사라진다.
+ */
+export default function ChinbaScheduleList({
+  dates,
+  startHour,
+  endHour,
+  selectedSlots,
+  onSlotsChange,
+}: ChinbaScheduleListProps) {
+  const sortedDates = useMemo(
+    () => [...new Set(dates.map((d) => d.slice(0, 10)))].sort(),
+    [dates]
+  );
+  const rangesByDate = useMemo(
+    () => slotsToRangesByDate(selectedSlots, sortedDates),
+    [selectedSlots, sortedDates]
+  );
+
+  // 접힘은 사용자가 명시적으로 접은 날짜만 — 기본은 펼침이라 구간이 생기면 바로 보인다
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [addTarget, setAddTarget] = useState<string | null>(null);
+
+  const toggleCollapse = (dateStr: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(dateStr)) next.delete(dateStr);
+      else next.add(dateStr);
+      return next;
+    });
+  };
+
+  const handleAdd = (dateStr: string, range: TimeRange) => {
+    onSlotsChange(addRange(selectedSlots, dateStr, range));
+    setCollapsed((prev) => {
+      if (!prev.has(dateStr)) return prev;
+      const next = new Set(prev);
+      next.delete(dateStr); // 추가한 구간이 접힌 채로 숨어버리지 않게 펼친다
+      return next;
+    });
+  };
+
+  const handleRemove = (dateStr: string, range: TimeRange) => {
+    onSlotsChange(removeRange(selectedSlots, dateStr, range));
+  };
+
+  return (
+    <div className="divide-y divide-gray-100 rounded-xl border border-gray-200">
+      {sortedDates.map((dateStr) => {
+        const ranges = rangesByDate.get(dateStr) ?? [];
+        const isCollapsed = collapsed.has(dateStr);
+        const dateLabel = formatDateLabel(dateStr);
+        return (
+          <div key={dateStr}>
+            <div className="flex items-center justify-between px-3 py-2.5">
+              {/* 날짜마다 같은 문구가 반복되므로 aria-label로 어느 날짜인지 구분해준다 */}
+              <button
+                type="button"
+                onClick={() => toggleCollapse(dateStr)}
+                aria-expanded={!isCollapsed}
+                aria-label={`${dateLabel} 시간 목록`}
+                className="flex items-center gap-1.5 text-sm font-medium text-gray-800"
+              >
+                {isCollapsed ? (
+                  <FiChevronRight size={14} className="text-gray-400" />
+                ) : (
+                  <FiChevronDown size={14} className="text-gray-400" />
+                )}
+                {dateLabel}
+                {ranges.length > 0 && (
+                  <span className="text-[11px] font-normal text-gray-400">{ranges.length}개</span>
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => setAddTarget(dateStr)}
+                aria-label={`${dateLabel} 시간 추가`}
+                className="flex items-center gap-1 rounded-lg px-2 py-1 text-[11px] font-medium text-gray-600 transition-colors hover:bg-gray-100 active:scale-95"
+              >
+                <FiPlus size={12} />
+                추가
+              </button>
+            </div>
+
+            {!isCollapsed && (
+              <div className="px-3 pb-2.5">
+                {ranges.length === 0 ? (
+                  <p className="py-1 text-[11px] text-gray-400">등록된 시간 없음</p>
+                ) : (
+                  <ul className="space-y-1">
+                    {ranges.map((range) => (
+                      <li
+                        key={`${range.start}-${range.end}`}
+                        className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2"
+                      >
+                        <span className="text-sm text-gray-800">
+                          {range.start} ~ {range.end}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemove(dateStr, range)}
+                          aria-label={`${dateLabel} ${range.start}~${range.end} 삭제`}
+                          className="rounded-full p-1 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 active:scale-95"
+                        >
+                          <FiX size={14} />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <AddTimeRangeModal
+        isOpen={addTarget !== null}
+        dateStr={addTarget ?? ''}
+        dateLabel={addTarget ? formatDateLabel(addTarget) : ''}
+        startHour={startHour}
+        endHour={endHour}
+        onSubmit={(range) => {
+          if (addTarget) handleAdd(addTarget, range);
+        }}
+        onClose={() => setAddTarget(null)}
+      />
+    </div>
+  );
+}

--- a/app/(main)/chinba/event/_components/MyScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/MyScheduleTab.tsx
@@ -190,22 +190,18 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
     <div className="px-4 pb-20">
       {/* Info + Actions */}
       <div className="mb-4 space-y-2">
-        {/* Instruction banner */}
-        <div className="rounded-xl bg-blue-50 border border-blue-100 px-3 py-2.5">
-          <p className="text-[11px] text-blue-700 font-medium leading-tight">
-            {mode === 'drag'
-              ? '불가능한 시간을 드래그로 선택해주세요'
-              : '불가능한 시간을 직접 입력해주세요'}
-          </p>
-          <p className="text-[10px] text-blue-500 mt-0.5">
-            {mode === 'drag'
-              ? '빨간색으로 표시된 시간이 불가능한 시간입니다'
-              : '날짜별로 시작·종료 시각을 추가합니다'}
-          </p>
+        {/* Instruction banner + 입력 방식 전환 — 문구는 세그먼트 라벨과 겹치지 않게 짧게 둔다 */}
+        <div className="flex items-center justify-between gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-3 py-2.5">
+          <div className="min-w-0">
+            <p className="text-[11px] text-emerald-800 font-medium leading-tight">
+              {mode === 'drag' ? '불가능한 시간을 칠하세요' : '불가능한 시간을 추가하세요'}
+            </p>
+            <p className="text-[10px] text-emerald-600 mt-0.5">
+              {mode === 'drag' ? '빨간색이 불가능한 시간입니다' : '날짜별 30분 단위로 넣습니다'}
+            </p>
+          </div>
+          <ScheduleInputModeTabs mode={mode} onModeChange={handleModeChange} />
         </div>
-
-        {/* Input mode */}
-        <ScheduleInputModeTabs mode={mode} onModeChange={handleModeChange} />
 
         {/* Action buttons */}
         <div className="flex items-stretch gap-2">

--- a/app/(main)/chinba/event/_components/MyScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/MyScheduleTab.tsx
@@ -8,6 +8,8 @@ import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Toast from '@/_components/ui/Toast';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import ChinbaScheduleGrid from './ChinbaScheduleGrid';
+import ChinbaScheduleList from './ChinbaScheduleList';
+import ScheduleInputModeTabs, { type ScheduleInputMode } from './ScheduleInputModeTabs';
 import { getLoginUrl } from '@/_lib/utils/requireLogin';
 import { useMyParticipation, useUpdateUnavailability, useImportTimetable } from '@/_lib/hooks/useChinba';
 
@@ -29,7 +31,9 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
   const importMutation = useImportTimetable(eventId);
 
   const draftKey = `chinba:event:${eventId}:draft-unavailable`;
+  const modeKey = `chinba:event:${eventId}:input-mode`;
   const [selectedSlots, setSelectedSlots] = useState<Set<string>>(new Set());
+  const [mode, setMode] = useState<ScheduleInputMode>('drag');
   const [hasDraft, setHasDraft] = useState(false);
   const [draftLoaded, setDraftLoaded] = useState(false);
   const [showNoTimetableModal, setShowNoTimetableModal] = useState(false);
@@ -63,6 +67,25 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
       setDraftLoaded(true);
     }
   }, [draftKey]);
+
+  // 입력 방식은 마지막 선택을 기억한다 (탭 복원과 같은 방식)
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(modeKey);
+      if (stored === 'drag' || stored === 'manual') setMode(stored);
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [modeKey]);
+
+  const handleModeChange = useCallback((next: ScheduleInputMode) => {
+    setMode(next);
+    try {
+      localStorage.setItem(modeKey, next);
+    } catch {
+      // ignore localStorage errors
+    }
+  }, [modeKey]);
 
   const handleSlotsChange = useCallback((slots: Set<string>) => {
     setSelectedSlots(slots);
@@ -170,10 +193,19 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
         {/* Instruction banner */}
         <div className="rounded-xl bg-blue-50 border border-blue-100 px-3 py-2.5">
           <p className="text-[11px] text-blue-700 font-medium leading-tight">
-            불가능한 시간을 드래그로 선택해주세요
+            {mode === 'drag'
+              ? '불가능한 시간을 드래그로 선택해주세요'
+              : '불가능한 시간을 직접 입력해주세요'}
           </p>
-          <p className="text-[10px] text-blue-500 mt-0.5">빨간색으로 표시된 시간이 불가능한 시간입니다</p>
+          <p className="text-[10px] text-blue-500 mt-0.5">
+            {mode === 'drag'
+              ? '빨간색으로 표시된 시간이 불가능한 시간입니다'
+              : '날짜별로 시작·종료 시각을 추가합니다'}
+          </p>
         </div>
+
+        {/* Input mode */}
+        <ScheduleInputModeTabs mode={mode} onModeChange={handleModeChange} />
 
         {/* Action buttons */}
         <div className="flex items-stretch gap-2">
@@ -203,16 +235,28 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
         </div>
       </div>
 
-      {/* Schedule Grid */}
-      <div className="mb-4 rounded-xl border border-gray-200 p-2 overflow-hidden">
-        <ChinbaScheduleGrid
-          dates={dates}
-          startHour={startHour}
-          endHour={endHour}
-          selectedSlots={selectedSlots}
-          onSlotsChange={handleSlotsChange}
-        />
-      </div>
+      {/* Schedule input — 두 모드가 같은 selectedSlots를 읽고 쓴다 */}
+      {mode === 'drag' ? (
+        <div className="mb-4 rounded-xl border border-gray-200 p-2 overflow-hidden">
+          <ChinbaScheduleGrid
+            dates={dates}
+            startHour={startHour}
+            endHour={endHour}
+            selectedSlots={selectedSlots}
+            onSlotsChange={handleSlotsChange}
+          />
+        </div>
+      ) : (
+        <div className="mb-4">
+          <ChinbaScheduleList
+            dates={dates}
+            startHour={startHour}
+            endHour={endHour}
+            selectedSlots={selectedSlots}
+            onSlotsChange={handleSlotsChange}
+          />
+        </div>
+      )}
 
       {/* Sticky bottom bar with save button */}
       <div className="sticky bottom-0 z-10 -mx-4 border-t border-gray-100 bg-white px-4 py-3 pb-safe">

--- a/app/(main)/chinba/event/_components/MyScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/MyScheduleTab.tsx
@@ -191,12 +191,12 @@ export default function MyScheduleTab({ eventId, dates, startHour, endHour, isLo
       {/* Info + Actions */}
       <div className="mb-4 space-y-2">
         {/* Instruction banner + 입력 방식 전환 — 문구는 세그먼트 라벨과 겹치지 않게 짧게 둔다 */}
-        <div className="flex items-center justify-between gap-2 rounded-xl bg-emerald-50 border border-emerald-100 px-3 py-2.5">
+        <div className="flex items-center justify-between gap-2 rounded-xl bg-emerald-100 border border-emerald-200 px-3 py-2.5">
           <div className="min-w-0">
-            <p className="text-[11px] text-emerald-800 font-medium leading-tight">
+            <p className="text-[11px] text-emerald-900 font-semibold leading-tight">
               {mode === 'drag' ? '불가능한 시간을 칠하세요' : '불가능한 시간을 추가하세요'}
             </p>
-            <p className="text-[10px] text-emerald-600 mt-0.5">
+            <p className="text-[10px] text-emerald-700 mt-0.5">
               {mode === 'drag' ? '빨간색이 불가능한 시간입니다' : '날짜별 30분 단위로 넣습니다'}
             </p>
           </div>

--- a/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
+++ b/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
@@ -15,10 +15,13 @@ interface ScheduleInputModeTabsProps {
 /**
  * "내 일정"의 입력 방식 전환. 안내 배너 안 오른쪽에 들어가므로 폭을 차지하지 않는 알약형이다
  * (밑줄형 TeamSegmentTabs는 flex-1로 가로를 다 먹어 배너 안에서 쓸 수 없다).
+ *
+ * 트랙(emerald-200)은 배너 바탕(emerald-100)보다 한 단계 짙게 둔다 — 선택된 흰 알약과
+ * 트랙, 배너가 3단으로 갈려야 어느 쪽이 켜져 있는지 한눈에 보인다.
  */
 export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleInputModeTabsProps) {
   return (
-    <div className="inline-flex shrink-0 rounded-lg bg-white/70 p-0.5" role="group">
+    <div className="inline-flex shrink-0 rounded-lg bg-emerald-200 p-0.5" role="group">
       {TABS.map((tab) => {
         const isActive = mode === tab.key;
         return (
@@ -29,8 +32,8 @@ export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleIn
             aria-pressed={isActive}
             className={`rounded-md px-2.5 py-1 text-[11px] whitespace-nowrap transition-colors ${
               isActive
-                ? 'bg-white font-bold text-emerald-700 shadow-sm'
-                : 'font-medium text-emerald-600/70 hover:text-emerald-700'
+                ? 'bg-white font-bold text-emerald-800 shadow-sm'
+                : 'font-medium text-emerald-700/80 hover:text-emerald-900'
             }`}
           >
             {tab.label}

--- a/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
+++ b/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import type { IconType } from 'react-icons';
-import { FiClock, FiEdit2 } from 'react-icons/fi';
-
 export type ScheduleInputMode = 'drag' | 'manual';
 
-const TABS: { key: ScheduleInputMode; label: string; icon: IconType }[] = [
-  { key: 'drag', label: '드래그', icon: FiEdit2 },
-  { key: 'manual', label: '직접 입력', icon: FiClock },
+const TABS: { key: ScheduleInputMode; label: string }[] = [
+  { key: 'drag', label: '드래그' },
+  { key: 'manual', label: '직접 입력' },
 ];
 
 interface ScheduleInputModeTabsProps {
@@ -15,30 +12,28 @@ interface ScheduleInputModeTabsProps {
   onModeChange: (mode: ScheduleInputMode) => void;
 }
 
-/** "내 일정"의 입력 방식 전환. 스타일은 teams/TeamSegmentTabs의 밑줄형 세그먼트와 맞춘다. */
+/**
+ * "내 일정"의 입력 방식 전환. 안내 배너 안 오른쪽에 들어가므로 폭을 차지하지 않는 알약형이다
+ * (밑줄형 TeamSegmentTabs는 flex-1로 가로를 다 먹어 배너 안에서 쓸 수 없다).
+ */
 export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleInputModeTabsProps) {
   return (
-    <div className="flex border-b border-gray-100">
+    <div className="inline-flex shrink-0 rounded-lg bg-white/70 p-0.5" role="group">
       {TABS.map((tab) => {
         const isActive = mode === tab.key;
-        const Icon = tab.icon;
         return (
           <button
             key={tab.key}
             type="button"
             onClick={() => onModeChange(tab.key)}
             aria-pressed={isActive}
-            className={`relative flex-1 py-2.5 text-center text-[13px] font-medium transition-colors ${
-              isActive ? 'font-bold text-gray-900' : 'text-gray-400 hover:text-gray-600'
+            className={`rounded-md px-2.5 py-1 text-[11px] whitespace-nowrap transition-colors ${
+              isActive
+                ? 'bg-white font-bold text-emerald-700 shadow-sm'
+                : 'font-medium text-emerald-600/70 hover:text-emerald-700'
             }`}
           >
-            <span className="inline-flex items-center justify-center gap-1.5">
-              <Icon size={14} />
-              {tab.label}
-            </span>
-            {isActive && (
-              <span className="absolute bottom-0 left-1/2 h-0.5 w-12 -translate-x-1/2 rounded-full bg-gray-900" />
-            )}
+            {tab.label}
           </button>
         );
       })}

--- a/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
+++ b/app/(main)/chinba/event/_components/ScheduleInputModeTabs.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import type { IconType } from 'react-icons';
+import { FiClock, FiEdit2 } from 'react-icons/fi';
+
+export type ScheduleInputMode = 'drag' | 'manual';
+
+const TABS: { key: ScheduleInputMode; label: string; icon: IconType }[] = [
+  { key: 'drag', label: '드래그', icon: FiEdit2 },
+  { key: 'manual', label: '직접 입력', icon: FiClock },
+];
+
+interface ScheduleInputModeTabsProps {
+  mode: ScheduleInputMode;
+  onModeChange: (mode: ScheduleInputMode) => void;
+}
+
+/** "내 일정"의 입력 방식 전환. 스타일은 teams/TeamSegmentTabs의 밑줄형 세그먼트와 맞춘다. */
+export default function ScheduleInputModeTabs({ mode, onModeChange }: ScheduleInputModeTabsProps) {
+  return (
+    <div className="flex border-b border-gray-100">
+      {TABS.map((tab) => {
+        const isActive = mode === tab.key;
+        const Icon = tab.icon;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            onClick={() => onModeChange(tab.key)}
+            aria-pressed={isActive}
+            className={`relative flex-1 py-2.5 text-center text-[13px] font-medium transition-colors ${
+              isActive ? 'font-bold text-gray-900' : 'text-gray-400 hover:text-gray-600'
+            }`}
+          >
+            <span className="inline-flex items-center justify-center gap-1.5">
+              <Icon size={14} />
+              {tab.label}
+            </span>
+            {isActive && (
+              <span className="absolute bottom-0 left-1/2 h-0.5 w-12 -translate-x-1/2 rounded-full bg-gray-900" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/(main)/chinba/event/_components/TeamJoinGate.tsx
+++ b/app/(main)/chinba/event/_components/TeamJoinGate.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { FiUsers } from 'react-icons/fi';
+
+import Button from '@/_components/ui/Button';
+import { useToast } from '@/_context/ToastContext';
+import { hasAccessToken } from '@/_lib/auth/tokenStore';
+import { useJoinChinbaEventTeam } from '@/_lib/hooks/useChinba';
+import { useSmartBack } from '@/_lib/hooks/useSmartBack';
+import { formatDateRanges } from '@/_lib/utils/dateRange';
+import { getLoginUrl } from '@/_lib/utils/requireLogin';
+import type { ChinbaEventDetail } from '@/_types/chinba';
+
+interface TeamJoinGateProps {
+  eventId: string;
+  event: ChinbaEventDetail;
+}
+
+// 동아리 초대 링크 없이 일정 링크만 받은 사람이 보는 화면.
+// 백엔드가 비멤버에게는 제목·동아리명·기간만 내려주므로(participants·heatmap은 빈 배열)
+// 여기서 가입 동의를 받고 나서야 일정 상세가 열린다.
+export default function TeamJoinGate({ eventId, event }: TeamJoinGateProps) {
+  const router = useRouter();
+  const goBack = useSmartBack('/chinba');
+  const { showToast } = useToast();
+  const joinMutation = useJoinChinbaEventTeam(eventId);
+
+  const handleJoin = useCallback(async () => {
+    // 비로그인이면 로그인 후 이 화면으로 돌아와 다시 누르게 한다 (/invite와 같은 방식)
+    if (!hasAccessToken()) {
+      router.replace(getLoginUrl(`/chinba/event?id=${encodeURIComponent(eventId)}&tab=team`));
+      return;
+    }
+
+    try {
+      const result = await joinMutation.mutateAsync();
+      showToast(result.message, 'success');
+    } catch (err: unknown) {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      showToast(detail || '가입에 실패했습니다', 'error');
+    }
+  }, [eventId, joinMutation, router, showToast]);
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center px-6 py-10 text-center">
+      <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+        <FiUsers size={28} className="text-gray-400" />
+      </div>
+
+      <h2 className="text-lg font-bold text-gray-800">{event.title}</h2>
+      <p className="mt-1 text-sm text-gray-500">{formatDateRanges(event.dates)}</p>
+
+      <p className="mt-6 text-sm text-gray-700">
+        이 일정은{' '}
+        <span className="font-bold text-gray-900">
+          {event.team_name ? `'${event.team_name}'` : '동아리'}
+        </span>
+        의 일정입니다
+      </p>
+      <p className="mt-1 text-sm text-gray-500">참여하려면 동아리에 가입해야 해요</p>
+
+      <div className="mt-8 flex w-full max-w-xs flex-col gap-2">
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          onClick={handleJoin}
+          disabled={joinMutation.isPending}
+        >
+          {joinMutation.isPending ? '가입하는 중...' : '가입하고 참여하기'}
+        </Button>
+        <Button variant="secondary" size="lg" fullWidth onClick={goBack}>
+          돌아가기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/event/_components/TeamScheduleTab.tsx
+++ b/app/(main)/chinba/event/_components/TeamScheduleTab.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
 import { FiCheck, FiClock, FiChevronDown, FiChevronUp } from 'react-icons/fi';
-import ChinbaHeatmapGrid from './ChinbaHeatmapGrid';
+
+import { useParticipantUnavailability } from '@/_lib/hooks/useChinba';
 import type { ChinbaEventDetail, ChinbaRecommendedTime } from '@/_types/chinba';
+
+import ChinbaHeatmapGrid from './ChinbaHeatmapGrid';
 
 const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -21,6 +25,22 @@ export default function TeamScheduleTab({ event }: TeamScheduleTabProps) {
   const [showParticipants, setShowParticipants] = useState(true);
   const submittedCount = event.participants.filter((p) => p.has_submitted).length;
   const totalCount = event.participants.length;
+
+  // 참여자 클릭 → 그 사람의 불가능 시간을 히트맵 위에 강조 (재클릭 = 해제, 다른 사람 = 전환)
+  // 선택 표시는 참여자 알약이 검정으로 바뀌는 것으로 충분하다 — 별도 배지 없음
+  const [focusedUserId, setFocusedUserId] = useState<number | null>(null);
+  const { data: focusData } = useParticipantUnavailability(event.event_id, focusedUserId);
+  const focusSlots = useMemo(
+    () =>
+      focusedUserId !== null && focusData?.user_id === focusedUserId
+        ? new Set(focusData.unavailable_slots)
+        : undefined,
+    [focusedUserId, focusData],
+  );
+
+  const handleParticipantClick = (userId: number) => {
+    setFocusedUserId((prev) => (prev === userId ? null : userId));
+  };
 
   return (
     <div className="px-4 pb-6">
@@ -40,18 +60,28 @@ export default function TeamScheduleTab({ event }: TeamScheduleTabProps) {
 
         {showParticipants && (
           <div className="flex flex-wrap gap-2 animate-fadeIn">
-            {event.participants.map((p) => (
-              <div
-                key={p.user_id}
-                className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs ${p.has_submitted
-                  ? 'bg-emerald-50 text-emerald-700'
-                  : 'bg-gray-100 text-gray-500'
+            {event.participants.map((p) => {
+              const isFocused = focusedUserId === p.user_id;
+              return (
+                <button
+                  key={p.user_id}
+                  type="button"
+                  onClick={() => handleParticipantClick(p.user_id)}
+                  disabled={!p.has_submitted}
+                  title={p.has_submitted ? '클릭하면 이 사람의 일정을 히트맵에 표시합니다' : '아직 일정을 제출하지 않았어요'}
+                  className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs transition-colors ${
+                    isFocused
+                      ? 'bg-gray-900 text-white'
+                      : p.has_submitted
+                        ? 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100 active:scale-95 cursor-pointer'
+                        : 'bg-gray-100 text-gray-500 cursor-default'
                   }`}
-              >
-                {p.has_submitted && <FiCheck size={10} />}
-                <span>{p.nickname || `유저${p.user_id}`}</span>
-              </div>
-            ))}
+                >
+                  {p.has_submitted && <FiCheck size={10} />}
+                  <span>{p.nickname || `유저${p.user_id}`}</span>
+                </button>
+              );
+            })}
           </div>
         )}
       </div>
@@ -72,6 +102,7 @@ export default function TeamScheduleTab({ event }: TeamScheduleTabProps) {
               startHour={event.start_hour}
               endHour={event.end_hour}
               totalParticipants={submittedCount}
+              focusSlots={focusSlots}
             />
           </div>
         )}

--- a/app/(main)/chinba/event/_components/chinbaSlotRanges.test.ts
+++ b/app/(main)/chinba/event/_components/chinbaSlotRanges.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  addRange,
+  buildEndOptions,
+  buildStartOptions,
+  getSlotKey,
+  rangeToSlotKeys,
+  removeRange,
+  slotsToRangesByDate,
+} from './chinbaSlotRanges';
+
+const D = '2026-08-02';
+const OTHER = '2026-08-03';
+
+// 구간 목록을 "09:00~11:00" 문자열 배열로 — 기대값을 눈으로 읽기 쉽게
+const fmt = (map: Map<string, { start: string; end: string }[]>, dateStr: string) =>
+  (map.get(dateStr) ?? []).map((r) => `${r.start}~${r.end}`);
+
+const setOf = (dateStr: string, ...times: string[]) =>
+  new Set(times.map((t) => getSlotKey(dateStr, t)));
+
+describe('rangeToSlotKeys', () => {
+  it('end는 exclusive — 09:00~10:00은 슬롯 두 개', () => {
+    expect(rangeToSlotKeys(D, { start: '09:00', end: '10:00' })).toEqual([
+      `${D}T09:00:00`,
+      `${D}T09:30:00`,
+    ]);
+  });
+
+  it('start === end면 슬롯 없음', () => {
+    expect(rangeToSlotKeys(D, { start: '09:00', end: '09:00' })).toEqual([]);
+  });
+
+  it('자정 넘김 없이 24:00까지 만든다', () => {
+    expect(rangeToSlotKeys(D, { start: '23:00', end: '24:00' })).toEqual([
+      `${D}T23:00:00`,
+      `${D}T23:30:00`,
+    ]);
+  });
+});
+
+describe('slotsToRangesByDate', () => {
+  it('연속 슬롯은 한 구간으로 병합된다', () => {
+    const slots = setOf(D, '09:00', '09:30', '10:00', '10:30');
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~11:00']);
+  });
+
+  it('끊긴 슬롯은 별개 구간으로 나뉜다', () => {
+    const slots = setOf(D, '09:00', '09:30', '14:00');
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~10:00', '14:00~14:30']);
+  });
+
+  it('입력 순서와 무관하게 시각순으로 정렬된다', () => {
+    const slots = setOf(D, '14:00', '09:30', '09:00');
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~10:00', '14:00~14:30']);
+  });
+
+  it('날짜별로 분리된다', () => {
+    const slots = new Set([...setOf(D, '09:00'), ...setOf(OTHER, '13:00', '13:30')]);
+    const map = slotsToRangesByDate(slots, [D, OTHER]);
+    expect(fmt(map, D)).toEqual(['09:00~09:30']);
+    expect(fmt(map, OTHER)).toEqual(['13:00~14:00']);
+  });
+
+  it('dates 밖 날짜의 슬롯은 목록에서 빠지되 원본 Set은 그대로다', () => {
+    const slots = new Set([...setOf(D, '09:00'), ...setOf('2026-01-01', '09:00')]);
+    const map = slotsToRangesByDate(slots, [D]);
+    expect([...map.keys()]).toEqual([D]);
+    expect(slots.has('2026-01-01T09:00:00')).toBe(true); // 저장 시 보존돼야 한다
+  });
+
+  it('슬롯이 없으면 빈 맵', () => {
+    expect(slotsToRangesByDate(new Set(), [D]).size).toBe(0);
+  });
+});
+
+describe('addRange / removeRange', () => {
+  it('겹치는 구간을 추가하면 한 구간으로 병합돼 보인다', () => {
+    let slots = new Set<string>();
+    slots = addRange(slots, D, { start: '09:00', end: '12:00' });
+    slots = addRange(slots, D, { start: '11:00', end: '13:00' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~13:00']);
+  });
+
+  it('붙어 있는(끝=시작) 구간도 한 구간이 된다', () => {
+    let slots = new Set<string>();
+    slots = addRange(slots, D, { start: '09:00', end: '10:00' });
+    slots = addRange(slots, D, { start: '10:00', end: '11:00' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~11:00']);
+  });
+
+  it('떨어진 구간을 추가하면 두 구간으로 남는다', () => {
+    let slots = new Set<string>();
+    slots = addRange(slots, D, { start: '09:00', end: '10:00' });
+    slots = addRange(slots, D, { start: '14:00', end: '15:00' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~10:00', '14:00~15:00']);
+  });
+
+  it('구간 중간을 지우면 두 구간으로 쪼개진다', () => {
+    let slots = addRange(new Set<string>(), D, { start: '09:00', end: '13:00' });
+    slots = removeRange(slots, D, { start: '11:00', end: '11:30' });
+    expect(fmt(slotsToRangesByDate(slots, [D]), D)).toEqual(['09:00~11:00', '11:30~13:00']);
+  });
+
+  it('삭제는 같은 날짜에만 적용된다', () => {
+    let slots = addRange(new Set<string>(), D, { start: '09:00', end: '10:00' });
+    slots = addRange(slots, OTHER, { start: '09:00', end: '10:00' });
+    slots = removeRange(slots, D, { start: '09:00', end: '10:00' });
+    const map = slotsToRangesByDate(slots, [D, OTHER]);
+    expect(fmt(map, D)).toEqual([]);
+    expect(fmt(map, OTHER)).toEqual(['09:00~10:00']);
+  });
+
+  it('원본 Set을 변형하지 않는다', () => {
+    const original = new Set<string>();
+    const added = addRange(original, D, { start: '09:00', end: '10:00' });
+    expect(original.size).toBe(0);
+    expect(added.size).toBe(2);
+  });
+});
+
+describe('buildStartOptions / buildEndOptions', () => {
+  it('시작 선택지는 endHour 정각을 포함하지 않는다', () => {
+    const options = buildStartOptions(8, 24);
+    expect(options[0]).toBe('08:00');
+    expect(options[options.length - 1]).toBe('23:30');
+    expect(options).not.toContain('24:00');
+  });
+
+  it('종료 선택지는 endHour 정각까지 포함한다', () => {
+    const options = buildEndOptions(8, 24);
+    expect(options[0]).toBe('08:30');
+    expect(options[options.length - 1]).toBe('24:00');
+  });
+
+  it('이벤트 범위 밖 시각은 선택지에 없다', () => {
+    expect(buildStartOptions(10, 14)).not.toContain('09:30');
+    expect(buildEndOptions(10, 14)).not.toContain('14:30');
+  });
+
+  it('after를 주면 그보다 늦은 종료 시각만 남는다', () => {
+    const options = buildEndOptions(8, 24, '13:00');
+    expect(options[0]).toBe('13:30');
+    expect(options).not.toContain('13:00');
+  });
+});

--- a/app/(main)/chinba/event/_components/chinbaSlotRanges.ts
+++ b/app/(main)/chinba/event/_components/chinbaSlotRanges.ts
@@ -1,0 +1,122 @@
+// 친바 "내 일정"의 슬롯 Set ↔ 시간 구간 변환.
+//
+// 드래그 모드와 직접 입력 모드는 같은 데이터(불가능 슬롯 Set)를 본다.
+// 두 모드가 어긋나지 않도록 목록은 상태를 따로 갖지 않고 이 파일의 함수로 Set에서 파생시킨다.
+//
+// 슬롯 키는 "YYYY-MM-DDTHH:MM:00" — 백엔드 unavailable_slots(30분 단위 ISO datetime)와 같은 형식이라
+// 변환 없이 그대로 PUT /chinba/events/{id}/my-unavailability 로 보낸다.
+
+/** 슬롯 키 — 그리드 셀과 구간 목록이 같은 키를 쓰도록 여기 한 곳에서만 만든다. */
+export const getSlotKey = (dateStr: string, time: string) => `${dateStr}T${time}:00`;
+
+/** 시각 구간. end는 exclusive — "09:00"~"10:00"은 09:00·09:30 슬롯 두 개다. */
+export interface TimeRange {
+  start: string; // "HH:MM"
+  end: string; // "HH:MM"
+}
+
+const SLOT_MINUTES = 30;
+
+/** "HH:MM" → 자정 기준 분 */
+export function toMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** 자정 기준 분 → "HH:MM" */
+export function toTimeString(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/**
+ * 시작 시각 선택지 — startHour ~ endHour 사이의 30분 눈금.
+ * 마지막 슬롯의 시작(endHour - 30분)까지만 만든다. endHour 정각은 시작이 될 수 없다.
+ */
+export function buildStartOptions(startHour: number, endHour: number): string[] {
+  const options: string[] = [];
+  for (let m = startHour * 60; m < endHour * 60; m += SLOT_MINUTES) {
+    options.push(toTimeString(m));
+  }
+  return options;
+}
+
+/**
+ * 종료 시각 선택지 — after 이후의 30분 눈금. endHour 정각까지 포함한다(exclusive end라 필요).
+ * after를 주면 그보다 늦은 시각만 남겨, 종료가 시작보다 앞서는 조합 자체를 못 만들게 한다.
+ */
+export function buildEndOptions(startHour: number, endHour: number, after?: string): string[] {
+  const from = after ? toMinutes(after) + SLOT_MINUTES : startHour * 60 + SLOT_MINUTES;
+  const options: string[] = [];
+  for (let m = Math.max(from, startHour * 60 + SLOT_MINUTES); m <= endHour * 60; m += SLOT_MINUTES) {
+    options.push(toTimeString(m));
+  }
+  return options;
+}
+
+/** 구간 → 슬롯 키 배열 (start 포함, end 제외) */
+export function rangeToSlotKeys(dateStr: string, range: TimeRange): string[] {
+  const keys: string[] = [];
+  for (let m = toMinutes(range.start); m < toMinutes(range.end); m += SLOT_MINUTES) {
+    keys.push(getSlotKey(dateStr, toTimeString(m)));
+  }
+  return keys;
+}
+
+/**
+ * 슬롯 Set → 날짜별 연속 구간 목록.
+ *
+ * dates에 없는 날짜의 슬롯은 목록에서 빠진다(이벤트 후보일이 아니므로 보여줄 자리가 없다).
+ * 다만 Set 자체는 건드리지 않는다 — 저장 시 그대로 보존돼야 조용한 데이터 손실이 없다.
+ */
+export function slotsToRangesByDate(
+  slots: Set<string>,
+  dates: string[]
+): Map<string, TimeRange[]> {
+  const dateSet = new Set(dates.map((d) => d.slice(0, 10)));
+  const minutesByDate = new Map<string, number[]>();
+
+  for (const key of slots) {
+    const dateStr = key.slice(0, 10);
+    if (!dateSet.has(dateStr)) continue;
+    const time = key.slice(11, 16); // "HH:MM"
+    const list = minutesByDate.get(dateStr);
+    if (list) list.push(toMinutes(time));
+    else minutesByDate.set(dateStr, [toMinutes(time)]);
+  }
+
+  const result = new Map<string, TimeRange[]>();
+  for (const [dateStr, minutes] of minutesByDate) {
+    const sorted = [...new Set(minutes)].sort((a, b) => a - b);
+    const ranges: TimeRange[] = [];
+    let blockStart = sorted[0];
+    let prev = sorted[0];
+    for (let i = 1; i < sorted.length; i++) {
+      if (sorted[i] === prev + SLOT_MINUTES) {
+        prev = sorted[i]; // 직전 슬롯과 붙어 있음 → 같은 구간
+      } else {
+        ranges.push({ start: toTimeString(blockStart), end: toTimeString(prev + SLOT_MINUTES) });
+        blockStart = sorted[i];
+        prev = sorted[i];
+      }
+    }
+    ranges.push({ start: toTimeString(blockStart), end: toTimeString(prev + SLOT_MINUTES) });
+    result.set(dateStr, ranges);
+  }
+  return result;
+}
+
+/** 구간 추가. Set union이라 기존 구간과 겹치면 목록에서 자연히 한 구간으로 병합된다. */
+export function addRange(slots: Set<string>, dateStr: string, range: TimeRange): Set<string> {
+  const next = new Set(slots);
+  for (const key of rangeToSlotKeys(dateStr, range)) next.add(key);
+  return next;
+}
+
+/** 구간 삭제. 긴 구간의 중간을 지우면 목록에서 두 구간으로 쪼개진다. */
+export function removeRange(slots: Set<string>, dateStr: string, range: TimeRange): Set<string> {
+  const next = new Set(slots);
+  for (const key of rangeToSlotKeys(dateStr, range)) next.delete(key);
+  return next;
+}

--- a/app/(main)/chinba/event/opengraph-image.tsx
+++ b/app/(main)/chinba/event/opengraph-image.tsx
@@ -9,12 +9,12 @@ import {
 export const dynamic = 'force-static';
 
 // Image metadata
-export const alt = '제로타임 - 전북대 공지사항 통합 알림';
+export const alt = '타임라인 (TimeLine) - 가장 편한 일정 잡기';
 export const size = OG_CARD_SIZE;
 
 export const contentType = OG_CARD_CONTENT_TYPE;
 
 // Image generation
 export default async function Image() {
-    return renderWordmarkCard('ZEROTIME', OG_ACCENT_COLOR.zerotime);
+    return renderWordmarkCard('TIMELINE', OG_ACCENT_COLOR.timeline);
 }

--- a/app/(main)/chinba/event/page.tsx
+++ b/app/(main)/chinba/event/page.tsx
@@ -1,5 +1,26 @@
 import { Suspense } from 'react';
+
+import type { Metadata } from 'next';
+
 import ChinbaDetailClient from './_components/ChinbaDetailClient';
+
+// 링크 프리뷰(OG) — 이 경로에서만 루트 layout의 제로타임 메타를 타임라인으로 덮는다.
+// openGraph는 세그먼트 단위로 통째 교체되므로 siteName·locale·type도 다시 적는다.
+// 카드 이미지는 같은 폴더의 opengraph-image.tsx가 자동으로 붙는다.
+const TITLE = '타임라인 - 가장 편한 일정 잡기';
+const DESCRIPTION = '내가 되는 시간만 체크하세요. 모두 되는 시간을 찾아드려요.';
+
+export const metadata: Metadata = {
+    title: TITLE,
+    description: DESCRIPTION,
+    openGraph: {
+        title: TITLE,
+        description: DESCRIPTION,
+        siteName: '타임라인 (TimeLine)',
+        locale: 'ko_KR',
+        type: 'website',
+    },
+};
 
 export default function ChinbaEventPage() {
     return (

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -50,8 +50,8 @@ export default function ChinbaHomePage() {
         {/* 제목 카드 */}
         <header className="rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-1.5">
-            <span className="text-lg font-bold tracking-tight text-blue-700">TIMELINE</span>
-            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            <span className="text-lg font-bold tracking-tight text-emerald-500">TIMELINE</span>
+            <span className="h-1.5 w-1.5 rounded-full bg-blue-700" />
           </div>
 
           {!isAuthLoaded ? (
@@ -76,7 +76,7 @@ export default function ChinbaHomePage() {
           )}
 
           {typeof stats?.total_teams === 'number' && (
-            <p className="mt-3 inline-flex rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700">
+            <p className="mt-3 inline-flex rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800">
               {stats.total_teams.toLocaleString('ko-KR')}개의 동아리가 함께하고 있어요
             </p>
           )}

--- a/app/(main)/chinba/page.tsx
+++ b/app/(main)/chinba/page.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import { useMemo } from 'react';
+
 import { useRouter } from 'next/navigation';
 import { FiCalendar, FiClock, FiGrid, FiLink, FiPlus, FiUsers } from 'react-icons/fi';
 
+import { ChinbaEventListItem } from '@/(main)/chinba/_components/ChinbaEventListItem';
 import TeamCard from '@/(main)/teams/_components/TeamCard';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { useMyChinbaEvents } from '@/_lib/hooks/useChinba';
 import { useMyTeams } from '@/_lib/hooks/useTeam';
 import { useTeamStats } from '@/_lib/hooks/useTeamStats';
 import { useUser } from '@/_lib/hooks/useUser';
+import { selectUpcoming, formatUpcomingDate } from '@/_lib/utils/chinbaUpcoming';
 import type { TeamListItem } from '@/_types/team';
 
 const CONCEPTS = [
@@ -35,6 +40,14 @@ export default function ChinbaHomePage() {
   const { isAuthLoaded, isLoggedIn } = useUser();
   const { data: stats } = useTeamStats();
   const { data: teamsData, isLoading: isTeamsLoading } = useMyTeams();
+  // 다가오는 일정 카드 — my-events 기반이라 동아리 일정과 '동아리 없이 잡은' 개인 일정을 모두 포함
+  const { data: myEvents } = useMyChinbaEvents(isAuthLoaded && isLoggedIn);
+  const upcoming = useMemo(() => selectUpcoming(myEvents ?? []), [myEvents]);
+  // 동아리 없이 잡은 개인 일정 — 완료 처리 전(진행중·지난 일정)까지 목록에 보여준다
+  const personalEvents = useMemo(
+    () => (myEvents ?? []).filter((e) => e.team_id == null && e.status !== 'completed'),
+    [myEvents],
+  );
 
   const teams = teamsData?.teams ?? [];
 
@@ -47,8 +60,9 @@ export default function ChinbaHomePage() {
   return (
     <div className="h-full overflow-y-auto bg-gray-50">
       <div className="space-y-5 px-5 pt-6 pb-10">
-        {/* 제목 카드 */}
-        <header className="rounded-2xl bg-white p-4 shadow-sm">
+        {/* 제목 카드 + 다가오는 일정 카드 (로그인 시) */}
+        <div className="flex items-stretch gap-3">
+        <header className="min-w-0 flex-1 rounded-2xl bg-white p-4 shadow-sm">
           <div className="flex items-center gap-1.5">
             <span className="text-lg font-bold tracking-tight text-emerald-500">TIMELINE</span>
             <span className="h-1.5 w-1.5 rounded-full bg-blue-700" />
@@ -81,6 +95,58 @@ export default function ChinbaHomePage() {
             </p>
           )}
         </header>
+
+        {/* 다가오는 일정 — 데스크톱 전용(모바일 홈에는 표시하지 않음).
+            앱 폴더처럼 2×2 미니 타일: 일정 최대 3개는 각각 상세로, 남으면 +N이 MY로 이동 */}
+        {isAuthLoaded && isLoggedIn && (
+          <div className="hidden w-44 shrink-0 flex-col rounded-2xl bg-white p-3.5 shadow-sm md:flex">
+            <button
+              type="button"
+              onClick={() => router.push('/chinba/my')}
+              className="flex items-center gap-1 text-xs font-bold text-gray-900 transition active:scale-[0.98]"
+            >
+              <FiClock size={13} className="shrink-0 text-emerald-500" />
+              다가오는 일정
+            </button>
+            {upcoming.length > 0 ? (
+              <div className="mt-2 grid flex-1 grid-cols-2 gap-1.5">
+                {upcoming.slice(0, 3).map(({ event, when }) => (
+                  <button
+                    key={event.event_id}
+                    type="button"
+                    onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                    className="flex aspect-square flex-col rounded-lg bg-gray-50 p-1.5 text-left transition hover:bg-gray-100 active:scale-95"
+                  >
+                    <span className="line-clamp-2 text-[10px] font-semibold leading-tight text-gray-700 break-keep">
+                      {event.title}
+                    </span>
+                    <span className="mt-auto text-[10px] font-semibold text-emerald-600">
+                      {formatUpcomingDate(when)}
+                    </span>
+                  </button>
+                ))}
+                {upcoming.length > 3 ? (
+                  <button
+                    type="button"
+                    onClick={() => router.push('/chinba/my')}
+                    className="flex aspect-square items-center justify-center rounded-lg bg-gray-50 text-xs font-bold text-gray-500 transition hover:bg-gray-100 active:scale-95"
+                  >
+                    +{upcoming.length - 3}
+                  </button>
+                ) : (
+                  Array.from({ length: 4 - upcoming.length }).map((_, i) => (
+                    <div key={i} className="aspect-square rounded-lg bg-gray-50/60" />
+                  ))
+                )}
+              </div>
+            ) : (
+              <p className="my-auto text-center text-[11px] leading-relaxed text-gray-400 break-keep">
+                예정된 일정이 없어요
+              </p>
+            )}
+          </div>
+        )}
+        </div>
 
         {/* 타임라인 동아리 선택 — 목록을 펼친 채로 + 만들기/참여 */}
         <section className="rounded-2xl bg-white p-4 shadow-sm">
@@ -133,14 +199,43 @@ export default function ChinbaHomePage() {
           </div>
         </section>
 
-        {/* 동아리 없이 일정 잡기 — 항상 노출 (텍스트 버튼) */}
-        <button
-          type="button"
-          onClick={() => router.push('/chinba/create')}
-          className="w-full py-1 text-center text-sm font-bold text-gray-900 transition active:scale-[0.99]"
-        >
-          동아리 없이 일정 잡기 →
-        </button>
+        {/* 동아리 없이 잡은 일정 — 동아리 선택 섹션과 같은 형태로 목록 노출 + 잡기 버튼 */}
+        <section className="rounded-2xl bg-white p-4 shadow-sm">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="text-sm font-bold text-gray-900">동아리 없이 잡은 일정</h2>
+            <button
+              type="button"
+              onClick={() => router.push('/chinba/create')}
+              className="flex shrink-0 items-center gap-1 rounded-lg bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-gray-800 active:scale-95"
+            >
+              <FiPlus size={13} />
+              일정 잡기
+            </button>
+          </div>
+
+          <div className="mt-3">
+            {!isAuthLoaded ? null : !isLoggedIn ? (
+              <p className="py-6 text-center text-xs text-gray-400 break-keep">
+                로그인하면 동아리 없이 잡은 일정을 모아볼 수 있어요.
+              </p>
+            ) : personalEvents.length === 0 ? (
+              <p className="py-6 text-center text-xs text-gray-400 break-keep">
+                동아리 없이 잡은 일정이 없어요. 링크 공유로 누구와도 시간을 맞출 수 있어요.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {personalEvents.map((event) => (
+                  <ChinbaEventListItem
+                    key={event.event_id}
+                    event={event}
+                    compact
+                    onClick={() => router.push(`/chinba/event?id=${event.event_id}`)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </section>
 
         {/* 소개 모드일 때만: 친바가 하는 일 / 이럴 때 써요 */}
         {isAuthLoaded && isNewcomer && (

--- a/app/(main)/chinba/team/join/opengraph-image.tsx
+++ b/app/(main)/chinba/team/join/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import {
+  OG_ACCENT_COLOR,
+  OG_CARD_CONTENT_TYPE,
+  OG_CARD_SIZE,
+  renderWordmarkCard,
+} from '@/_lib/og/wordmarkCard';
+
+// Static export를 위한 설정
+export const dynamic = 'force-static';
+
+// Image metadata
+export const alt = '타임라인 (TimeLine) - 가장 편한 일정 잡기';
+export const size = OG_CARD_SIZE;
+
+export const contentType = OG_CARD_CONTENT_TYPE;
+
+// Image generation
+export default async function Image() {
+  return renderWordmarkCard('TIMELINE', OG_ACCENT_COLOR.timeline);
+}

--- a/app/(main)/chinba/team/join/page.tsx
+++ b/app/(main)/chinba/team/join/page.tsx
@@ -1,5 +1,26 @@
 import { Suspense } from 'react';
+
+import type { Metadata } from 'next';
+
 import TeamJoinView from '../../_components/team/TeamJoinView';
+
+// 링크 프리뷰(OG) — 이 경로에서만 루트 layout의 제로타임 메타를 타임라인으로 덮는다.
+// openGraph는 세그먼트 단위로 통째 교체되므로 siteName·locale·type도 다시 적는다.
+// 카드 이미지는 같은 폴더의 opengraph-image.tsx가 자동으로 붙는다.
+const TITLE = '타임라인 - 우리 동아리에 초대합니다';
+const DESCRIPTION = '일정 조율부터 활동 기록, 조별 랭킹, 운영진 관리까지 한 곳에서.';
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: '타임라인 (TimeLine)',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+};
 
 export default function TeamJoinPage() {
   return (

--- a/app/(main)/teams/_components/TeamSegmentTabs.tsx
+++ b/app/(main)/teams/_components/TeamSegmentTabs.tsx
@@ -3,6 +3,8 @@
 import type { IconType } from 'react-icons';
 import { LuCalendar, LuPencil, LuMedal } from 'react-icons/lu';
 
+import { CHINBA_RANKING_TAB_VISIBLE } from '@/_lib/constants/features';
+
 export type TeamSegment = 'mannaja' | 'mwoheni' | 'jabahbwa';
 
 interface TeamSegmentTabsProps {
@@ -13,7 +15,9 @@ interface TeamSegmentTabsProps {
 const TABS: { key: TeamSegment; label: string; icon: IconType }[] = [
   { key: 'mannaja', label: '일정', icon: LuCalendar },
   { key: 'mwoheni', label: '기록', icon: LuPencil },
-  { key: 'jabahbwa', label: '랭킹', icon: LuMedal },
+  ...(CHINBA_RANKING_TAB_VISIBLE
+    ? [{ key: 'jabahbwa' as const, label: '랭킹', icon: LuMedal }]
+    : []),
 ];
 
 export default function TeamSegmentTabs({ activeTab, onTabChange }: TeamSegmentTabsProps) {

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -7,6 +7,7 @@ import { LuPlus, LuClock, LuCalendar, LuTrash2, LuPencil, LuX, LuUsers } from 'r
 
 import MemberPickerSheet from '@/(main)/chinba/_components/team/groups/MemberPickerSheet';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import Modal from '@/_components/ui/Modal';
 import { useToast } from '@/_context/ToastContext';
 import { CHINBA_GROUP_SCORING_ENABLED } from '@/_lib/constants/features';
 import {
@@ -297,12 +298,16 @@ export default function ActivityTab({
         </p>
       )}
 
-      {/* Create / Edit Form */}
-      {showForm && (
-        <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3">
-          <p className="text-xs font-medium text-gray-500">
-            {isEditing ? '활동 기록 수정' : '활동 기록하기'}
-          </p>
+      {/* Create / Edit Form — 팝업 모달. X/배경 클릭으로 닫으면 아무것도 확정하지 않는다
+          (완료 흐름에서 온 경우에도 일정은 진행중 상태로 보존 — '기록하지 않기'와 다름) */}
+      <Modal
+        isOpen={showForm}
+        onClose={closeForm}
+        title={isEditing ? '활동 기록 수정' : '활동 기록하기'}
+        // 모바일은 기본 폭, 데스크톱(md+)은 기존 인라인 카드처럼 넓게 — 세로 스크롤을 줄인다
+        maxWidth="max-w-md md:max-w-2xl"
+      >
+        <div className="p-4 space-y-3">
           <input
             type="text"
             placeholder="활동 제목"
@@ -512,7 +517,7 @@ export default function ActivityTab({
             </button>
           </div>
         </div>
-      )}
+      </Modal>
 
       {/* 참여 인원 선택 시트 — 기존 선택을 이어받고, 제외는 폼의 칩에서 한다 */}
       {showMemberPicker && (

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -9,7 +9,7 @@ import MemberPickerSheet from '@/(main)/chinba/_components/team/groups/MemberPic
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import Modal from '@/_components/ui/Modal';
 import { useToast } from '@/_context/ToastContext';
-import { CHINBA_GROUP_SCORING_ENABLED } from '@/_lib/constants/features';
+import { CHINBA_GROUP_SCORING_ENABLED, CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import {
   useActivities,
   useCreateActivity,
@@ -52,7 +52,7 @@ export default function ActivityTab({
     category_id: selectedCategoryId ?? undefined,
   });
   const { data: groupsData } = useGroups(teamId);
-  const { data: categoriesData } = useEventCategories(teamId);
+  const { data: categoriesData } = useEventCategories(CHINBA_HASHTAG_ENABLED ? teamId : undefined);
   const { data: membersData } = useTeamMembers(teamId);
   const teamMembers = useMemo(() => membersData?.members ?? [], [membersData]);
   const categories = categoriesData?.categories ?? [];
@@ -135,7 +135,7 @@ export default function ActivityTab({
       setFormData({
         title: recordTitle ?? '',
         activity_date: recordDate || new Date().toISOString().slice(0, 10),
-        category_id: recordCategoryId,
+        category_id: CHINBA_HASHTAG_ENABLED ? recordCategoryId : undefined,
       });
       setFormScores([]);
       setCompletingEventId(recordEventId);
@@ -600,7 +600,7 @@ function ActivityCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
             <h3 className="text-sm font-semibold text-gray-800 truncate">{activity.title}</h3>
-            {activity.category && (
+            {CHINBA_HASHTAG_ENABLED && activity.category && (
               <span className="shrink-0 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
                 #{activity.category.name}
               </span>

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -15,6 +15,7 @@ import {
   useUpdateActivity,
   useDeleteActivity,
 } from '@/_lib/hooks/useActivities';
+import { useCompleteChinbaEvent } from '@/_lib/hooks/useChinba';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroups, useGroupSets } from '@/_lib/hooks/useGroups';
 import { useTeamMembers } from '@/_lib/hooks/useTeam';
@@ -57,10 +58,14 @@ export default function ActivityTab({
   const createMutation = useCreateActivity(teamId);
   const updateMutation = useUpdateActivity(teamId);
   const deleteMutation = useDeleteActivity(teamId);
+  const completeEventMutation = useCompleteChinbaEvent();
   const { showToast } = useToast();
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
+  // 일정 완료 처리 흐름에서 넘어온 경우의 대상 일정 id — 이 값이 있으면
+  // '기록하기/기록하지 않기' 선택 시점에 해당 일정의 완료가 확정된다.
+  const [completingEventId, setCompletingEventId] = useState<string | null>(null);
   const [formData, setFormData] = useState<ActivityCreateRequest>({
     title: '',
     activity_date: new Date().toISOString().slice(0, 10),
@@ -109,11 +114,14 @@ export default function ActivityTab({
     setEditingId(null);
   }, [selectedGroupId]);
 
-  // 일정 완료 처리에서 넘어온 경우: 활동 기록 폼을 완료된 일정 정보로 미리 채워 자동 오픈.
-  // (URL의 recordTitle/recordDate 파라미터를 1회 소비하고 즉시 제거해 재오픈 방지)
+  // 일정 완료 처리에서 넘어온 경우: 활동 기록 폼을 일정 정보로 미리 채워 자동 오픈.
+  // 이 시점에 일정은 아직 완료되지 않았다 — 폼의 '기록하기/기록하지 않기'를 눌러야 완료가
+  // 확정되고, 아무 버튼 없이 이탈하면 일정은 이전 상태 그대로 보존된다.
+  // (URL의 record* 파라미터를 1회 소비하고 즉시 제거해 재오픈 방지)
   useEffect(() => {
     const recordTitle = searchParams.get('recordTitle');
-    if (recordTitle === null) return;
+    const recordEventId = searchParams.get('recordEventId');
+    if (recordTitle === null && recordEventId === null) return;
 
     if (hasRole) {
       const recordDate = searchParams.get('recordDate');
@@ -124,11 +132,12 @@ export default function ActivityTab({
           ? Number(recordCategoryIdRaw)
           : undefined;
       setFormData({
-        title: recordTitle,
+        title: recordTitle ?? '',
         activity_date: recordDate || new Date().toISOString().slice(0, 10),
         category_id: recordCategoryId,
       });
       setFormScores([]);
+      setCompletingEventId(recordEventId);
       setShowForm(true);
     }
 
@@ -136,6 +145,7 @@ export default function ActivityTab({
     params.delete('recordTitle');
     params.delete('recordDate');
     params.delete('recordCategoryId');
+    params.delete('recordEventId');
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -156,6 +166,7 @@ export default function ActivityTab({
   const closeForm = () => {
     setShowForm(false);
     setEditingId(null);
+    setCompletingEventId(null);
     setFormData({ title: '', activity_date: new Date().toISOString().slice(0, 10) });
     setFormScores([]);
     setParticipantIds([]);
@@ -164,6 +175,7 @@ export default function ActivityTab({
 
   const handleEdit = (activity: Activity) => {
     setEditingId(activity.id);
+    setCompletingEventId(null);
     setFormData({
       title: activity.title,
       activity_date: activity.activity_date,
@@ -179,6 +191,20 @@ export default function ActivityTab({
     setFormScores(activity.scores.map((s) => ({ group_id: s.group_id, score: s.score })));
     setParticipantIds(activity.participants.map((p) => p.member_id));
     setShowForm(true);
+  };
+
+  const isCompletionMode = completingEventId !== null && !isEditing;
+
+  // '기록하지 않기' — 기록 없이 일정 완료만 확정
+  const handleSkipRecord = async () => {
+    if (!completingEventId) return;
+    try {
+      await completeEventMutation.mutateAsync(completingEventId);
+      showToast('일정이 완료 처리되었습니다');
+      closeForm();
+    } catch {
+      showToast('일정 완료 처리에 실패했어요', 'error');
+    }
   };
 
   const handleSubmit = async () => {
@@ -217,6 +243,15 @@ export default function ActivityTab({
           category_id: submitCategoryId,
           participant_member_ids: participantIds.length > 0 ? participantIds : undefined,
         });
+        // 일정 완료 흐름에서 온 기록이면 이 시점에 일정 완료를 확정한다
+        if (completingEventId) {
+          try {
+            await completeEventMutation.mutateAsync(completingEventId);
+          } catch {
+            // 기록은 이미 저장됨 — 완료만 실패했으니 일정 상세에서 다시 완료 처리하면 된다
+            showToast('기록은 저장됐지만 일정 완료 처리에 실패했어요', 'error');
+          }
+        }
       }
       closeForm();
     } catch {
@@ -450,10 +485,15 @@ export default function ActivityTab({
 
           <div className="flex gap-2 pt-1">
             <button
-              onClick={closeForm}
-              className="flex-1 rounded-lg bg-gray-200 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-300"
+              onClick={isCompletionMode ? handleSkipRecord : closeForm}
+              disabled={isCompletionMode && completeEventMutation.isPending}
+              className="flex-1 rounded-lg bg-gray-200 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-300 disabled:opacity-50"
             >
-              취소
+              {isCompletionMode
+                ? completeEventMutation.isPending
+                  ? '처리 중...'
+                  : '기록하지 않기'
+                : '취소'}
             </button>
             <button
               onClick={handleSubmit}

--- a/app/(main)/teams/detail/_components/ActivityTab.tsx
+++ b/app/(main)/teams/detail/_components/ActivityTab.tsx
@@ -183,7 +183,6 @@ export default function ActivityTab({
       start_time: activity.start_time ?? undefined,
       end_time: activity.end_time ?? undefined,
       description: activity.description ?? undefined,
-      highlight: activity.highlight ?? undefined,
       total_cost: activity.total_cost ?? undefined,
       cost_note: activity.cost_note ?? undefined,
     });
@@ -224,8 +223,8 @@ export default function ActivityTab({
           data: {
             ...formData,
             // 비워둔 항목은 빈 문자열로 보내야 서버에서 지워진다 (undefined는 기존 값 유지)
+            // highlight는 입력 UI 폐지로 아예 보내지 않는다 — 기존 값은 서버에 그대로 남는다
             description: formData.description ?? '',
-            highlight: formData.highlight ?? '',
             start_time: formData.start_time ?? '',
             end_time: formData.end_time ?? '',
             cost_note: formData.cost_note ?? '',
@@ -348,22 +347,6 @@ export default function ActivityTab({
               onChange={(e) => setFormData({ ...formData, description: e.target.value || undefined })}
               className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none resize-none"
               rows={2}
-            />
-          </div>
-
-          {/* Highlight — 자유 텍스트 칸이 둘이라 무엇을 어디에 쓰는지 라벨·예시로 구분한다 */}
-          <div className="space-y-2">
-            <div>
-              <p className="text-xs font-medium text-gray-500">하이라이트 (선택)</p>
-              <p className="text-[11px] text-gray-400">카드 맨 위에 강조되어 보입니다</p>
-            </div>
-            <input
-              type="text"
-              placeholder="예: 장소 예약은 2주 전에"
-              aria-label="하이라이트"
-              value={formData.highlight ?? ''}
-              onChange={(e) => setFormData({ ...formData, highlight: e.target.value || undefined })}
-              className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:border-gray-400 focus:outline-none"
             />
           </div>
 
@@ -642,16 +625,9 @@ function ActivityCard({
         </div>
       </div>
 
-      {/* Highlight */}
-      {activity.highlight && (
-        <p className="mt-2 text-xs text-gray-500 bg-yellow-50 rounded-lg px-2.5 py-1.5 border border-yellow-100">
-          {activity.highlight}
-        </p>
-      )}
-
-      {/* Description */}
+      {/* Description — 하이라이트 입력 폐지로 유일한 자유 텍스트: 검정에 가까운 초록으로 본문 대접 */}
       {activity.description && (
-        <p className="mt-2 text-xs text-gray-500 line-clamp-2">{activity.description}</p>
+        <p className="mt-2 text-xs text-emerald-950 line-clamp-2">{activity.description}</p>
       )}
 
       {/* Cost */}

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -155,20 +155,6 @@ export default function MannajaTab({
       {hasGroups ? (
         /* 섹션 분리 레이아웃 */
         <>
-          <SectionHeader icon={FiUsers} label={terminology === 'club' ? '동아리 전체 일정' : '팀 전체 일정'} />
-          {teamWideEvents.length > 0 ? (
-            teamWideEvents.map((event) => (
-              <EventCard
-                key={event.event_id}
-                event={event}
-                groupSetNameMap={groupSetNameMap}
-                onClick={() => openEvent(event.event_id)}
-              />
-            ))
-          ) : (
-            <SectionEmptyState message={terminology === 'club' ? '동아리 전체 일정이 없습니다' : '팀 전체 일정이 없습니다'} />
-          )}
-
           <SectionHeader icon={FiLayers} label="조별 일정" />
           {groupEvents.length > 0 ? (
             groupEvents.map((event) => (
@@ -184,6 +170,20 @@ export default function MannajaTab({
               message="아직 조별 일정이 없습니다"
               submessage={canCreate ? '조별 일정을 만들어 보세요' : undefined}
             />
+          )}
+
+          <SectionHeader icon={FiUsers} label={terminology === 'club' ? '동아리 전체 일정' : '팀 전체 일정'} />
+          {teamWideEvents.length > 0 ? (
+            teamWideEvents.map((event) => (
+              <EventCard
+                key={event.event_id}
+                event={event}
+                groupSetNameMap={groupSetNameMap}
+                onClick={() => openEvent(event.event_id)}
+              />
+            ))
+          ) : (
+            <SectionEmptyState message={terminology === 'club' ? '동아리 전체 일정이 없습니다' : '팀 전체 일정이 없습니다'} />
           )}
         </>
       ) : events.length === 0 ? (

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -8,6 +8,7 @@ import type { IconType } from 'react-icons';
 import { FiPlus, FiCalendar, FiUsers, FiLayers } from 'react-icons/fi';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useTeamEvents } from '@/_lib/hooks/useTeamEvents';
 import { formatDateRanges } from '@/_lib/utils/dateRange';
@@ -252,7 +253,7 @@ function EventCard({ event, groupSetNameMap, onClick }: { event: TeamEvent; grou
 
       {/* Target groups - 항상 표시 */}
       <div className="flex flex-wrap gap-1 mb-2">
-        {event.category && (
+        {CHINBA_HASHTAG_ENABLED && event.category && (
           <span className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[10px] font-medium text-gray-500">
             #{event.category.name}
           </span>

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -238,7 +238,7 @@ function EventCard({ event, groupSetNameMap, onClick }: { event: TeamEvent; grou
                 : 'bg-gray-50 text-gray-400'
           }`}
         >
-          {event.status === 'active' ? '진행 중' : event.status === 'completed' ? '완료' : '만료'}
+          {event.status === 'active' ? '진행 중' : event.status === 'completed' ? '완료됨' : '지난 일정'}
         </span>
       </div>
 

--- a/app/(main)/teams/detail/_components/MannajaTab.tsx
+++ b/app/(main)/teams/detail/_components/MannajaTab.tsx
@@ -148,7 +148,7 @@ export default function MannajaTab({
           className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-4 text-sm font-medium text-gray-400 transition-colors hover:border-gray-300 hover:text-gray-500 active:scale-[0.98]"
         >
           <FiPlus size={18} />
-          <span>{terminology === 'club' ? '동아리 친바 만들기' : '팀 친바 만들기'}</span>
+          <span>일정 잡기</span>
         </button>
       )}
 

--- a/app/(main)/teams/detail/_components/TeamDetailClient.tsx
+++ b/app/(main)/teams/detail/_components/TeamDetailClient.tsx
@@ -8,7 +8,7 @@ import { LuChevronLeft } from 'react-icons/lu';
 
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
-import { CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
+import { CHINBA_HASHTAG_ENABLED, CHINBA_RANKING_TAB_ENABLED } from '@/_lib/constants/features';
 import { useEventCategories } from '@/_lib/hooks/useCategories';
 import { useGroupSets } from '@/_lib/hooks/useGroups';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
@@ -55,7 +55,7 @@ export default function TeamDetailClient() {
   // 세트 1개일 때 자동 선택
   const effectiveSetId = groupSets.length === 1 ? groupSets[0].id : selectedSetId;
 
-  const { data: categoriesData } = useEventCategories(teamId);
+  const { data: categoriesData } = useEventCategories(CHINBA_HASHTAG_ENABLED ? teamId : undefined);
   const categories = categoriesData?.categories ?? [];
 
   // 선택 중이던 카테고리가 삭제되면 필터 자동 해제 (로딩 중 오리셋 방지 위해 데이터 존재 가드)

--- a/app/(main)/teams/detail/_components/TeamSetupGuide.tsx
+++ b/app/(main)/teams/detail/_components/TeamSetupGuide.tsx
@@ -60,12 +60,12 @@ export default function TeamSetupGuide({
   };
 
   return (
-    <div className="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 p-4 space-y-3">
+    <div className="rounded-xl bg-gradient-to-r from-emerald-100 to-teal-50 p-4 space-y-3">
       {/* Step 1 */}
       {!isStep1Done ? (
         <div className="flex items-start gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100">
-            <span className="text-xs font-bold text-blue-600">①</span>
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-200">
+            <span className="text-xs font-bold text-emerald-700">①</span>
           </div>
           <div className="flex-1">
             <p className="text-sm font-medium text-gray-700">
@@ -96,8 +96,9 @@ export default function TeamSetupGuide({
         </div>
       ) : (
         <div className="flex items-center gap-2">
-          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-green-100">
-            <FiCheck size={12} className="text-green-600" />
+          {/* 카드 자체가 초록이라 완료 표시는 흰 원으로 띄운다 */}
+          <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white">
+            <FiCheck size={12} className="text-emerald-600" />
           </div>
           <p className="text-sm font-medium text-gray-500">
             {terminology === 'club' ? '회원' : '팀원'} 초대 완료 ({memberCount}명)
@@ -114,8 +115,8 @@ export default function TeamSetupGuide({
         </div>
       ) : (
         <div className="flex items-start gap-3">
-          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-100">
-            <FiUsers size={14} className="text-blue-600" />
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-200">
+            <FiUsers size={14} className="text-emerald-700" />
           </div>
           <div className="flex-1">
             <p className="text-sm font-medium text-gray-700">조를 편성해보세요</p>
@@ -124,7 +125,7 @@ export default function TeamSetupGuide({
             </p>
             <button
               onClick={() => router.push(`/chinba/team/groups?id=${teamId}`)}
-              className="mt-1.5 text-xs font-semibold text-blue-600 hover:text-blue-700"
+              className="mt-1.5 text-xs font-semibold text-emerald-700 hover:text-emerald-800"
             >
               조 편성하러 가기 →
             </button>

--- a/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
+++ b/app/(main)/teams/settings/_components/TeamSettingsClient.tsx
@@ -9,6 +9,7 @@ import { LuChevronLeft } from 'react-icons/lu';
 import ConfirmModal from '@/_components/ui/ConfirmModal';
 import LoadingSpinner from '@/_components/ui/LoadingSpinner';
 import { useToast } from '@/_context/ToastContext';
+import { CHINBA_HASHTAG_ENABLED } from '@/_lib/constants/features';
 import { useSmartBack } from '@/_lib/hooks/useSmartBack';
 import {
   useTeamDetail,
@@ -322,11 +323,13 @@ export default function TeamSettingsClient() {
           canManage={canEditTeam(myRole)}
         />
 
-        {/* 일정 카테고리 관리 */}
-        <EventCategorySection
-          teamId={teamId}
-          canManage={canEditTeam(myRole)}
-        />
+        {/* 일정 카테고리(해시태그) 관리 */}
+        {CHINBA_HASHTAG_ENABLED && (
+          <EventCategorySection
+            teamId={teamId}
+            canManage={canEditTeam(myRole)}
+          />
+        )}
 
         {/* Section 5: 구독 관리 */}
         <SubscriptionSection

--- a/app/_components/layout/DesktopSidebar.tsx
+++ b/app/_components/layout/DesktopSidebar.tsx
@@ -54,6 +54,7 @@ export default function DesktopSidebar({ collapsed, onToggle }: DesktopSidebarPr
 
   return (
     <aside
+      data-app-sidebar
       className={`hidden md:flex md:shrink-0 h-full border-r border-gray-100 bg-white overflow-hidden relative${
         transitionEnabled ? ' transition-[width] duration-300 ease-in-out' : ''
       } ${collapsed ? 'md:w-[60px]' : 'md:w-[260px]'}`}

--- a/app/_lib/api/chinba.test.ts
+++ b/app/_lib/api/chinba.test.ts
@@ -1,0 +1,88 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('./client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import api from './client';
+import { getChinbaEventDetail, joinChinbaEventTeam } from './chinba';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getChinbaEventDetail', () => {
+  it('비멤버 응답의 동아리 정보를 그대로 넘긴다', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: {
+        event_id: 'ev123456',
+        title: '정기 모임',
+        dates: ['2026-04-01'],
+        start_hour: 8,
+        end_hour: 24,
+        status: 'active',
+        creator_id: 10,
+        creator_nickname: '팀장',
+        category: null,
+        participants: [],
+        heatmap: [],
+        recommended_times: [],
+        created_at: '2026-03-15',
+        team_id: 7,
+        team_name: '컴공 알고리즘 동아리',
+        is_team_member: false,
+      },
+    });
+
+    const result = await getChinbaEventDetail('ev123456');
+
+    expect(api.get).toHaveBeenCalledWith('/chinba/events/ev123456');
+    expect(result.team_id).toBe(7);
+    expect(result.team_name).toBe('컴공 알고리즘 동아리');
+    expect(result.is_team_member).toBe(false);
+    expect(result.participants).toEqual([]);
+  });
+});
+
+describe('joinChinbaEventTeam', () => {
+  it('sends POST /chinba/events/:eventId/join-team', async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        team_id: 7,
+        team_name: '컴공 알고리즘 동아리',
+        my_role: 'member',
+        already_member: false,
+        message: '컴공 알고리즘 동아리에 가입했습니다',
+      },
+    });
+
+    const result = await joinChinbaEventTeam('ev123456');
+
+    expect(api.post).toHaveBeenCalledWith('/chinba/events/ev123456/join-team');
+    expect(result.team_id).toBe(7);
+    expect(result.my_role).toBe('member');
+    expect(result.already_member).toBe(false);
+  });
+
+  it('이미 멤버여도 성공 응답을 그대로 반환한다', async () => {
+    vi.mocked(api.post).mockResolvedValue({
+      data: {
+        team_id: 7,
+        team_name: '컴공 알고리즘 동아리',
+        my_role: 'captain',
+        already_member: true,
+        message: '이미 가입한 동아리입니다',
+      },
+    });
+
+    const result = await joinChinbaEventTeam('ev123456');
+
+    expect(result.already_member).toBe(true);
+  });
+});

--- a/app/_lib/api/chinba.ts
+++ b/app/_lib/api/chinba.ts
@@ -5,6 +5,7 @@ import type {
   ChinbaEventListItem,
   ChinbaEventCreateRequest,
   ChinbaEventCreateResponse,
+  ChinbaEventTeamJoinResponse,
   ChinbaUnavailabilityUpdateRequest,
 } from '@/_types/chinba';
 
@@ -15,6 +16,13 @@ export async function createChinbaEvent(data: ChinbaEventCreateRequest): Promise
 
 export async function getChinbaEventDetail(eventId: string): Promise<ChinbaEventDetail> {
   const res = await api.get(`/chinba/events/${eventId}`);
+  return res.data;
+}
+
+// 동아리 일정 링크만 받은 사람이 그 동아리에 가입하고 일정에 참여한다.
+// 초대 코드 없이 event_id로 가입 대상이 정해지며, 이미 멤버여도 200(already_member=true)이다.
+export async function joinChinbaEventTeam(eventId: string): Promise<ChinbaEventTeamJoinResponse> {
+  const res = await api.post(`/chinba/events/${eventId}/join-team`);
   return res.data;
 }
 

--- a/app/_lib/api/chinba.ts
+++ b/app/_lib/api/chinba.ts
@@ -6,6 +6,7 @@ import type {
   ChinbaEventCreateRequest,
   ChinbaEventCreateResponse,
   ChinbaEventTeamJoinResponse,
+  ChinbaParticipantUnavailability,
   ChinbaUnavailabilityUpdateRequest,
 } from '@/_types/chinba';
 
@@ -28,6 +29,14 @@ export async function joinChinbaEventTeam(eventId: string): Promise<ChinbaEventT
 
 export async function getChinbaMyParticipation(eventId: string): Promise<ChinbaMyParticipation> {
   const res = await api.get(`/chinba/events/${eventId}/my-participation`);
+  return res.data;
+}
+
+export async function getChinbaParticipantUnavailability(
+  eventId: string,
+  userId: number,
+): Promise<ChinbaParticipantUnavailability> {
+  const res = await api.get(`/chinba/events/${eventId}/participants/${userId}/unavailability`);
   return res.data;
 }
 

--- a/app/_lib/constants/features.ts
+++ b/app/_lib/constants/features.ts
@@ -20,3 +20,10 @@ export const CHINBA_GROUP_SCORING_ENABLED: boolean = false;
  * "추후 업데이트 예정입니다" 안내만 띄운다. 백엔드 랭킹 API·데이터는 그대로 살아 있다.
  */
 export const CHINBA_RANKING_TAB_ENABLED: boolean = false;
+
+/**
+ * 해시태그(일정 카테고리) — 관리 모달·일정/활동 폼의 선택·필터바·배지 전부.
+ * 조/그룹 기능과 역할이 겹쳐 숨김(2026-08 결정). 백엔드 event-categories API와
+ * 이미 기록된 해시태그 데이터는 그대로 살아 있다.
+ */
+export const CHINBA_HASHTAG_ENABLED: boolean = false;

--- a/app/_lib/constants/features.ts
+++ b/app/_lib/constants/features.ts
@@ -22,6 +22,21 @@ export const CHINBA_GROUP_SCORING_ENABLED: boolean = false;
 export const CHINBA_RANKING_TAB_ENABLED: boolean = false;
 
 /**
+ * 팀 상세의 '랭킹' 탭 버튼 노출 자체.
+ * 애플 앱 심사는 미완성 기능 노출을 불허해 버튼까지 숨김(2026-08 결정) —
+ * 심사 통과 후 dev에서 true로 되돌려 버튼(+진입 차단 안내)을 복구한다.
+ * false면 CHINBA_RANKING_TAB_ENABLED와 무관하게 탭이 렌더되지 않는다.
+ */
+export const CHINBA_RANKING_TAB_VISIBLE: boolean = false;
+
+/**
+ * 응답 현황(운영 패널)의 미제출자 '알림' 버튼.
+ * 백엔드 미비로 "준비 중" 토스트만 띄우는 빈껍데기라 앱 심사 대비 숨김(2026-08 결정) —
+ * 심사 통과 후 dev에서 true로 되돌린다. '복사' 버튼은 완성 기능이라 그대로 노출.
+ */
+export const CHINBA_UNSUBMITTED_NOTIFY_ENABLED: boolean = false;
+
+/**
  * 해시태그(일정 카테고리) — 관리 모달·일정/활동 폼의 선택·필터바·배지 전부.
  * 조/그룹 기능과 역할이 겹쳐 숨김(2026-08 결정). 백엔드 event-categories API와
  * 이미 기록된 해시태그 데이터는 그대로 살아 있다.

--- a/app/_lib/hooks/useChinba.ts
+++ b/app/_lib/hooks/useChinba.ts
@@ -10,6 +10,7 @@ import {
   importChinbaTimetable,
   deleteChinbaEvent,
   completeChinbaEvent,
+  joinChinbaEventTeam,
 } from '@/_lib/api/chinba';
 import type {
   ChinbaEventCreateRequest,
@@ -75,6 +76,21 @@ export function useImportTimetable(eventId: string) {
       queryClient.invalidateQueries({ queryKey: ['chinba', 'event', eventId] });
       queryClient.invalidateQueries({ queryKey: ['chinba', 'participation', eventId] });
       queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+    },
+  });
+}
+
+// 동아리 일정 링크에서 가입 확인 -> 가입 + 그 일정 참여가 한 번에 끝난다.
+// 가입으로 동아리 목록·상세가 바뀌므로 teams 캐시도 함께 비운다.
+export function useJoinChinbaEventTeam(eventId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => joinChinbaEventTeam(eventId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['chinba', 'event', eventId] });
+      queryClient.invalidateQueries({ queryKey: ['chinba', 'participation', eventId] });
+      queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
     },
   });
 }

--- a/app/_lib/hooks/useChinba.ts
+++ b/app/_lib/hooks/useChinba.ts
@@ -95,12 +95,15 @@ export function useJoinChinbaEventTeam(eventId: string) {
   });
 }
 
+// 삭제·완료는 팀 상세의 일정 탭 목록(['teams', teamId, 'events', ...])에도 반영되어야 한다 —
+// teams 캐시를 함께 비우지 않으면 목록이 옛 상태(진행중/존재)로 남는다.
 export function useDeleteChinbaEvent() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (eventId: string) => deleteChinbaEvent(eventId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
     },
   });
 }
@@ -112,6 +115,7 @@ export function useCompleteChinbaEvent() {
     onSuccess: (_data, eventId) => {
       queryClient.invalidateQueries({ queryKey: ['chinba', 'event', eventId] });
       queryClient.invalidateQueries({ queryKey: ['chinba', 'my-events'] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
     },
   });
 }

--- a/app/_lib/hooks/useChinba.ts
+++ b/app/_lib/hooks/useChinba.ts
@@ -5,6 +5,7 @@ import {
   getMyChinbaEvents,
   getChinbaEventDetail,
   getChinbaMyParticipation,
+  getChinbaParticipantUnavailability,
   createChinbaEvent,
   updateChinbaUnavailability,
   importChinbaTimetable,
@@ -41,6 +42,19 @@ export function useMyParticipation(eventId: string | undefined) {
     queryKey: ['chinba', 'participation', eventId],
     queryFn: () => getChinbaMyParticipation(eventId!),
     enabled: !!eventId,
+    staleTime: 1000 * 30,
+  });
+}
+
+// 전체 일정에서 참여자 클릭 시 그 사람의 불가능 시간을 조회한다 (userId가 없으면 비활성)
+export function useParticipantUnavailability(
+  eventId: string | undefined,
+  userId: number | null,
+) {
+  return useQuery({
+    queryKey: ['chinba', 'participant-unavailability', eventId, userId],
+    queryFn: () => getChinbaParticipantUnavailability(eventId!, userId!),
+    enabled: !!eventId && userId !== null,
     staleTime: 1000 * 30,
   });
 }

--- a/app/_lib/og/wordmarkCard.tsx
+++ b/app/_lib/og/wordmarkCard.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from 'next/og';
+
+/** 링크 프리뷰 카드 규격 — 1200×630은 카카오톡·디스코드·슬랙 공통 안전지대 */
+export const OG_CARD_SIZE = { width: 1200, height: 630 };
+export const OG_CARD_CONTENT_TYPE = 'image/png';
+
+/** 워드마크 옆 강조 사각형 색 — 서비스별로 이 값만 다르다 */
+export const OG_ACCENT_COLOR = {
+  zerotime: '#3B82F6',
+  timeline: '#10B981',
+} as const;
+
+/**
+ * 워드마크 + 강조 사각형 카드를 굽는다 (빌드 타임 — 각 라우트의 opengraph-image가 호출).
+ *
+ * ⚠️ wordmark에는 **라틴 문자만** 넣는다. satori는 시스템 폰트 폴백이 없어서
+ * 아래 Inter latin 서브셋에 없는 글리프(한글 등)는 빈칸으로 렌더된다.
+ */
+export async function renderWordmarkCard(wordmark: string, accentColor: string) {
+  // Font loading
+  // Using standard fetch without import.meta.url for better compatibility
+  const interBold = await fetch(
+    'https://cdn.jsdelivr.net/npm/@fontsource/inter@5.0.18/files/inter-latin-800-normal.woff'
+  ).then((res) => {
+    if (!res.ok) {
+      throw new Error('Failed to fetch font');
+    }
+    return res.arrayBuffer();
+  });
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'white',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            justifyContent: 'center',
+          }}
+        >
+          {/* Wordmark */}
+          <div
+            style={{
+              fontFamily: 'Inter',
+              fontSize: '128px',
+              fontWeight: 800,
+              letterSpacing: '0.05em',
+              color: '#111827',
+              transform: 'skewX(-6deg)',
+            }}
+          >
+            {wordmark}
+          </div>
+
+          {/* Design Detail: Brand Accent Dot (Square) */}
+          <div
+            style={{
+              width: '35px',
+              height: '35px',
+              backgroundColor: accentColor,
+              marginLeft: '24px',
+              transform: 'skewX(-6deg)',
+            }}
+          />
+        </div>
+      </div>
+    ),
+    {
+      ...OG_CARD_SIZE,
+      fonts: [
+        {
+          name: 'Inter',
+          data: interBold,
+          style: 'normal',
+          weight: 800,
+        },
+      ],
+    }
+  );
+}

--- a/app/_lib/utils/chinbaUpcoming.ts
+++ b/app/_lib/utils/chinbaUpcoming.ts
@@ -1,0 +1,48 @@
+/** 친바 '다가오는 일정' 선별 — MY 탭과 타임라인 홈 카드가 같은 기준을 쓴다. */
+
+/** dates 배열에서 오늘(자정) 이후의 가장 이른 날짜를 ms로 반환. 없으면 null. */
+export function earliestUpcoming(dates: string[], todayMs: number): number | null {
+  let min: number | null = null;
+  for (const d of dates) {
+    const t = new Date(d).getTime();
+    if (Number.isNaN(t) || t < todayMs) continue;
+    if (min === null || t < min) min = t;
+  }
+  return min;
+}
+
+export interface UpcomingEntry<T> {
+  event: T;
+  /** 가장 이른 예정 날짜 (자정 기준 ms) */
+  when: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** 다가오는 일정으로 치는 기간 — 가장 이른 예정 날짜가 오늘부터 7일 이내(7일째 포함) */
+const UPCOMING_WINDOW_DAYS = 7;
+
+/**
+ * active 일정 중 가장 이른 예정 날짜가 오늘~7일 이내인 것을 날짜 오름차순으로 반환.
+ * 홈 카드와 MY 탭 '다가오는 일정'이 함께 쓴다.
+ */
+export function selectUpcoming<T extends { status: string; dates: string[] }>(
+  events: T[],
+): UpcomingEntry<T>[] {
+  const todayMs = new Date(new Date().toDateString()).getTime();
+  const limitMs = todayMs + UPCOMING_WINDOW_DAYS * DAY_MS;
+  return events
+    .filter((e) => e.status === 'active')
+    .map((event) => ({ event, when: earliestUpcoming(event.dates, todayMs) }))
+    .filter((x): x is UpcomingEntry<T> => x.when !== null && x.when <= limitMs)
+    .sort((a, b) => a.when - b.when);
+}
+
+/** 예정 날짜 표시용 라벨 — 오늘/내일/M월 D일 */
+export function formatUpcomingDate(whenMs: number): string {
+  const todayMs = new Date(new Date().toDateString()).getTime();
+  if (whenMs < todayMs + DAY_MS) return '오늘';
+  if (whenMs < todayMs + DAY_MS * 2) return '내일';
+  const d = new Date(whenMs);
+  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+}

--- a/app/_types/chinba.ts
+++ b/app/_types/chinba.ts
@@ -58,6 +58,8 @@ export interface ChinbaEventListItem {
   title: string;
   dates: string[];
   status: 'active' | 'completed' | 'expired';
+  /** 동아리 일정이면 팀 id, 개인(동아리 없이 잡은) 일정이면 null */
+  team_id: number | null;
   creator_id: number;
   creator_nickname: string | null;
   participant_count: number;

--- a/app/_types/chinba.ts
+++ b/app/_types/chinba.ts
@@ -32,6 +32,20 @@ export interface ChinbaEventDetail {
   heatmap: ChinbaHeatmapSlot[];
   recommended_times: ChinbaRecommendedTime[];
   created_at: string;
+  // 동아리(팀) 일정 여부 — 개인 친바는 null
+  team_id: number | null;
+  team_name: string | null;
+  // false면 동아리 일정인데 아직 멤버가 아니라는 뜻 — participants·heatmap이 비어 오고
+  // 가입 확인 화면(TeamJoinGate)을 띄운다
+  is_team_member: boolean;
+}
+
+export interface ChinbaEventTeamJoinResponse {
+  team_id: number;
+  team_name: string;
+  my_role: string;
+  already_member: boolean;
+  message: string;
 }
 
 export interface ChinbaMyParticipation {

--- a/app/_types/chinba.ts
+++ b/app/_types/chinba.ts
@@ -53,6 +53,14 @@ export interface ChinbaMyParticipation {
   unavailable_slots: string[];
 }
 
+/** 특정 참여자의 불가능 시간 — 전체 일정에서 참여자 클릭 시 개인 일정 강조용 */
+export interface ChinbaParticipantUnavailability {
+  user_id: number;
+  nickname: string | null;
+  has_submitted: boolean;
+  unavailable_slots: string[];
+}
+
 export interface ChinbaEventListItem {
   event_id: string;
   title: string;

--- a/app/globals.css
+++ b/app/globals.css
@@ -135,15 +135,17 @@ body {
   animation: slideInLeft 0.25s ease-out;
 }
 
-/* 사이드바 FOUC 방지 — React 로딩 전 인라인 스크립트가 클래스 추가 */
+/* 사이드바 FOUC 방지 — React 로딩 전 인라인 스크립트가 클래스 추가.
+   data-app-sidebar(왼쪽 앱 사이드바)로 한정 — 맨 aside 선택자는 오른쪽 운영 패널 같은
+   다른 aside까지 강제 접힘시켜 왼쪽이 접힌 동안 오른쪽이 안 펴지는 버그가 있었다 */
 @media (min-width: 52rem) {
-  .sidebar-collapsed aside {
+  .sidebar-collapsed aside[data-app-sidebar] {
     width: 60px !important;
   }
-  .sidebar-collapsed aside > div:first-child {
+  .sidebar-collapsed aside[data-app-sidebar] > div:first-child {
     opacity: 1 !important;
   }
-  .sidebar-collapsed aside > div:last-child {
+  .sidebar-collapsed aside[data-app-sidebar] > div:last-child {
     opacity: 0 !important;
     pointer-events: none !important;
   }

--- a/app/invite/opengraph-image.tsx
+++ b/app/invite/opengraph-image.tsx
@@ -1,20 +1,20 @@
 import {
-    OG_ACCENT_COLOR,
-    OG_CARD_CONTENT_TYPE,
-    OG_CARD_SIZE,
-    renderWordmarkCard,
+  OG_ACCENT_COLOR,
+  OG_CARD_CONTENT_TYPE,
+  OG_CARD_SIZE,
+  renderWordmarkCard,
 } from '@/_lib/og/wordmarkCard';
 
 // Static export를 위한 설정
 export const dynamic = 'force-static';
 
 // Image metadata
-export const alt = '제로타임 - 전북대 공지사항 통합 알림';
+export const alt = '타임라인 (TimeLine) - 가장 편한 일정 잡기';
 export const size = OG_CARD_SIZE;
 
 export const contentType = OG_CARD_CONTENT_TYPE;
 
 // Image generation
 export default async function Image() {
-    return renderWordmarkCard('ZEROTIME', OG_ACCENT_COLOR.zerotime);
+  return renderWordmarkCard('TIMELINE', OG_ACCENT_COLOR.timeline);
 }

--- a/app/invite/page.tsx
+++ b/app/invite/page.tsx
@@ -1,6 +1,26 @@
 import { Suspense } from 'react';
 
+import type { Metadata } from 'next';
+
 import InviteClient from './_components/InviteClient';
+
+// 링크 프리뷰(OG) — 이 경로에서만 루트 layout의 제로타임 메타를 타임라인으로 덮는다.
+// openGraph는 세그먼트 단위로 통째 교체되므로 siteName·locale·type도 다시 적는다.
+// 카드 이미지는 같은 폴더의 opengraph-image.tsx가 자동으로 붙는다.
+const TITLE = '타임라인 - 우리 동아리에 초대합니다';
+const DESCRIPTION = '일정 조율부터 활동 기록, 조별 랭킹, 운영진 관리까지 한 곳에서.';
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: '타임라인 (TimeLine)',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+};
 
 export default function InvitePage() {
   return (

--- a/e2e/fixtures/test-data.ts
+++ b/e2e/fixtures/test-data.ts
@@ -153,6 +153,7 @@ export const MOCK_CHINBA_EVENTS = [
     title: '조별과제 회의',
     dates: ['2024-07-10', '2024-07-11', '2024-07-12'],
     status: 'active' as const,
+    team_id: null,
     creator_id: 1,
     creator_nickname: '테스트유저',
     participant_count: 3,


### PR DESCRIPTION
## 범위
develop 39커밋 (4e5b44d). 전부 app/·e2e/ 내 변경 — next.config·vercel.json·package.json·env 불변.

- 친바: 일정 리스트 직접 입력 모드, 시간 그리드 일괄 선택, 팀 일정 링크 비멤버 가입 게이트(TeamJoinGate), 홈 다가오는 일정 카드, 활동 기록 모달화
- OG 링크 프리뷰: /invite·/chinba/event·/chinba/team/join 타임라인 카드 분리 (루트 OG 이미지는 바이트 동일 — 기존 프리뷰 영향 없음)
- 앱 심사 대비 기능 숨김(코드 상수): 랭킹 탭·미제출자 알림·해시태그 — **웹 사용자에게도 적용됨** (승인됨)
- 사이드바 접힘 CSS 범위 축소 수정

## 검증
- 로컬 빌드 통과(42페이지 정적 생성, OG 4종 빌드타임 PNG), 유닛 테스트 353개 통과
- 백엔드 신규 API(join-team·team_id·불가능 시간) 의존은 전부 우아한 실패 확인 — 백엔드는 prod 반영 완료(a132caa)라 의존성 충족
- 네이티브 재출시 불필요 — 웹 배포만으로 전부 반영 (심사용 숨김을 앱에 실으려면 별도 네이티브 빌드 필요)

## 예정된 이벤트 (장애 아님)
- 이미 공유된 초대·일정 링크의 카톡 프리뷰는 캐시 만료까지 옛 카드로 남음
- 머지 전까지 비멤버가 팀 일정 링크를 열면 참여자 0명 화면 → 이 PR 반영으로 가입 안내 화면으로 바뀜

🤖 Generated with [Claude Code](https://claude.com/claude-code)