### PR TITLE
Feat/chinba guide

### DIFF
--- a/app/(main)/chinba/guide/_components/GuideBlocks.tsx
+++ b/app/(main)/chinba/guide/_components/GuideBlocks.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+
+/** 설명서 공통 타이포그래피 블록 — 챕터/스텝/문단/팁의 위계와 간격을 한 곳에서 관리한다. */
+
+export function ChapterHeader({
+  no,
+  title,
+  subtitle,
+  id,
+}: {
+  no: number;
+  title: string;
+  subtitle: string;
+  id: string;
+}) {
+  return (
+    <div id={id} className="mt-16 scroll-mt-6 border-t border-gray-100 pt-10">
+      <p className="text-xs font-bold tracking-widest text-emerald-600">CHAPTER {no}</p>
+      <h2 className="mt-1.5 text-2xl font-bold text-gray-900">{title}</h2>
+      <p className="mt-1.5 text-sm text-gray-400">{subtitle}</p>
+    </div>
+  );
+}
+
+export function StepHeading({ no, title }: { no?: number; title: string }) {
+  return (
+    <div className="mt-12 flex items-center gap-2.5">
+      {no !== undefined && (
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-900 text-sm font-bold text-white">
+          {no}
+        </span>
+      )}
+      <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+    </div>
+  );
+}
+
+export function GuideP({ children }: { children: ReactNode }) {
+  return <p className="mt-4 text-[15px] leading-7 text-gray-700">{children}</p>;
+}
+
+export function GuideTip({ label = '💡 팁', children }: { label?: string; children: ReactNode }) {
+  return (
+    <div className="mt-5 border-l-2 border-blue-300 bg-blue-50 px-4 py-3">
+      <p className="text-xs font-bold text-blue-700">{label}</p>
+      <div className="mt-1.5 text-sm leading-relaxed text-blue-900">{children}</div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/_components/GuideExecFlow.tsx
+++ b/app/(main)/chinba/guide/_components/GuideExecFlow.tsx
@@ -1,0 +1,331 @@
+import { FiCheck, FiClock, FiPlus, FiTrash2, FiXCircle } from 'react-icons/fi';
+
+import { ChapterHeader, GuideTip, StepHeading } from './GuideBlocks';
+import MockFrame from './MockFrame';
+
+/**
+ * 1장 — 동아리 임원진 플로우 (홍길동 회장 시점)
+ * 동아리 만들기 → 조 편성 → 일정 잡기 → 시간 조율.
+ * 목업 마크업은 실제 화면(TeamCreateView, GroupInlineEditor, GroupTextInput,
+ * DateSelector, ChinbaHeatmapGrid, TeamScheduleTab)의 클래스를 복제한 것이다.
+ */
+export default function GuideExecFlow() {
+  return (
+    <section>
+      <ChapterHeader
+        no={1}
+        id="exec-flow"
+        title="임원진 플로우"
+        subtitle="동아리 개설부터 일정 확정까지, 회장 홍길동을 따라갑니다"
+      />
+
+      <StepHeading no={1} title="동아리 만들기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        코딩 동아리 회장 홍길동은 타임라인 홈에서 &ldquo;타임라인 동아리 선택&rdquo; 카드
+        오른쪽 위의 <strong>[+ 만들기]</strong> 버튼을 누릅니다. 동아리 이름을 입력하고
+        카테고리를 하나 고르면 끝입니다. 카테고리는 선택 사항이라 건너뛰어도 됩니다.{' '}
+        <strong>[만들기]</strong>를 누르는 순간 동아리가 생성되고, 초대 코드도 자동으로
+        발급됩니다.
+      </p>
+
+      <MockFrame title="동아리 만들기" caption="동아리 이름과 카테고리만 정하면 개설 완료">
+        <div className="mb-6">
+          <label className="mb-2 block text-sm font-bold text-gray-700">동아리 이름</label>
+          <div className="relative">
+            <div className="w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-800">
+              전북대 코딩 동아리
+            </div>
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300">
+              <FiXCircle size={18} />
+            </span>
+          </div>
+          <p className="mt-1 text-right text-[11px] text-gray-400">10/50</p>
+        </div>
+        <div className="mb-6">
+          <label className="mb-2 block text-sm font-bold text-gray-700">
+            카테고리
+            <span className="ml-1 text-xs font-normal text-gray-400">(선택)</span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            <span className="rounded-full border border-gray-900 bg-gray-900 px-4 py-2 text-sm font-medium text-white">
+              동아리
+            </span>
+            {['학과', '스터디', '연구실', '학회', '기타'].map((label) => (
+              <span
+                key={label}
+                className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-600"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="border-t border-gray-100 px-0 pt-3">
+          <div className="w-full rounded-xl bg-gray-900 py-3 text-center text-base font-semibold text-white">
+            만들기
+          </div>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        동아리를 갓 만들면 일정 탭 맨 위에 <strong>셋업 가이드 카드</strong>가 떠서 다음
+        순서를 안내합니다. 초대링크로 회원을 초대하고, 조를 편성하라는 두 단계입니다.
+        멤버와 조가 채워지면 카드는 자연스럽게 사라집니다.
+      </GuideTip>
+
+      <StepHeading no={2} title="그룹 만들고 조 편성하기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        동아리가 만들어지면 운영 패널이나 설정 페이지에서 <strong>[조 / 그룹 관리]</strong>로
+        들어가 <strong>그룹세트</strong>부터 하나 만듭니다. 그룹세트는 조 편성의 묶음
+        단위입니다. 예를 들어 &ldquo;스터디&rdquo; 그룹세트와 &ldquo;MT&rdquo; 그룹세트를
+        따로 만들면, 같은 멤버를 목적에 따라 다른 조로 나눠 둘 수 있습니다.
+      </p>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        그룹세트 이름을 정하면 편성 방식을 고릅니다.
+      </p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>
+          <strong>직접 선택하기</strong> : 멤버를 눌러 조에 배정합니다.
+        </li>
+        <li>
+          <strong>텍스트 붙여넣기 (AI)</strong> : 엑셀·카톡 명단을 붙여넣어 자동 분석합니다.
+        </li>
+      </ol>
+
+      <p className="mt-6 text-[15px] leading-7 text-gray-700">
+        <strong>직접 선택하기</strong>를 고르면 아래 편성 화면이 열립니다. <strong>[+ 새 조
+        추가]</strong>로 조를 만들고, 조 카드의 <strong>[+ 멤버 추가]</strong>를 눌러 멤버를
+        골라 담습니다. 멤버는 알약(칩)으로 표시되며 <strong>조장은 검은 칩에 ★</strong>가
+        붙습니다. 칩을 누르면 하단에 <strong>[조장 지정] [이동] [미배정으로]</strong> 버튼이
+        떠서 그 자리에서 조를 옮기거나 조장을 바꿀 수 있습니다. 아직 조에 못 들어간 사람은
+        아래 점선 카드 &ldquo;미배정 멤버&rdquo;에 모여 있습니다. 모든 조에 멤버와 조장이
+        채워지면 <strong>[저장하기]</strong>가 활성화됩니다.
+      </p>
+
+      <MockFrame title="조 편성" caption="검은 칩(★)이 조장, 점선 카드는 아직 배정되지 않은 멤버">
+        <div className="space-y-3">
+          <div className="rounded-xl border border-gray-200 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm font-bold text-gray-800">1조</span>
+              <span className="p-1 text-gray-300">
+                <FiTrash2 size={14} />
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              <span className="inline-flex items-center rounded-full bg-gray-900 px-2.5 py-1 text-xs font-medium text-white">
+                홍길동 ★
+              </span>
+              <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700">
+                김철수
+              </span>
+              <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700">
+                이영희
+              </span>
+            </div>
+            <p className="mt-2 text-xs font-medium text-gray-400">
+              <FiPlus className="mr-0.5 inline" size={12} />
+              멤버 추가
+            </p>
+          </div>
+          <div className="rounded-xl border border-dashed border-gray-300 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium text-gray-500">미배정 멤버</span>
+              <span className="text-[11px] text-gray-400">눌러서 조에 배정</span>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              <span className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500">최수진</span>
+              <span className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500">정민호</span>
+            </div>
+          </div>
+        </div>
+      </MockFrame>
+
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        이미 엑셀이나 카톡 공지에 조 명단이 있다면 <strong>텍스트 붙여넣기 (AI)</strong>가
+        빠릅니다. 명단을 통째로 붙여넣고 <strong>[AI로 분석하기]</strong>를 누르면 조와
+        조장을 자동으로 인식해 편성 화면에 채워 줍니다. 결과를 확인하고 어긋난 부분만
+        고치면 됩니다.
+      </p>
+
+      <MockFrame title="조 편성" caption="텍스트 붙여넣기: 카톡 명단을 그대로 붙여넣으면 된다">
+        <label className="mb-2 block text-sm font-bold text-gray-700">조 편성 텍스트 입력</label>
+        <p className="mb-3 text-xs text-gray-400">엑셀, 카톡, 메모장 등 어떤 형식이든 OK</p>
+        <div className="h-28 w-full whitespace-pre-line rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-800">
+          {'1조: 홍길동(조장), 김철수, 이영희\n2조: 박지민(조장), 최수진, 정민호'}
+        </div>
+        <div className="mt-3 flex gap-2 border-t border-gray-100 pt-3">
+          <div className="flex-1 rounded-lg border border-gray-200 px-6 py-3 text-center text-base font-semibold text-gray-700">
+            돌아가기
+          </div>
+          <div className="flex-1 rounded-lg bg-gray-900 px-6 py-3 text-center text-base font-semibold text-white">
+            AI로 분석하기
+          </div>
+        </div>
+      </MockFrame>
+
+      <StepHeading no={3} title="조별로 일정 잡기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        동아리 화면의 일정 탭에서 <strong>[+ 일정 잡기]</strong>를 누릅니다(임원진 전용).
+        대상 조를 고르고 모임 이름을 적은 뒤, 달력에서 <strong>후보 날짜를 클릭하거나
+        드래그</strong>해 여러 날을 한 번에 선택합니다. 아직 &ldquo;몇 시&rdquo;는 정하지
+        않습니다. 시간은 멤버들이 되는 시간을 제출한 뒤 자연스럽게 정해집니다.
+      </p>
+
+      <MockFrame title="일정 잡기" caption="후보 날짜 선택: 검은 칸이 선택된 날, 드래그로 여러 날을 한 번에">
+        <div className="mx-auto w-full max-w-[26rem]">
+          <div className="mb-3 flex items-center justify-between">
+            <span className="p-1.5 text-gray-300">&#8249;</span>
+            <span className="text-sm font-bold text-gray-800">2026년 8월</span>
+            <span className="p-1.5 text-gray-500">&#8250;</span>
+          </div>
+          <div className="mb-1 grid grid-cols-7">
+            {['일', '월', '화', '수', '목', '금', '토'].map((d) => (
+              <div key={d} className="flex h-8 items-center justify-center text-[11px] font-medium text-gray-400">
+                {d}
+              </div>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-0.5">
+            {[16, 17, 18].map((d) => (
+              <div key={d} className="flex aspect-square items-center justify-center rounded-lg text-sm font-medium text-gray-200">
+                {d}
+              </div>
+            ))}
+            <div className="flex aspect-square items-center justify-center rounded-lg bg-blue-50 text-sm font-medium text-blue-700">
+              19
+            </div>
+            <div className="flex aspect-square items-center justify-center rounded-lg bg-gray-900 text-sm font-medium text-white">
+              20
+            </div>
+            <div className="flex aspect-square items-center justify-center rounded-lg bg-gray-900 text-sm font-medium text-white">
+              21
+            </div>
+            <div className="flex aspect-square items-center justify-center rounded-lg text-sm font-medium text-gray-700">
+              22
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+              8/20(목) <span className="ml-0.5 text-gray-400">&times;</span>
+            </span>
+            <span className="inline-flex items-center gap-0.5 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600">
+              8/21(금) <span className="ml-0.5 text-gray-400">&times;</span>
+            </span>
+          </div>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        조를 여러 개 선택하면 <strong>합동 일정</strong>이 됩니다. 아무 조도 선택하지 않으면
+        전체 동아리 대상 일정이 됩니다. 정기총회처럼 모두가 모여야 할 때 쓰세요.
+      </GuideTip>
+
+      <StepHeading no={4} title="모두의 시간이 모이면" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        일정이 만들어지면 조원들이 각자 안 되는 시간을 제출합니다(방법은 2장에서). 제출이
+        쌓이면 <strong>전체 일정</strong> 탭에 30분 단위 히트맵이 그려집니다. 읽는 법은
+        간단합니다.
+      </p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>
+          <strong>칸의 색</strong> : 진한 초록일수록 되는 사람이 많고, 빨간색은 전원
+          불가입니다.
+        </li>
+        <li>
+          <strong>칸의 숫자</strong> : 그 시간에 가능한 인원 수입니다.
+        </li>
+        <li>
+          <strong>칸을 누르면</strong> : 누가 안 되는지 이름까지 보여줍니다.
+        </li>
+      </ol>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        위쪽 참여자 알약에서 초록 체크가 붙은 사람은 제출을 마친 사람입니다. 알약을 누르면
+        그 사람의 불가능 시간만 히트맵 위에 강조됩니다. 아래 <strong>추천 시간</strong>에는
+        가장 많은 인원이 가능한 상위 후보가 자동으로 정리되므로, 회장은 여기서 골라
+        공지하면 됩니다.
+      </p>
+
+      <MockFrame title="조별과제 회의" caption="전체 일정 탭: 히트맵 색이 진할수록 가능 인원이 많다">
+        <div className="mb-3 flex flex-wrap items-center gap-1.5">
+          <span className="text-xs font-bold text-gray-500">참여자 (3/4 제출)</span>
+          {['홍길동', '김철수', '이영희'].map((name) => (
+            <span
+              key={name}
+              className="flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-1 text-xs text-emerald-700"
+            >
+              <FiCheck size={10} />
+              {name}
+            </span>
+          ))}
+          <span className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-400">
+            박지민
+          </span>
+        </div>
+        <div>
+          <div className="flex">
+            <div className="w-7 shrink-0" />
+            {['목 8/20', '금 8/21'].map((label) => (
+              <div key={label} className="flex flex-1 flex-col items-center justify-center py-1">
+                <span className="text-[10px] text-gray-400">{label.split(' ')[0]}</span>
+                <span className="text-xs font-medium text-gray-700">{label.split(' ')[1]}</span>
+              </div>
+            ))}
+          </div>
+          {[
+            ['18시', 'bg-[#21a278]', '4', 'bg-[#62c784]', '3'],
+            ['', 'bg-[#21a278]', '4', 'bg-[#a3ec8f]', '2'],
+            ['19시', 'bg-[#41b47e]', '3', 'bg-[#c4fe95]', '1'],
+            ['', 'bg-[#62c784]', '3', 'bg-red-500', ''],
+          ].map(([label, c1, n1, c2, n2], i) => (
+            <div key={i} className="flex">
+              <div className="flex w-7 shrink-0 items-center justify-start">
+                {label && <span className="-mt-2 text-[10px] text-gray-400">{label}</span>}
+              </div>
+              <div className={`flex h-[22px] flex-1 items-center justify-center border-r border-t border-gray-100 ${c1}`}>
+                {n1 && <span className="text-[9px] font-bold text-gray-800">{n1}</span>}
+              </div>
+              <div className={`flex h-[22px] flex-1 items-center justify-center border-t border-gray-100 ${c2}`}>
+                {n2 && <span className="text-[9px] font-bold text-gray-800">{n2}</span>}
+              </div>
+            </div>
+          ))}
+          <div className="mt-3 flex items-center justify-center gap-2 px-2">
+            <span className="text-[10px] text-gray-400">가능</span>
+            <div className="h-3 w-4 rounded-sm bg-[#21a278]" />
+            <div className="h-3 w-4 rounded-sm bg-[#41b47e]" />
+            <div className="h-3 w-4 rounded-sm bg-[#62c784]" />
+            <div className="h-3 w-4 rounded-sm bg-[#a3ec8f]" />
+            <div className="h-3 w-4 rounded-sm bg-[#c4fe95]" />
+            <div className="h-3 w-4 rounded-sm bg-red-500" />
+            <span className="text-[10px] text-gray-400">불가</span>
+          </div>
+        </div>
+        <div className="mt-4">
+          <h4 className="mb-2 text-xs font-bold text-gray-500">추천 시간</h4>
+          <div className="space-y-2">
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3">
+              <div className="flex items-center gap-1.5">
+                <FiClock size={14} className="text-emerald-600" />
+                <span className="text-sm font-bold text-emerald-700">8/20(목) 18:00~19:00</span>
+              </div>
+              <p className="mt-1 text-xs text-emerald-600">4명 전원 가능</p>
+            </div>
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-3">
+              <div className="flex items-center gap-1.5">
+                <FiClock size={14} className="text-amber-600" />
+                <span className="text-sm font-bold text-amber-700">8/21(금) 18:00~18:30</span>
+              </div>
+              <p className="mt-1 text-xs text-amber-600">3/4명 가능</p>
+            </div>
+          </div>
+        </div>
+      </MockFrame>
+
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        모임을 마쳤다면 일정 화면 오른쪽 위의 <strong>완료 처리</strong>(초록 체크 아이콘)를
+        누릅니다. 동아리 일정이라면 곧바로 기록 화면으로 이어집니다. 완료 처리와 기록이
+        어떻게 이어지는지는 5장에서 자세히 다룹니다.
+      </p>
+    </section>
+  );
+}

--- a/app/(main)/chinba/guide/_components/GuideExtras.tsx
+++ b/app/(main)/chinba/guide/_components/GuideExtras.tsx
@@ -1,0 +1,100 @@
+import { ChapterHeader } from './GuideBlocks';
+
+/**
+ * 6장 — 알아두면 좋은 기능 (MY 탭, 동아리 전환, 일정 상태, 동아리 설정)
+ * 7장 — 자주 묻는 질문
+ * 근거 화면: MyTabContent, ClubSwitcher, ChinbaEventDetailBody(상태·생성자 권한),
+ * TeamSettingsView, 백엔드 import-timetable(시간표 슬롯만 교체·수동 입력 보존).
+ */
+
+const EXTRA_FEATURES: { title: string; body: string }[] = [
+  {
+    title: 'MY 탭, 내 것만 모아 보기',
+    body: '하단의 MY 탭은 나를 기준으로 정리된 화면입니다. 아직 시간을 제출하지 않은 일정이 "내 할일"에 모이고, 내가 속한 동아리 목록과 앞으로 7일 안의 다가오는 일정이 이어집니다. 내 시간표 관리도 이 탭의 [내 시간표] 버튼에서 합니다.',
+  },
+  {
+    title: '동아리 여러 개 오가기',
+    body: '동아리에 2개 이상 속해 있으면 동아리 화면 상단의 동아리 이름 옆에 ▼가 생깁니다. 눌러서 드롭다운으로 바로 전환할 수 있고, 마지막에 보던 동아리를 기억해 다음에 열 때 그 동아리부터 보여줍니다.',
+  },
+  {
+    title: '일정의 세 가지 상태',
+    body: '일정은 진행중(파랑) → 완료됨(초록) 또는 지난 일정(회색)으로 흘러갑니다. 후보 날짜가 다 지나면 자동으로 "지난 일정"이 되는데, 그때도 완료 처리하고 활동을 기록할 수 있습니다. 일정의 완료 처리와 삭제는 그 일정을 만든 사람만 할 수 있습니다.',
+  },
+  {
+    title: '사이드바에서 바로 가기',
+    body: '왼쪽 사이드바의 타임라인 메뉴를 펼치면 내가 참여 중인 일정 목록이 바로 나옵니다. 어느 화면에 있든 두 번의 클릭으로 일정 제출 화면까지 갈 수 있습니다.',
+  },
+  {
+    title: '동아리 설정 페이지',
+    body: '동아리 화면 오른쪽 위 톱니바퀴가 동아리 설정입니다. 동아리 이름·카테고리 수정, 초대 링크, 멤버 관리, 그룹/조 관리가 한 페이지에 모여 있고, 맨 아래에 회장 위임과 동아리 삭제(회장·부회장만)가 있습니다.',
+  },
+];
+
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: '제출한 시간을 바꾸고 싶어요.',
+    a: '일정의 "내 일정" 탭에서 다시 칠하고 [저장하기]를 누르면 이전 제출을 덮어씁니다. 몇 번이든 수정할 수 있습니다.',
+  },
+  {
+    q: '시간표를 바꿨는데 일정에 반영이 안 돼요.',
+    a: '일정마다 [내 시간표 불러오기]를 다시 누르면 됩니다. 시간표에서 온 시간만 새로 갈아끼우고, 직접 칠한 시간은 그대로 보존됩니다.',
+  },
+  {
+    q: '조 편성을 바꾸고 싶어요.',
+    a: '조 / 그룹 관리에서 그룹세트의 [수정]으로 조원을 옮기거나, [재편성]으로 처음부터 다시 짤 수 있습니다. 스터디용·MT용처럼 용도가 다르면 그룹세트를 하나 더 만드는 쪽이 깔끔합니다.',
+  },
+  {
+    q: '일정 조율은 몇 시부터 몇 시까지인가요?',
+    a: '기본 오전 8시부터 자정까지, 30분 단위입니다.',
+  },
+  {
+    q: '동아리 없이도 쓸 수 있나요?',
+    a: '네. 타임라인 홈의 "동아리 없이 잡은 일정"에서 일정을 만들고 링크만 공유하면 됩니다. 조·멤버 관리 없이 시간 조율 기능만 가볍게 쓰는 방식입니다.',
+  },
+  {
+    q: '초대 코드가 밖으로 새어 나갔어요.',
+    a: '동아리 설정의 [초대 코드 재생성]을 누르세요(회장·부회장만). 기존 링크는 즉시 무효가 됩니다.',
+  },
+];
+
+export default function GuideExtras() {
+  return (
+    <>
+      <section>
+        <ChapterHeader
+          no={6}
+          id="extras"
+          title="알아두면 좋은 기능"
+          subtitle="플로우 밖에 있지만 쓰다 보면 찾게 되는 것들"
+        />
+
+        <div className="mt-8 space-y-4">
+          {EXTRA_FEATURES.map(({ title, body }) => (
+            <div key={title} className="rounded-xl border border-gray-100 bg-white p-5">
+              <h3 className="text-base font-bold text-gray-900">{title}</h3>
+              <p className="mt-2 text-sm leading-7 text-gray-700">{body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <ChapterHeader
+          no={7}
+          id="faq"
+          title="자주 묻는 질문"
+          subtitle="짧게 묻고 짧게 답하기"
+        />
+
+        <div className="mt-8 space-y-4">
+          {FAQ.map(({ q, a }) => (
+            <div key={q} className="rounded-xl border border-gray-100 bg-gray-50 p-5">
+              <p className="text-[15px] font-bold text-gray-900">Q. {q}</p>
+              <p className="mt-2 text-sm leading-7 text-gray-700">{a}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/(main)/chinba/guide/_components/GuideInvites.tsx
+++ b/app/(main)/chinba/guide/_components/GuideInvites.tsx
@@ -1,0 +1,96 @@
+import { FiCopy, FiLink, FiRefreshCw, FiShare2, FiUsers } from 'react-icons/fi';
+
+import { ChapterHeader, GuideTip, StepHeading } from './GuideBlocks';
+import MockFrame from './MockFrame';
+
+/**
+ * 4장 — 링크와 초대
+ * 동아리 초대링크(InviteSection)와 일정 전용 공유 링크(TeamJoinGate) 목업.
+ */
+export default function GuideInvites() {
+  return (
+    <section>
+      <ChapterHeader
+        no={4}
+        id="invites"
+        title="링크와 초대"
+        subtitle="사람을 모으는 두 가지 방법, 동아리 초대링크와 일정 링크"
+      />
+
+      <StepHeading title="동아리 초대링크" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        동아리마다 고유한 초대 코드가 있습니다. 동아리 설정의 <strong>초대 링크</strong>{' '}
+        섹션(또는 운영 패널의 <strong>[초대링크 복사]</strong>)에서 링크를 복사해 단톡방에
+        붙이면, 받은 사람은 링크 한 번으로 가입이 끝납니다. 코드가 외부로 새어 나갔다면{' '}
+        <strong>[초대 코드 재생성]</strong>으로 기존 링크를 무효화할 수 있습니다(재생성은
+        회장·부회장만).
+      </p>
+
+      <MockFrame title="동아리 설정" caption="초대 링크 섹션: 복사·공유·재생성">
+        <div className="space-y-3">
+          <div className="rounded-xl border border-gray-100 bg-gray-50 px-4 py-3">
+            <p className="mb-1 text-[11px] text-gray-400">초대 코드</p>
+            <p className="break-all font-mono text-sm font-medium text-gray-700">a1b2c3d4e5</p>
+          </div>
+          <div className="flex gap-2">
+            <span className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-gray-200 bg-white py-2.5 text-sm font-medium text-gray-700">
+              <FiCopy size={14} />
+              링크 복사
+            </span>
+            <span className="flex flex-1 items-center justify-center gap-1.5 rounded-xl bg-gray-900 py-2.5 text-sm font-medium text-white">
+              <FiShare2 size={14} />
+              공유하기
+            </span>
+          </div>
+          <span className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-gray-100 py-2.5 text-xs text-gray-400">
+            <FiRefreshCw size={12} />
+            초대 코드 재생성
+          </span>
+        </div>
+      </MockFrame>
+
+      <StepHeading title="일정 전용 공유 링크" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        모든 일정에는 그 일정만의 링크도 있습니다. 일정 화면 오른쪽 위의{' '}
+        <FiLink className="inline text-gray-500" size={14} /> <strong>링크 복사</strong> /{' '}
+        <FiShare2 className="inline text-gray-500" size={14} /> <strong>공유</strong> 버튼으로
+        만들며, &ldquo;이번 회의 시간 제출해 주세요&rdquo;라고 일정 하나만 콕 집어 보낼 때
+        씁니다. 아직 동아리에 가입하지 않은 사람이 이 링크를 열면 아래처럼 가입 안내
+        화면이 먼저 나오는데, <strong>[가입하고 참여하기]</strong> 한 번이면 초대 코드 없이도
+        그 동아리에 가입되면서 바로 일정에 참여합니다. 초대링크와 일정 링크 중 아무거나
+        받아도 결국 합류할 수 있는 셈입니다.
+      </p>
+
+      <MockFrame title="조별과제 회의" caption="동아리 밖 사람이 일정 링크를 열었을 때: 가입과 참여가 한 번에">
+        <div className="flex flex-col items-center px-2 py-4 text-center">
+          <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-gray-50">
+            <FiUsers size={28} className="text-gray-400" />
+          </div>
+          <p className="text-lg font-bold text-gray-800">조별과제 회의</p>
+          <p className="mt-1 text-sm text-gray-500">8/20(목) ~ 8/21(금)</p>
+          <p className="mt-6 text-sm text-gray-700">
+            이 일정은 <span className="font-bold text-gray-900">&lsquo;전북대 코딩 동아리&rsquo;</span>의
+            일정입니다
+          </p>
+          <p className="mt-1 text-sm text-gray-500">참여하려면 동아리에 가입해야 해요</p>
+          <div className="mt-8 flex w-full max-w-xs flex-col gap-2">
+            <span className="w-full rounded-xl bg-gray-900 py-3 text-center text-base font-semibold text-white">
+              가입하고 참여하기
+            </span>
+            <span className="w-full rounded-xl bg-gray-100 py-3 text-center text-base font-semibold text-gray-700">
+              돌아가기
+            </span>
+          </div>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        어떤 링크를 보낼지 헷갈린다면 이렇게 기억하세요. 사람을 <strong>모을 때는
+        초대링크</strong>, 특정
+        일정의 <strong>시간 제출을 받을 때는 일정 링크</strong>. 일정 링크로도 가입까지
+        되므로, 신입에게 &ldquo;이번 회의부터 참여해&rdquo;라며 일정 링크 하나만 보내도
+        됩니다.
+      </GuideTip>
+    </section>
+  );
+}

--- a/app/(main)/chinba/guide/_components/GuideMemberFlow.tsx
+++ b/app/(main)/chinba/guide/_components/GuideMemberFlow.tsx
@@ -1,0 +1,228 @@
+import { Fragment } from 'react';
+
+import { FiRotateCcw, FiUpload } from 'react-icons/fi';
+
+import { ChapterHeader, GuideTip, StepHeading } from './GuideBlocks';
+import MockFrame from './MockFrame';
+
+/**
+ * 2장 — 일반 사용자 플로우 (김철수 신입 부원 시점)
+ * 초대링크로 가입 → 시간표 등록 → 안 되는 시간 제출.
+ * 목업은 InviteClient, TimetableTab, MyScheduleTab+ChinbaScheduleGrid 복제.
+ */
+export default function GuideMemberFlow() {
+  return (
+    <section>
+      <ChapterHeader
+        no={2}
+        id="member-flow"
+        title="일반 사용자 플로우"
+        subtitle="가입하고 내 시간 제출하기, 신입 부원 김철수를 따라갑니다"
+      />
+
+      <StepHeading no={1} title="초대링크로 가입하기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        신입 부원 김철수는 단톡방에서 초대링크(<code className="rounded bg-gray-100 px-1 py-0.5 text-xs">
+        zerotime.kr/invite?code=...</code>)를 받습니다. 링크를 열면 로그인 후 자동으로
+        가입이 진행되고, &ldquo;참여 완료&rdquo; 화면에서 <strong>[팀으로 이동]</strong>을
+        누르면 바로 동아리 화면입니다. 링크 대신 초대 코드만 받았다면 타임라인 홈의{' '}
+        <strong>[초대코드]</strong> 버튼을 눌러 코드를 직접 입력해도 됩니다.
+      </p>
+
+      <MockFrame caption="초대링크를 열면 자동으로 가입이 진행된다">
+        <div className="mx-auto flex w-full max-w-sm flex-col items-center gap-4 py-4 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-50">
+            <span className="text-3xl">🎉</span>
+          </div>
+          <div>
+            <p className="text-lg font-bold text-gray-800">팀 참여 완료!</p>
+            <p className="mt-1 text-sm text-gray-500">환영합니다</p>
+          </div>
+          <div className="w-full rounded-xl bg-gray-900 py-3 text-center text-sm font-medium text-white">
+            팀으로 이동
+          </div>
+        </div>
+      </MockFrame>
+
+      <StepHeading no={2} title="내 시간표 등록하기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        타임라인 하단의 <strong>MY</strong> 탭 오른쪽 위 <strong>[내 시간표]</strong> 버튼을
+        누르면 시간표 화면이 열립니다. 시간표를 채우는 방법은 두 가지입니다.
+      </p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>
+          <strong>에브리타임 시간표 업로드</strong> : 에브리타임 시간표를 캡처한 이미지를
+          올리면 AI가 분석해 수업을 자동으로 채워 줍니다. 인식이 애매한 수업에는
+          &ldquo;확인필요&rdquo; 표시가 붙어 직접 고칠 수 있습니다.
+        </li>
+        <li>
+          <strong>직접 추가</strong> : 알바나 과외처럼 시간표에 없는 고정 일정은 빈 칸을
+          드래그해서 넣습니다.
+        </li>
+      </ol>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        시간표는 한 번만 등록해 두면 앞으로 모든 일정 조율에 재사용됩니다.
+      </p>
+
+      <MockFrame title="내 시간표" caption="에브리타임 캡처를 올리면 AI가 자동으로 채워 준다">
+        <div className="flex items-center justify-between pb-2">
+          <span className="rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs font-medium text-gray-700">
+            2학기 ▾
+          </span>
+          <span className="flex items-center gap-1 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-600">
+            <FiUpload size={12} />
+            에브리타임 시간표 업로드
+          </span>
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-2">
+          <div className="grid grid-cols-6 gap-px text-center">
+            <div />
+            {['월', '화', '수', '목', '금'].map((d) => (
+              <div key={d} className="py-1 text-[10px] font-medium text-gray-400">
+                {d}
+              </div>
+            ))}
+            {['9시', '10시', '11시'].map((hour, row) => (
+              <Fragment key={hour}>
+                <div className="py-2 pr-1 text-right text-[10px] text-gray-400">
+                  {hour}
+                </div>
+                {[0, 1, 2, 3, 4].map((col) => {
+                  const isClass = (row === 0 && col === 1) || (row === 1 && (col === 1 || col === 3));
+                  const isOrange = row === 2 && col === 0;
+                  return (
+                    <div
+                      key={`${hour}-${col}`}
+                      className={`h-8 rounded-sm border border-gray-100 ${
+                        isClass
+                          ? 'bg-blue-100'
+                          : isOrange
+                            ? 'border-orange-300 bg-orange-50'
+                            : 'bg-white'
+                      }`}
+                    >
+                      {row === 0 && col === 1 && (
+                        <span className="text-[8px] font-medium text-blue-700">자료구조</span>
+                      )}
+                      {isOrange && (
+                        <span className="text-[8px] font-medium text-orange-600">확인필요</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </Fragment>
+            ))}
+          </div>
+          <p className="mt-2 text-center text-[10px] text-gray-300">
+            드래그하여 내 고정 일정 추가/수정
+          </p>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        시간표는 <strong>학기별</strong>로 관리됩니다(1학기·여름학기·2학기·겨울학기).
+        학기가 바뀌면 왼쪽 위 학기 선택에서 새 학기를 고르고 다시 업로드하세요. 등록된
+        수업을 누르면 상세 확인·수정·삭제도 됩니다.
+      </GuideTip>
+
+      <StepHeading no={3} title="안 되는 시간 제출하기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        임원진이 일정을 만들면 사이드바의 타임라인 목록과 MY 탭의 &ldquo;내 할일&rdquo;에
+        새 일정이 나타납니다. 제출은 네 단계면 끝납니다.
+      </p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>
+          일정을 열어 <strong>내 일정</strong> 탭으로 갑니다.
+        </li>
+        <li>
+          30분 단위 그리드에서 <strong>안 되는 시간을 빨갛게 칠합니다</strong>. 되는 시간을
+          고르는 게 아니라, 안 되는 시간만 표시하면 나머지는 전부 가능으로 칩니다.
+        </li>
+        <li>
+          <strong>[내 시간표 불러오기]</strong>를 누르면 등록해 둔 시간표의 수업 시간이
+          자동으로 불가능 처리됩니다. 손으로 칠할 필요가 없습니다.
+        </li>
+        <li>
+          <strong>[저장하기]</strong>를 눌러 제출합니다.
+        </li>
+      </ol>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        드래그가 불편하면 오른쪽 위 탭에서 <strong>직접 입력</strong> 모드로 바꿔 시간
+        구간을 목록으로 추가할 수도 있습니다.
+      </p>
+
+      <MockFrame title="조별과제 회의" caption="내 일정 탭: 빨간 칸이 내가 안 되는 시간">
+        <div className="mb-3 flex items-center justify-between gap-2 rounded-xl border border-emerald-200 bg-emerald-100 px-3 py-2.5">
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold leading-tight text-emerald-900">
+              불가능한 시간을 칠하세요
+            </p>
+            <p className="mt-0.5 text-[10px] text-emerald-700">빨간색이 불가능한 시간입니다</p>
+          </div>
+          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[10px] font-medium text-gray-600">
+            드래그 | 직접 입력
+          </span>
+        </div>
+        <div className="mb-3 flex items-stretch gap-2">
+          <span className="flex flex-1 items-center justify-center gap-1.5 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-[11px] font-medium text-gray-600">
+            <FiUpload size={12} />
+            내 시간표 불러오기
+          </span>
+          <span className="flex shrink-0 items-center justify-center gap-1.5 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-[11px] font-medium text-red-500">
+            <FiRotateCcw size={12} />
+            초기화
+          </span>
+        </div>
+        <div className="rounded-xl border border-gray-200 p-2">
+          <div className="flex">
+            <div className="w-7 shrink-0" />
+            {['목 8/20', '금 8/21'].map((label) => (
+              <div key={label} className="flex flex-1 flex-col items-center justify-center py-1">
+                <span className="text-[10px] text-gray-400">{label.split(' ')[0]}</span>
+                <span className="text-xs font-medium text-gray-700">{label.split(' ')[1]}</span>
+              </div>
+            ))}
+          </div>
+          {[
+            ['17시', false, true],
+            ['', false, true],
+            ['18시', false, false],
+            ['', true, false],
+          ].map(([label, red1, red2], i) => (
+            <div key={i} className="flex">
+              <div className="flex w-7 shrink-0 items-center justify-start">
+                {label && <span className="-mt-2 text-[10px] text-gray-400">{label as string}</span>}
+              </div>
+              <div className={`h-[22px] flex-1 border-r border-t border-gray-100 ${red1 ? 'bg-red-400' : 'bg-white'}`} />
+              <div className={`h-[22px] flex-1 border-t border-gray-100 ${red2 ? 'bg-red-400' : 'bg-white'}`} />
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 border-t border-gray-100 pt-3">
+          <div className="w-full rounded-xl bg-gray-900 py-3 text-center text-base font-semibold text-white">
+            저장하기
+          </div>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        그리드를 빠르게 칠하는 법. <strong>날짜 머리글을 누르면 그 날 하루 전체</strong>가,{' '}
+        <strong>왼쪽 &ldquo;N시&rdquo; 라벨을 누르면 모든 날짜의 그 시간대</strong>가 한 번에
+        토글됩니다. 하루 종일 안 되는 날은 머리글 한 번이면 끝. 칠하다가 나가도 입력 중이던
+        내용은 기기에 임시 저장되어 다시 열면 이어서 할 수 있습니다.
+      </GuideTip>
+
+      <p className="mt-6 text-[15px] leading-7 text-gray-700">
+        동아리 초대 없이 <strong>일정 링크만</strong> 받은 경우에도 문제없습니다. 일정
+        화면에서 가입까지 한 번에 해결됩니다(4장 참고). 김철수가 할 일은 시간표 한 번
+        등록해 두고, 일정이 올라올 때마다 확인하고 저장하는 것뿐입니다. 단톡방 투표는 더
+        이상 없습니다.
+      </p>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        동아리 없이도 쓸 수 있습니다. 타임라인 홈의 &ldquo;동아리 없이 잡은 일정&rdquo;
+        섹션에서 <strong>[+ 일정 잡기]</strong>로 일정을 만들고 링크만 공유하면, 과제 팀이나
+        친구 모임처럼 가벼운 약속도 같은 방식으로 조율됩니다.
+      </p>
+    </section>
+  );
+}

--- a/app/(main)/chinba/guide/_components/GuideOpsTools.tsx
+++ b/app/(main)/chinba/guide/_components/GuideOpsTools.tsx
@@ -1,0 +1,176 @@
+import {
+  FiCalendar,
+  FiChevronRight,
+  FiEdit3,
+  FiGrid,
+  FiLink,
+  FiSearch,
+  FiUser,
+  FiUsers,
+} from 'react-icons/fi';
+
+import { ChapterHeader, GuideTip, StepHeading } from './GuideBlocks';
+import MockFrame from './MockFrame';
+
+/**
+ * 3장 — 운영 도구 (이영희 부회장 시점)
+ * 운영 패널(TeamOpsPanel)과 멤버 관리(TeamMembersModal) 목업.
+ */
+export default function GuideOpsTools() {
+  return (
+    <section>
+      <ChapterHeader
+        no={3}
+        id="ops-tools"
+        title="운영 도구"
+        subtitle="운영 사이드바와 멤버 관리, 부회장 이영희의 하루"
+      />
+
+      <StepHeading title="운영 사이드바" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        부회장 이영희가 데스크톱(넓은 화면)으로 동아리에 들어가면 오른쪽에{' '}
+        <strong>운영 패널</strong>이 보입니다. 임원진(회장·부회장·운영진)에게만 보이는 전용
+        도구 모음으로, 위에서부터 세 구역입니다.
+      </p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>
+          <strong>운영 도구</strong> : 멤버 관리, 조/그룹 관리, 초대링크 복사가 모여
+          있습니다.
+        </li>
+        <li>
+          <strong>응답 현황</strong> : 일정마다 몇 명이 시간을 제출했는지 진행바로
+          보여줍니다.
+        </li>
+        <li>
+          <strong>바로가기</strong> : 일정 잡기와 활동 기록으로 가는 지름길입니다.
+        </li>
+      </ol>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        모바일이나 좁은 화면에서는 이 기능들이 오른쪽 위 <strong>설정(톱니바퀴)</strong>{' '}
+        페이지 안에 같은 구성으로 들어 있습니다.
+      </p>
+
+      <MockFrame title="운영" caption="운영 패널: 임원진에게만 보이는 오른쪽 사이드바">
+        <div className="flex flex-col gap-5">
+          <section className="flex flex-col">
+            <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">
+              운영 도구
+            </span>
+            {[
+              { icon: FiUsers, label: '멤버 관리', trailing: '⤢' },
+              { icon: FiGrid, label: '조 / 그룹 관리', trailing: '⤢' },
+              { icon: FiLink, label: '초대링크 복사', trailing: '⧉' },
+            ].map(({ icon: Icon, label, trailing }) => (
+              <div
+                key={label}
+                className="flex w-full items-center gap-2.5 px-3 py-2.5 text-sm font-medium text-gray-700"
+              >
+                <Icon size={16} className="shrink-0 text-gray-500" />
+                <span className="flex-1 text-left">{label}</span>
+                <span className="text-xs text-gray-300">{trailing}</span>
+              </div>
+            ))}
+          </section>
+          <section className="flex flex-col">
+            <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">
+              응답 현황
+            </span>
+            <div className="px-3 py-1">
+              <div className="flex items-center justify-between text-xs">
+                <span className="truncate font-medium text-gray-700">조별과제 회의</span>
+                <span className="shrink-0 text-gray-400">3/4</span>
+              </div>
+              <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                <div className="h-full w-3/4 rounded-full bg-emerald-400" />
+              </div>
+              <p className="mt-1.5 text-[11px] text-gray-400">
+                미제출: <span className="text-gray-500">박지민</span>
+              </p>
+            </div>
+          </section>
+          <section className="flex flex-col border-t border-gray-100 pt-4">
+            <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">
+              바로가기
+            </span>
+            {[
+              { icon: FiCalendar, label: '일정 잡기' },
+              { icon: FiEdit3, label: '활동 기록하기' },
+            ].map(({ icon: Icon, label }) => (
+              <div
+                key={label}
+                className="flex w-full items-center gap-2.5 px-3 py-2.5 text-sm font-medium text-gray-700"
+              >
+                <Icon size={16} className="shrink-0 text-gray-500" />
+                <span className="flex-1 text-left">{label}</span>
+                <span className="text-xs text-gray-300">
+                  <FiChevronRight size={12} className="inline" />
+                </span>
+              </div>
+            ))}
+          </section>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        응답 현황에서 일정을 누르면 <strong>미제출자 이름 목록과 [복사] 버튼</strong>이
+        나옵니다. 복사해서 단톡방에 붙이면 독촉 멘트가 완성됩니다.
+      </GuideTip>
+
+      <StepHeading title="멤버 관리" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        <strong>[멤버 관리]</strong>를 열면 멤버 목록이 뜹니다. 각 줄에 프로필·닉네임·소속
+        조가 보이고, 회장과 부회장은 역할 드롭다운으로 <strong>회원 / 운영진 / 부회장</strong>을
+        바로 바꿀 수 있습니다. 회장 자리는 별도의 <strong>회장 위임</strong> 메뉴로만 넘길 수
+        있고, 위임하면 본인은 운영진이 됩니다. <strong>[내보내기]</strong>는 확인을 한 번 더
+        거친 뒤 동아리에서 내보냅니다.
+      </p>
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">역할별 권한은 이렇게 나뉩니다.</p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>일정·기록·조 편성 : 임원진 전체(회장·부회장·운영진)</li>
+        <li>역할 변경 : 회장·부회장</li>
+        <li>동아리 삭제·회장 위임 : 회장·부회장(위임은 회장만)</li>
+      </ol>
+
+      <MockFrame title="멤버 관리 · 4명" caption="역할 드롭다운과 내보내기: 회장·부회장만 조작 가능">
+        <div className="relative mb-3">
+          <FiSearch size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-300" />
+          <div className="w-full rounded-xl border border-gray-200 py-2.5 pl-9 pr-3 text-sm text-gray-400">
+            이름 검색
+          </div>
+        </div>
+        <div className="space-y-1">
+          {[
+            { name: '홍길동', group: '친바 - 1조 (조장)', badge: '회장', badgeClass: 'bg-red-100 text-red-700' },
+            { name: '이영희', group: '친바 - 1조', badge: '부회장', badgeClass: 'bg-orange-100 text-orange-700' },
+            { name: '박지민', group: '친바 - 2조 (조장)', badge: null, badgeClass: '' },
+            { name: '김철수', group: '친바 - 1조', badge: null, badgeClass: '' },
+          ].map(({ name, group, badge, badgeClass }) => (
+            <div key={name} className="flex items-center gap-3 rounded-lg px-2 py-2">
+              <div className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-400">
+                <FiUser size={16} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-gray-800">{name}</p>
+                <p className="mt-0.5 truncate text-[11px] text-gray-400">{group}</p>
+              </div>
+              {badge ? (
+                <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${badgeClass}`}>
+                  {badge}
+                </span>
+              ) : (
+                <>
+                  <span className="rounded-lg border border-gray-200 px-2 py-1 text-xs font-medium text-gray-700">
+                    회원 ▾
+                  </span>
+                  <span className="shrink-0 rounded-lg px-2 py-1 text-xs font-medium text-red-400">
+                    내보내기
+                  </span>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      </MockFrame>
+    </section>
+  );
+}

--- a/app/(main)/chinba/guide/_components/GuideRecordsRanking.tsx
+++ b/app/(main)/chinba/guide/_components/GuideRecordsRanking.tsx
@@ -1,0 +1,219 @@
+import { FiCheckCircle, FiLink, FiShare2, FiTrash2 } from 'react-icons/fi';
+import { LuCalendar, LuClock, LuTrophy } from 'react-icons/lu';
+
+import { ChapterHeader, GuideTip, StepHeading } from './GuideBlocks';
+import MockFrame from './MockFrame';
+
+/**
+ * 5장 — 기록과 랭킹
+ * 완료 처리(ChinbaEventDetailBody 헤더)·활동 기록 폼·ActivityCard·조별 랭킹(RankingBar) 목업.
+ * 랭킹은 구현 완료·현재 비노출 상태(features.ts의 CHINBA_RANKING_TAB_VISIBLE=false).
+ */
+export default function GuideRecordsRanking() {
+  return (
+    <section>
+      <ChapterHeader
+        no={5}
+        id="records-ranking"
+        title="기록과 랭킹"
+        subtitle="모임이 끝난 뒤, 활동을 남기고 언젠가 순위를 겨루기"
+      />
+
+      <StepHeading title="일정 완료 처리하기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        기록은 일정을 <strong>완료 처리</strong>하는 데서 시작합니다. 순서는 세 단계입니다.
+      </p>
+      <ol className="mt-3 list-decimal space-y-1.5 pl-6 text-[15px] leading-7 text-gray-700">
+        <li>
+          일정 화면 오른쪽 위의 <strong>초록 체크 아이콘</strong>을 누릅니다. 일정을 만든
+          사람에게만 보입니다.
+        </li>
+        <li>
+          확인 팝업을 지나면 동아리의 <strong>기록 탭</strong>으로 이동하고, 기록 폼이
+          자동으로 열립니다.
+        </li>
+        <li>
+          <strong>[기록하기]</strong> 또는 <strong>[기록하지 않기]</strong>를 누르는 순간
+          일정 완료가 확정됩니다. 그냥 창을 닫으면 일정은 진행중 상태로 남습니다.
+        </li>
+      </ol>
+
+      <MockFrame caption="일정 화면 오른쪽 위 아이콘들. 초록 체크가 완료 처리 버튼">
+        <div className="border-b border-gray-100 pb-2">
+          <div className="flex items-center justify-between">
+            <p className="truncate text-[11px] text-gray-500">8/20(목) ~ 8/21(금)</p>
+            <div className="flex shrink-0 items-center gap-1">
+              <span className="rounded-full bg-emerald-50 p-2 text-emerald-600">
+                <FiCheckCircle size={18} />
+              </span>
+              <span className="rounded-full p-2 text-gray-600">
+                <FiLink size={17} />
+              </span>
+              <span className="rounded-full p-2 text-gray-600">
+                <FiShare2 size={18} />
+              </span>
+              <span className="rounded-full p-2 text-red-500">
+                <FiTrash2 size={16} />
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end gap-1 pt-1.5 text-center text-[10px] text-gray-400">
+          <span className="w-9 text-emerald-600">완료</span>
+          <span className="w-9">링크</span>
+          <span className="w-9">공유</span>
+          <span className="w-9 text-red-400">삭제</span>
+        </div>
+      </MockFrame>
+
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        날짜가 다 지난 일정은 자동으로 &ldquo;지난 일정&rdquo;이 되지만, 그때도 같은 체크
+        아이콘으로 완료 처리하고 기록을 남길 수 있습니다.
+      </p>
+
+      <StepHeading title="활동 기록하기" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        기록 폼에는 제목·날짜·시간에 더해 무엇을 했는지, 회식비 같은 사용 금액, 누가
+        참여했는지까지 남길 수 있습니다. 참여 인원은 멤버 목록에서 골라 칩으로 추가합니다.
+        완료 흐름이 아니어도 기록 탭의 <strong>[+ 활동 기록하기]</strong> 버튼으로 언제든
+        직접 열 수 있습니다(임원진 전용).
+      </p>
+
+      <MockFrame title="활동 기록하기" caption="일정 완료 흐름에서 자동으로 열리는 기록 폼">
+        <div className="space-y-3">
+          <div className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+            조별과제 회의
+          </div>
+          <div className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+            2026-08-20
+          </div>
+          <div className="flex gap-2">
+            <div className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+              18:00
+            </div>
+            <div className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+              19:00
+            </div>
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-gray-500">활동 설명 (선택)</p>
+            <div className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+              발표 자료 초안 완성, 역할 분담
+            </div>
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-gray-500">사용 금액 (선택)</p>
+            <div className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+              24,000
+            </div>
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-medium text-gray-500">참여 인원 (선택) · 총 3명</p>
+            <div className="flex flex-wrap gap-1.5">
+              {['홍길동', '김철수', '이영희'].map((name) => (
+                <span
+                  key={name}
+                  className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white py-1 pl-2.5 pr-1.5 text-xs text-gray-600"
+                >
+                  {name} <span className="text-gray-300">&times;</span>
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="flex gap-2 pt-1">
+            <span className="flex-1 rounded-lg bg-gray-200 py-2 text-center text-sm font-medium text-gray-600">
+              기록하지 않기
+            </span>
+            <span className="flex-1 rounded-lg bg-gray-900 py-2 text-center text-sm font-medium text-white">
+              기록하기
+            </span>
+          </div>
+        </div>
+      </MockFrame>
+
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        기록된 활동은 기록 탭에 카드로 쌓입니다. 언제, 무엇을, 얼마를 쓰고, 누구와 했는지가
+        한 장에 정리되어 동아리의 활동 역사가 됩니다. 조 필터와 함께 보면 조별 활동 내역만
+        골라 볼 수도 있습니다.
+      </p>
+
+      <MockFrame caption="기록 탭에 쌓이는 활동 카드">
+        <div className="rounded-xl border border-gray-100 bg-white p-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-sm font-bold text-gray-800">조별과제 회의</p>
+              <div className="mt-1 flex items-center gap-2 text-[11px] text-gray-400">
+                <span className="inline-flex items-center gap-0.5">
+                  <LuCalendar size={11} /> 2026-08-20
+                </span>
+                <span className="inline-flex items-center gap-0.5">
+                  <LuClock size={11} /> 18:00~19:00
+                </span>
+              </div>
+            </div>
+            <span className="shrink-0 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              1조
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-gray-600">발표 자료 초안 완성, 역할 분담</p>
+          <div className="mt-2 flex items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-600">
+              💸 24,000원
+            </span>
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              기록: 홍길동
+            </span>
+          </div>
+        </div>
+      </MockFrame>
+
+      <GuideTip>
+        사용 금액과 용도 메모를 꾸준히 남기면 기록 탭이 그대로 <strong>간단한 회계
+        장부</strong>가 됩니다. 학기말 결산 때 카드 내역을 뒤지지 않아도 됩니다.
+      </GuideTip>
+
+      <StepHeading title="랭킹 (추후 업데이트 예정)" />
+      <p className="mt-4 text-[15px] leading-7 text-gray-700">
+        기록이 쌓이면 그 데이터로 <strong>조별 랭킹</strong>이 만들어집니다. 활동 횟수와
+        점수를 합산해 조끼리 순위를 겨루는 기능으로, 순위 변동(↑↓)과 내 조의 참여율까지
+        보여줍니다. 아래와 같은 모습으로 이미 만들어져 있지만 <strong>지금은 잠시 꺼 둔
+        상태</strong>이며, 추후 업데이트로 공개될 예정입니다. 지금 남기는 활동 기록은
+        그대로 랭킹에 반영되니, 미리 부지런히 기록해 두면 공개되는 날 우리 조가 1등으로
+        시작할 수도 있습니다.
+      </p>
+
+      <MockFrame title="랭킹" caption="조별 랭킹: 구현 완료, 추후 업데이트로 공개 예정">
+        <div className="mb-3 flex items-center gap-2">
+          <LuTrophy size={16} className="text-yellow-500" />
+          <span className="text-sm font-bold text-gray-800">조별 랭킹</span>
+        </div>
+        <div className="space-y-2">
+          {[
+            { rank: 1, name: '1조', change: '↑1', changeClass: 'text-green-500', count: 8, score: 120, bar: 'bg-yellow-400', width: 'w-full' },
+            { rank: 2, name: '2조', change: '↓1', changeClass: 'text-red-500', count: 6, score: 95, bar: 'bg-gray-400', width: 'w-4/5' },
+            { rank: 3, name: '3조', change: '', changeClass: '', count: 4, score: 60, bar: 'bg-amber-600', width: 'w-1/2' },
+          ].map(({ rank, name, change, changeClass, count, score, bar, width }) => (
+            <div key={rank} className="rounded-lg border border-gray-100 bg-white p-3">
+              <div className="mb-1.5 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <span className="w-5 text-center text-xs font-bold text-gray-400">{rank}</span>
+                  <span className="text-sm font-semibold text-gray-800">{name}</span>
+                  {change && (
+                    <span className={`ml-1 text-[10px] font-medium ${changeClass}`}>{change}</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-gray-400">{count}회</span>
+                  <span className="text-sm font-bold text-gray-800">{score}점</span>
+                </div>
+              </div>
+              <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+                <div className={`h-full rounded-full ${bar} ${width}`} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </MockFrame>
+    </section>
+  );
+}

--- a/app/(main)/chinba/guide/_components/MockFrame.tsx
+++ b/app/(main)/chinba/guide/_components/MockFrame.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+
+interface MockFrameProps {
+  title?: string;
+  caption?: string;
+  children: ReactNode;
+}
+
+/**
+ * 설명서 전용 화면 목업 프레임.
+ * 실제 앱 화면의 마크업(Tailwind 클래스)을 복제해 "코드로 그린 스크린샷"처럼 보여준다.
+ * - pointer-events-none: 버튼 마크업이 들어 있어도 그림일 뿐 클릭되지 않는다.
+ * - 실제 컴포넌트를 import하지 않는다(훅·데이터 바인딩 때문) — 클래스 문자열만 복제.
+ */
+export default function MockFrame({ title, caption, children }: MockFrameProps) {
+  return (
+    <figure className="my-7">
+      <div
+        role="img"
+        aria-label={caption || title || '앱 화면 예시'}
+        className="pointer-events-none select-none overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm"
+      >
+        {title && (
+          <div className="border-b border-gray-100 px-4 py-3 text-center text-sm font-bold text-gray-800">
+            {title}
+          </div>
+        )}
+        <div className="p-4">{children}</div>
+      </div>
+      {caption && (
+        <figcaption className="mt-2 text-center text-xs text-gray-400">{caption}</figcaption>
+      )}
+    </figure>
+  );
+}

--- a/app/(main)/chinba/guide/page.tsx
+++ b/app/(main)/chinba/guide/page.tsx
@@ -1,0 +1,138 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import GuideExecFlow from './_components/GuideExecFlow';
+import GuideExtras from './_components/GuideExtras';
+import GuideInvites from './_components/GuideInvites';
+import GuideMemberFlow from './_components/GuideMemberFlow';
+import GuideOpsTools from './_components/GuideOpsTools';
+import GuideRecordsRanking from './_components/GuideRecordsRanking';
+
+export const metadata: Metadata = {
+  title: '타임라인 설명서 | 제로타임',
+  description:
+    '동아리 개설부터 조 편성, 일정 조율, 활동 기록까지 타임라인 사용법을 화면과 함께 안내합니다.',
+};
+
+const TOC: { href: string; no: number; title: string; desc: string }[] = [
+  { href: '#exec-flow', no: 1, title: '임원진 플로우', desc: '동아리 개설 → 조 편성 → 일정 잡기 → 확정' },
+  { href: '#member-flow', no: 2, title: '일반 사용자 플로우', desc: '가입 → 시간표 등록 → 내 시간 제출' },
+  { href: '#ops-tools', no: 3, title: '운영 도구', desc: '운영 사이드바 · 멤버 관리' },
+  { href: '#invites', no: 4, title: '링크와 초대', desc: '초대링크 · 일정 전용 링크' },
+  { href: '#records-ranking', no: 5, title: '기록과 랭킹', desc: '활동 기록 · 조별 랭킹(예정)' },
+  { href: '#extras', no: 6, title: '알아두면 좋은 기능', desc: 'MY 탭 · 동아리 전환 · 일정 상태' },
+  { href: '#faq', no: 7, title: '자주 묻는 질문', desc: '짧게 묻고 짧게 답하기' },
+];
+
+const CHARACTERS: { emoji: string; name: string; role: string; desc: string }[] = [
+  { emoji: '👑', name: '홍길동', role: '회장', desc: '동아리를 만들고 일정을 잡는다' },
+  { emoji: '🛠️', name: '이영희', role: '부회장', desc: '멤버와 조를 관리한다' },
+  { emoji: '🌱', name: '김철수', role: '신입 부원', desc: '초대받아 시간을 제출한다' },
+];
+
+// (main) 셸이 overflow-hidden flex 체인이라 min-h-screen 대신 h-full + overflow-y-auto를 쓴다.
+export default function ChinbaGuidePage() {
+  return (
+    <main className="h-full overflow-y-auto bg-white">
+      <div className="mx-auto w-full max-w-3xl px-5 py-12 text-gray-900">
+        {/* 표지 */}
+        <div className="flex items-start justify-between gap-4">
+          <p className="text-xs font-bold tracking-widest text-emerald-600">TIMELINE GUIDE</p>
+          <Link
+            href="/chinba/guide/tutorial/"
+            className="inline-flex shrink-0 items-center gap-2 bg-gray-900 px-5 py-3 text-sm font-bold text-white shadow-sm transition-all hover:bg-gray-800 active:scale-[0.98]"
+          >
+            🎮 타임라인 튜토리얼 들어가기
+          </Link>
+        </div>
+        <h1 className="mt-2 text-3xl font-bold leading-snug">
+          타임라인 설명서
+        </h1>
+        <p className="mt-4 text-[15px] leading-7 text-gray-700">
+          타임라인은 <strong>단톡방 투표 없이 모임 시간을 찾아 주는</strong> 서비스입니다.
+          임원진이 후보 날짜만 던져 두면, 멤버들은 각자 안 되는 시간을 표시하고, 타임라인이
+          모두가 되는 시간을 찾아 줍니다.
+        </p>
+        <p className="mt-4 text-[15px] leading-7 text-gray-700">
+          이 설명서는 가상의 <strong>&lsquo;전북대 코딩 동아리&rsquo;</strong> 세 사람을
+          따라갑니다. 동아리를 운영하는 입장이라면 1장부터, 초대를 받은 입장이라면 2장부터
+          읽으면 됩니다.
+        </p>
+
+        {/* 등장인물 */}
+        <div className="mt-8 grid gap-3 sm:grid-cols-3">
+          {CHARACTERS.map(({ emoji, name, role, desc }) => (
+            <div key={name} className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+              <p className="text-2xl">{emoji}</p>
+              <p className="mt-2 text-sm font-bold text-gray-900">
+                {name} <span className="ml-1 text-xs font-medium text-gray-400">{role}</span>
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-gray-500">{desc}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* 목차 */}
+        <nav className="mt-10 rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+          <p className="text-xs font-bold uppercase tracking-widest text-gray-400">목차</p>
+          <ol className="mt-3 divide-y divide-gray-50">
+            {TOC.map(({ href, no, title, desc }) => (
+              <li key={href}>
+                <a href={href} className="group flex items-center gap-3 py-2.5">
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-500 group-hover:bg-blue-100 group-hover:text-blue-700">
+                    {no}
+                  </span>
+                  <span className="text-sm font-semibold text-gray-800 group-hover:text-blue-700">
+                    {title}
+                  </span>
+                  <span className="ml-auto hidden text-xs text-gray-400 sm:block">{desc}</span>
+                </a>
+              </li>
+            ))}
+          </ol>
+        </nav>
+
+        <p className="mt-6 text-xs leading-relaxed text-gray-400">
+          아래 화면들은 실제 앱 화면을 그대로 재현한 예시 그림입니다. 등장하는 이름과
+          숫자는 모두 가상의 예시입니다.
+        </p>
+
+        <GuideExecFlow />
+        <GuideMemberFlow />
+        <GuideOpsTools />
+        <GuideInvites />
+        <GuideRecordsRanking />
+        <GuideExtras />
+
+        {/* 마무리 */}
+        <section className="mt-16 border-t border-gray-100 pt-10 pb-12">
+          <p className="text-xs font-bold tracking-widest text-emerald-600">WRAP-UP</p>
+          <h2 className="mt-1.5 text-2xl font-bold">한눈에 정리</h2>
+          <div className="mt-6 space-y-4">
+            <div className="rounded-xl border border-gray-100 bg-gray-50 p-5">
+              <p className="text-sm font-bold text-gray-900">임원진은</p>
+              <p className="mt-1.5 text-sm leading-7 text-gray-700">
+                동아리 만들기 → 조 편성 → 일정 잡기 → 완료 후 기록. 초대링크로 사람을 모으고,
+                운영 사이드바에서 응답 현황을 챙깁니다.
+              </p>
+            </div>
+            <div className="rounded-xl border border-gray-100 bg-gray-50 p-5">
+              <p className="text-sm font-bold text-gray-900">멤버는</p>
+              <p className="mt-1.5 text-sm leading-7 text-gray-700">
+                초대링크로 가입 → 시간표 한 번 등록 → 일정마다 안 되는 시간 저장. 이게
+                전부입니다.
+              </p>
+            </div>
+            <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-5">
+              <p className="text-sm font-bold text-emerald-800">나머지는 타임라인이</p>
+              <p className="mt-1.5 text-sm leading-7 text-emerald-900">
+                모두가 되는 시간 찾기, 응답 현황 집계, 활동 기록 정리. 단톡방 투표는 이제
+                없습니다.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/ClubShell.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/ClubShell.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { FiSettings } from 'react-icons/fi';
+import { LuCalendar, LuChevronDown, LuPencil } from 'react-icons/lu';
+
+import FakeOpsPanel from './FakeOpsPanel';
+import { TutorialTarget } from './Spotlight';
+import type { TutorialEngine } from './useTutorialEngine';
+
+interface ClubShellProps {
+  engine: TutorialEngine;
+  tab: 'mannaja' | 'mwoheni';
+  children: ReactNode;
+}
+
+/**
+ * 동아리 상세 화면(TeamDetailView)의 튜토리얼 판 —
+ * 헤더(동아리명 + 설정 톱니) + 탭(일정|기록) + 본문 + 우측 운영 패널.
+ */
+export default function ClubShell({ engine, tab, children }: ClubShellProps) {
+  const { state } = engine;
+  return (
+    <div className="flex min-h-full flex-col bg-white">
+      {/* 헤더 */}
+      <div className="shrink-0 px-4 pb-3 pt-4">
+        <div className="relative flex items-center justify-center">
+          <span className="inline-flex items-center gap-1 text-base font-bold text-gray-800">
+            {state.clubName || '동아리'}
+            <LuChevronDown size={16} className="text-gray-400" />
+          </span>
+          <div className="absolute right-0">
+            <TutorialTarget id="club-gear" engine={engine}>
+              <span className="block rounded-full p-2 text-gray-500">
+                <FiSettings size={18} />
+              </span>
+            </TutorialTarget>
+          </div>
+        </div>
+      </div>
+
+      {/* 본문 + 운영 패널 */}
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        <div className="min-w-0 flex-1">
+          {/* 탭 */}
+          <div className="flex border-b border-gray-100">
+            {(
+              [
+                { key: 'mannaja', label: '일정', icon: LuCalendar },
+                { key: 'mwoheni', label: '기록', icon: LuPencil },
+              ] as const
+            ).map(({ key, label, icon: Icon }) => {
+              const isActive = tab === key;
+              return (
+                <div
+                  key={key}
+                  className={`relative flex-1 py-3 text-center text-sm transition-colors ${
+                    isActive ? 'font-bold text-gray-900' : 'font-medium text-gray-400'
+                  }`}
+                >
+                  <span className="inline-flex items-center justify-center gap-1.5">
+                    <Icon size={16} strokeWidth={isActive ? 2.5 : 2} />
+                    {label}
+                  </span>
+                  {isActive && (
+                    <span className="absolute bottom-0 left-1/2 h-0.5 w-12 -translate-x-1/2 rounded-full bg-gray-900" />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <div className="px-4 py-4">{children}</div>
+        </div>
+
+        <FakeOpsPanel engine={engine} />
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/DoneScreen.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/DoneScreen.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+
+/** 튜토리얼 완료 화면 */
+export default function DoneScreen({ onRestart }: { onRestart: () => void }) {
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-md flex-col items-center justify-center px-5 py-16 text-center">
+      <p className="mb-6 text-7xl">🎉</p>
+      <h1 className="text-2xl font-bold text-gray-900">튜토리얼 완료!</h1>
+      <p className="mt-3 text-sm leading-relaxed text-gray-500">
+        동아리 개설부터 시간 제출, 기록까지 전부 해봤어요. 이제 진짜 동아리를 만들 준비가
+        됐습니다.
+      </p>
+
+      <div className="mt-10 flex w-full flex-col gap-2">
+        <Link
+          href="/chinba/"
+          className="w-full rounded-xl bg-gray-900 py-4 text-center font-bold text-white transition-all hover:bg-gray-800"
+        >
+          타임라인 시작하기
+        </Link>
+        <button
+          type="button"
+          onClick={onRestart}
+          className="w-full rounded-xl border border-gray-200 py-3 text-sm font-semibold text-gray-600 transition-all hover:border-gray-400"
+        >
+          처음부터 다시 해보기
+        </button>
+        <Link
+          href="/chinba/guide/"
+          className="w-full py-2 text-center text-sm font-medium text-gray-400 transition-all hover:text-gray-600"
+        >
+          설명서로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/FakeOpsPanel.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/FakeOpsPanel.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { FiCalendar, FiChevronRight, FiEdit3, FiGrid, FiLink, FiUsers } from 'react-icons/fi';
+
+import { TutorialTarget } from './Spotlight';
+import type { TutorialEngine } from './useTutorialEngine';
+
+function PanelRow({
+  icon: Icon,
+  label,
+  trailing = '›',
+}: {
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  label: string;
+  trailing?: string;
+}) {
+  return (
+    <div className="group flex w-full cursor-pointer items-center gap-2.5 px-3 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-blue-50 hover:text-blue-700">
+      <Icon size={16} className="shrink-0 text-gray-500" />
+      <span className="flex-1 text-left">{label}</span>
+      <span className="text-xs text-gray-300">{trailing}</span>
+    </div>
+  );
+}
+
+/**
+ * 실제 TeamOpsPanel(데스크톱 우측 운영 패널)의 튜토리얼 판.
+ * lg 이상에서는 오른쪽 사이드바, 그 아래 해상도에서는 본문 아래에 쌓인다
+ * (실제 앱은 모바일에서 설정 페이지로 대체되지만, 튜토리얼 진행을 위해 항상 노출).
+ */
+export default function FakeOpsPanel({ engine }: { engine: TutorialEngine }) {
+  const { state } = engine;
+  const hasEvent = state.eventTitle.trim().length > 0 && state.eventDates.length > 0;
+
+  return (
+    <aside className="w-full shrink-0 border-t border-gray-100 bg-white lg:w-[236px] lg:border-l lg:border-t-0">
+      <div className="flex flex-col gap-6 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-bold text-gray-800">운영</h2>
+          <span className="rounded-full p-1.5 text-gray-400">
+            <FiChevronRight size={16} />
+          </span>
+        </div>
+
+        <section className="flex flex-col">
+          <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">
+            운영 도구
+          </span>
+          <TutorialTarget id="ops-members" engine={engine}>
+            <PanelRow icon={FiUsers} label="멤버 관리" trailing="⤢" />
+          </TutorialTarget>
+          <TutorialTarget id="ops-groups" engine={engine}>
+            <PanelRow icon={FiGrid} label="조 / 그룹 관리" trailing="⤢" />
+          </TutorialTarget>
+          <TutorialTarget id="ops-invite" engine={engine}>
+            <PanelRow icon={FiLink} label="초대링크 복사" trailing="⧉" />
+          </TutorialTarget>
+        </section>
+
+        <TutorialTarget id="ops-response" engine={engine}>
+          <section className="flex flex-col p-1">
+            <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">
+              응답 현황
+            </span>
+            {hasEvent ? (
+              <div className="px-3 py-1">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="truncate font-medium text-gray-700">{state.eventTitle}</span>
+                  <span className="shrink-0 text-gray-400">
+                    {state.submissions.length}/{state.members.length}
+                  </span>
+                </div>
+                <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-emerald-400 transition-all"
+                    style={{
+                      width: `${
+                        state.members.length === 0
+                          ? 0
+                          : Math.round((state.submissions.length / state.members.length) * 100)
+                      }%`,
+                    }}
+                  />
+                </div>
+                {state.submissions.length < state.members.length && (
+                  <p className="mt-1.5 text-[11px] text-gray-400">
+                    미제출:{' '}
+                    {state.members
+                      .filter((m) => !state.submissions.includes(m.id))
+                      .map((m) => m.name)
+                      .join(', ')}{' '}
+                    <span className="text-gray-500">[복사]</span>
+                  </p>
+                )}
+              </div>
+            ) : (
+              <p className="px-3 py-1 text-[11px] text-gray-400">아직 진행 중인 일정이 없어요</p>
+            )}
+          </section>
+        </TutorialTarget>
+
+        <section className="flex flex-col border-t border-gray-100 pt-5">
+          <span className="mb-2 px-1 text-[11px] font-bold uppercase tracking-wide text-gray-400">
+            바로가기
+          </span>
+          <PanelRow icon={FiCalendar} label="일정 잡기" />
+          <PanelRow icon={FiEdit3} label="활동 기록하기" />
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/FakeSidebar.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/FakeSidebar.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { FiBell, FiBookOpen, FiExternalLink, FiUser, FiUsers } from 'react-icons/fi';
+import { SiNaver } from 'react-icons/si';
+
+/**
+ * 실제 앱 왼쪽 사이드바(SidebarContent)의 정적 복제 — 튜토리얼 배경용.
+ * 클릭 동작은 없다(스포트라이트 오버레이가 덮거나, 오버레이 없는 스텝에서도 inert).
+ */
+export default function FakeSidebar() {
+  return (
+    <aside className="hidden w-[260px] shrink-0 select-none flex-col border-r border-gray-100 bg-white md:flex">
+      <div className="px-5 pb-2 pt-6">
+        <span className="text-lg font-extrabold tracking-tight text-gray-900">ZeroTime</span>
+      </div>
+
+      {/* 사용자 영역 */}
+      <div className="border-b border-gray-100 px-5 pb-4 pt-2">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-400">
+            <FiUser size={18} />
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-bold text-gray-800">홍길동</p>
+            <p className="truncate text-[11px] text-gray-400">전북대학교</p>
+          </div>
+        </div>
+      </div>
+
+      {/* 서비스 목록 */}
+      <div className="px-3 pt-4">
+        <div className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-gray-700">
+          <FiBell size={18} />
+          <span className="text-sm font-medium">전북대학교 알리미</span>
+        </div>
+        <div className="flex w-full items-center gap-3 rounded-lg bg-blue-50 px-3 py-2.5 text-left text-blue-700">
+          <FiUsers size={18} />
+          <span className="text-sm font-medium">타임라인</span>
+          <span className="ml-auto rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-500">
+            현재
+          </span>
+        </div>
+
+        <div className="mt-3 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-gray-500">
+          <SiNaver size={16} />
+          <span className="text-sm font-medium">제로타임 앱 사용하기</span>
+          <FiExternalLink size={13} className="ml-auto text-gray-300" />
+        </div>
+        <div className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-gray-500">
+          <FiBookOpen size={16} />
+          <span className="text-sm font-medium">타임라인 설명서</span>
+        </div>
+      </div>
+
+      <div className="flex-1" />
+      <div className="px-5 pb-6 text-[11px] text-gray-300">© ZeroTime</div>
+    </aside>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/SceneFrame.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/SceneFrame.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { LuChevronLeft } from 'react-icons/lu';
+
+interface SceneFrameProps {
+  title?: ReactNode;
+  headerRight?: ReactNode;
+  showBack?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * 풀페이지 장면 프레임 — 실제 FullPageModal(inline) 헤더 구조를 재현한다.
+ * 주의: transform/filter/opacity를 걸면 안 된다 — 스포트라이트 z-승격이 깨진다.
+ */
+export default function SceneFrame({
+  title,
+  headerRight,
+  showBack = true,
+  children,
+}: SceneFrameProps) {
+  return (
+    <div className="flex min-h-full flex-col bg-white">
+      {title !== undefined && (
+        <div className="shrink-0 px-4 pb-3 pt-4">
+          <div className="relative flex items-center justify-center">
+            {showBack && (
+              <span className="absolute left-0 -ml-1 rounded-full p-2 text-gray-600">
+                <LuChevronLeft size={24} strokeWidth={2.5} />
+              </span>
+            )}
+            <h1 className="text-base font-bold text-gray-800">{title}</h1>
+            {headerRight && <div className="absolute right-0">{headerRight}</div>}
+          </div>
+        </div>
+      )}
+      <div className="flex-1 px-4 pb-8">{children}</div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/SpeechBubble.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/SpeechBubble.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface SpeechBubbleProps {
+  content: ReactNode;
+  placement: 'top' | 'bottom' | 'left' | 'right';
+  align?: 'center' | 'right';
+  /** 오버레이 클릭 시 증가 — key 리마운트로 fadeIn 재생해 시선 유도 */
+  nudgeKey: number;
+  showNext?: boolean;
+  nextEnabled?: boolean;
+  onNext?: () => void;
+}
+
+/**
+ * 클릭 유도 말풍선 — ClubSwitcher의 1회성 힌트 말풍선 마크업을 재현.
+ * 부모(TutorialTarget)가 relative인 것을 전제로 absolute 배치한다.
+ */
+export default function SpeechBubble({
+  content,
+  placement,
+  align = 'center',
+  nudgeKey,
+  showNext = false,
+  nextEnabled = true,
+  onNext,
+}: SpeechBubbleProps) {
+  let positionClass = '';
+  let arrowClass = '';
+  const horizontal = align === 'right' ? 'right-0' : 'left-1/2 -translate-x-1/2';
+  const arrowHorizontal = align === 'right' ? 'right-4' : 'left-1/2 -translate-x-1/2';
+
+  switch (placement) {
+    case 'bottom':
+      positionClass = `absolute top-full z-[95] mt-3 ${horizontal}`;
+      arrowClass = `absolute -top-1 h-2 w-2 rotate-45 bg-gray-900 ${arrowHorizontal}`;
+      break;
+    case 'top':
+      positionClass = `absolute bottom-full z-[95] mb-3 ${horizontal}`;
+      arrowClass = `absolute -bottom-1 h-2 w-2 rotate-45 bg-gray-900 ${arrowHorizontal}`;
+      break;
+    case 'left':
+      positionClass = 'absolute right-full top-1/2 z-[95] mr-3 -translate-y-1/2';
+      arrowClass = 'absolute -right-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45 bg-gray-900';
+      break;
+    case 'right':
+      positionClass = 'absolute left-full top-1/2 z-[95] ml-3 -translate-y-1/2';
+      arrowClass = 'absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rotate-45 bg-gray-900';
+      break;
+  }
+
+  return (
+    <div key={nudgeKey} className={`${positionClass} animate-fadeIn`}>
+      <div className="relative w-max max-w-[17rem] rounded-lg bg-gray-900 px-3.5 py-2.5 text-xs font-medium leading-relaxed text-white shadow-lg">
+        <div>{content}</div>
+        {showNext && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onNext?.();
+            }}
+            disabled={!nextEnabled}
+            className="mt-2 w-full rounded-md bg-white px-3 py-1.5 text-xs font-bold text-gray-900 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            다음
+          </button>
+        )}
+        <div className={arrowClass} />
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/Spotlight.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/Spotlight.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import SpeechBubble from './SpeechBubble';
+import type { TutorialEngine } from './useTutorialEngine';
+
+/**
+ * 스포트라이트 오버레이 — 뷰포트 전체(실제 사이드바 포함)를 어둡게 덮어
+ * 아래 요소의 클릭을 전부 차단한다. 대상은 TutorialTarget이 z-[90]으로 승격.
+ * 오버레이 클릭 = "여기가 아니에요" → 말풍선 재생(nudge).
+ */
+export function TutorialOverlay({ engine }: { engine: TutorialEngine }) {
+  const { step, transitioning } = engine;
+  if (!step || transitioning || step.overlay === false) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[80] bg-black/40 animate-fadeIn"
+      aria-hidden
+      onClick={engine.nudge}
+    />
+  );
+}
+
+interface TutorialTargetProps {
+  id: string;
+  engine: TutorialEngine;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * 스포트라이트 대상 래퍼.
+ * active면 오버레이(z-80) 위로 승격(z-90)되고 파란 링 + 흰 배경으로 강조된다.
+ * advance가 click이면 래퍼 클릭이 곧 스텝 완료다.
+ */
+export function TutorialTarget({ id, engine, className = '', children }: TutorialTargetProps) {
+  const { step, transitioning } = engine;
+  const active = !!step && step.target === id && !transitioning;
+  const isClick = active && step.advance.kind === 'click';
+  const bubble = active ? step.bubble : null;
+  const showNext = active && step.advance.kind === 'next';
+  const nextEnabled =
+    active && (step.advance.kind === 'next' || step.advance.kind === 'click')
+      ? (step.advance.enabledWhen?.(engine.state) ?? true)
+      : true;
+
+  return (
+    <div
+      id={`tut-${id}`}
+      onClick={isClick ? () => engine.completeStep() : undefined}
+      className={`${
+        active
+          ? `relative z-[90] rounded-xl bg-white ring-4 ring-blue-400/60 ${isClick ? 'cursor-pointer' : ''}`
+          : 'relative'
+      } ${className}`}
+    >
+      {children}
+      {bubble && (
+        <SpeechBubble
+          content={bubble.content}
+          placement={bubble.placement}
+          align={bubble.align}
+          nudgeKey={engine.nudgeKey}
+          showNext={showNext}
+          nextEnabled={nextEnabled}
+          onNext={engine.completeStep}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/StartScreen.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/StartScreen.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Link from 'next/link';
+
+/** 튜토리얼 시작 화면 */
+export default function StartScreen({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-md flex-col justify-center px-5 py-12">
+      <p className="text-xs font-bold tracking-widest text-emerald-600">TIMELINE TUTORIAL</p>
+      <h1 className="mt-2 text-3xl font-bold text-gray-900">타임라인 튜토리얼</h1>
+      <p className="mt-3 text-[15px] leading-7 text-gray-600">
+        실제 화면과 똑같은 연습 공간이에요. 동아리를 만들고, 부원을 초대하고, 시간을 제출하고,
+        기록까지 남겨봅니다. 말풍선이 가리키는 버튼만 누르면 됩니다.
+      </p>
+
+      <div className="mt-10 flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={onStart}
+          className="w-full bg-gray-900 py-4 text-center text-base font-bold text-white transition-all hover:bg-gray-800 active:scale-[0.99]"
+        >
+          튜토리얼 시작하기
+        </button>
+        <Link
+          href="/chinba/guide/"
+          className="w-full py-2 text-center text-sm font-medium text-gray-400 transition-all hover:text-gray-600"
+        >
+          설명서로 돌아가기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/TutorialApp.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/TutorialApp.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import DoneScreen from './DoneScreen';
+import FakeSidebar from './FakeSidebar';
+import SceneClubHome from './scenes/SceneClubHome';
+import SceneCreateClub from './scenes/SceneCreateClub';
+import SceneEventCreate from './scenes/SceneEventCreate';
+import SceneEventDetail from './scenes/SceneEventDetail';
+import SceneGroups from './scenes/SceneGroups';
+import SceneMembersModal from './scenes/SceneMembersModal';
+import SceneRecordForm from './scenes/SceneRecordForm';
+import SceneRecords from './scenes/SceneRecords';
+import SceneTimetable from './scenes/SceneTimetable';
+import { TutorialOverlay } from './Spotlight';
+import StartScreen from './StartScreen';
+import { TUTORIAL_STEPS } from './tracks';
+import TutorialChrome from './TutorialChrome';
+import TutorialConfirmModal from './TutorialConfirmModal';
+import TutorialToasts from './TutorialToasts';
+import type { SceneId } from './types';
+import { useTutorialEngine, type TutorialEngine } from './useTutorialEngine';
+
+const SCENES: Record<SceneId, (props: { engine: TutorialEngine }) => React.ReactNode> = {
+  createClub: SceneCreateClub,
+  clubHome: SceneClubHome,
+  membersModal: SceneMembersModal,
+  groups: SceneGroups,
+  eventCreate: SceneEventCreate,
+  timetable: SceneTimetable,
+  eventDetail: SceneEventDetail,
+  recordForm: SceneRecordForm,
+  records: SceneRecords,
+};
+
+/**
+ * 튜토리얼 루트 — 실제 앱 셸 전체를 fixed 오버레이(z-[70])로 덮고,
+ * 그 안에 가짜 앱 화면(왼쪽 사이드바 + 중앙 + 우측 운영 패널)을 복제한다.
+ */
+export default function TutorialApp() {
+  const [started, setStarted] = useState(false);
+  const [runId, setRunId] = useState(0);
+
+  return (
+    <div className="fixed inset-0 z-[70] flex flex-col bg-gray-50">
+      {started ? (
+        <TutorialRun
+          key={runId}
+          onRestart={() => {
+            setStarted(false);
+            setRunId((n) => n + 1);
+          }}
+        />
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          <StartScreen onStart={() => setStarted(true)} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TutorialRun({ onRestart }: { onRestart: () => void }) {
+  const router = useRouter();
+  const engine = useTutorialEngine(TUTORIAL_STEPS);
+  const [showExitConfirm, setShowExitConfirm] = useState(false);
+
+  if (engine.isDone) {
+    return (
+      <div className="flex-1 overflow-y-auto">
+        <DoneScreen onRestart={onRestart} />
+      </div>
+    );
+  }
+
+  const scene = engine.step!.scene;
+  const Scene = SCENES[scene];
+
+  return (
+    <>
+      <TutorialChrome
+        trackLabel="타임라인 튜토리얼"
+        stepIndex={engine.stepIndex}
+        totalSteps={engine.totalSteps}
+        onExit={() => setShowExitConfirm(true)}
+      />
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {/* 실제 (main) 레이아웃 재현: 가운데 정렬된 [사이드바 | 콘텐츠] 박스 */}
+        <div className="mx-auto flex min-h-full w-full max-w-[1200px] md:shadow-xl">
+          <FakeSidebar />
+          <div className="flex min-h-full w-full min-w-0 flex-1 flex-col border-x border-gray-100 bg-white md:border-l-0">
+            {/* 장면 — scene이 바뀔 때 리마운트 + fadeIn (transform 계열 금지: 스포트라이트 z-승격 보호) */}
+            <div key={scene} className="flex-1 animate-fadeIn">
+              <Scene engine={engine} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <TutorialOverlay engine={engine} />
+      <TutorialToasts toasts={engine.toasts} />
+
+      <TutorialConfirmModal
+        isOpen={showExitConfirm}
+        title="튜토리얼 나가기"
+        confirmLabel="나가기"
+        onConfirm={() => router.push('/chinba/guide/')}
+        onCancel={() => setShowExitConfirm(false)}
+      >
+        진행 상황은 저장되지 않아요. 나갈까요?
+      </TutorialConfirmModal>
+    </>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/TutorialChrome.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/TutorialChrome.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { FiX } from 'react-icons/fi';
+
+interface TutorialChromeProps {
+  trackLabel: string;
+  stepIndex: number;
+  totalSteps: number;
+  onExit: () => void;
+}
+
+/** 튜토리얼 상단 고정 바 — 진행바 + 나가기. 스포트라이트(z-80)보다 위(z-100)라 항상 조작 가능 */
+export default function TutorialChrome({
+  trackLabel,
+  stepIndex,
+  totalSteps,
+  onExit,
+}: TutorialChromeProps) {
+  const progress = totalSteps === 0 ? 0 : Math.min((stepIndex / totalSteps) * 100, 100);
+  return (
+    <div className="relative z-[100] shrink-0 border-b border-gray-100 bg-white px-4 py-3">
+      <div className="mx-auto w-full max-w-md">
+        <div className="mb-2 flex items-center justify-between">
+          <p className="text-xs font-semibold text-gray-500">{trackLabel}</p>
+          <div className="flex items-center gap-3">
+            <p className="text-xs font-semibold text-gray-500">
+              {Math.min(stepIndex + 1, totalSteps)} / {totalSteps}
+            </p>
+            <button
+              type="button"
+              onClick={onExit}
+              className="flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            >
+              <FiX size={13} />
+              나가기
+            </button>
+          </div>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-gray-200">
+          <div
+            className="h-full rounded-full bg-blue-500"
+            style={{ width: `${progress}%`, transition: 'width 280ms cubic-bezier(0.22, 1, 0.36, 1)' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/TutorialConfirmModal.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/TutorialConfirmModal.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+interface TutorialConfirmModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title?: string;
+  children: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+/**
+ * ConfirmModal 마크업 복제판 — 튜토리얼 스포트라이트(z-80)·크롬(z-100) 위에
+ * 떠야 해서 z-[110]으로 올린 것만 다르다. 백드롭이 클릭 게이팅을 대신한다.
+ */
+export default function TutorialConfirmModal({
+  isOpen,
+  onConfirm,
+  onCancel,
+  title,
+  children,
+  confirmLabel = '확인',
+  cancelLabel = '취소',
+}: TutorialConfirmModalProps) {
+  if (!isOpen) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+    >
+      <div
+        className="w-[80%] max-w-xs rounded-2xl bg-white p-5 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && <h3 className="mb-2 text-center text-base font-semibold text-gray-900">{title}</h3>}
+        <div className="text-center text-sm text-gray-600">{children}</div>
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-3 text-sm font-semibold text-gray-700 transition-all hover:bg-gray-50 active:scale-95"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex-1 rounded-xl bg-gray-900 py-3 text-sm font-semibold text-white transition-all hover:bg-gray-800 active:scale-95"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/TutorialToasts.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/TutorialToasts.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { TutorialToastItem } from './useTutorialEngine';
+
+/** 앱 Toast의 마크업을 복제한 튜토리얼 전용 토스트 스택 (실제 ToastContext와 독립) */
+export default function TutorialToasts({ toasts }: { toasts: TutorialToastItem[] }) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="fixed bottom-28 left-1/2 z-[200] flex -translate-x-1/2 flex-col-reverse gap-2">
+      {toasts.map((toast) => (
+        <div key={toast.id} className="animate-slide-up">
+          <div
+            className={`max-w-[90vw] whitespace-nowrap rounded-lg px-4 py-2.5 text-sm text-white shadow-lg ${
+              toast.type === 'success' ? 'bg-gray-700' : 'bg-gray-900'
+            }`}
+          >
+            {toast.message}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneClubHome.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneClubHome.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { FiPlus } from 'react-icons/fi';
+import { LuCalendar } from 'react-icons/lu';
+
+import ClubShell from '../ClubShell';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+/** 동아리 상세 홈(일정 탭) — 초대·조 편성 진입, 일정 만들기, 기능 투어의 배경 화면 */
+export default function SceneClubHome({ engine }: { engine: TutorialEngine }) {
+  const { state } = engine;
+  const hasEvent = state.eventTitle.trim().length > 0 && state.eventDates.length > 0;
+
+  return (
+    <ClubShell engine={engine} tab="mannaja">
+      {!state.groupSaved && (
+        <div className="mb-4 rounded-2xl border border-emerald-100 bg-gradient-to-br from-emerald-50 to-white p-4">
+          <p className="text-sm font-bold text-emerald-800">동아리 준비 2단계</p>
+          <p className="mt-1 text-xs leading-relaxed text-emerald-700">
+            ① 초대링크로 회원을 초대하세요 → ② 조를 편성하세요
+          </p>
+        </div>
+      )}
+
+      {hasEvent ? (
+        <div className="rounded-xl border border-gray-100 bg-white p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <LuCalendar size={16} className="text-gray-400" />
+              <p className="text-sm font-bold text-gray-800">{state.eventTitle}</p>
+            </div>
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
+                state.eventCompleted
+                  ? 'bg-emerald-50 text-emerald-600'
+                  : 'bg-blue-50 text-blue-600'
+              }`}
+            >
+              {state.eventCompleted ? '완료됨' : '진행중'}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-gray-400">
+            8/20(목) ~ 8/21(금) · {state.submissions.length}/{state.members.length} 제출
+          </p>
+        </div>
+      ) : (
+        <>
+          <TutorialTarget id="home-create-event" engine={engine}>
+            <div className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-3 text-sm font-medium text-gray-500">
+              <FiPlus size={16} />
+              일정 잡기
+            </div>
+          </TutorialTarget>
+          <div className="py-10 text-center">
+            <p className="text-sm text-gray-400">아직 잡은 일정이 없어요</p>
+            <p className="mt-1 text-xs text-gray-300">일정을 만들면 여기에 쌓입니다</p>
+          </div>
+        </>
+      )}
+    </ClubShell>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneCreateClub.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneCreateClub.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { FiXCircle } from 'react-icons/fi';
+
+import SceneFrame from '../SceneFrame';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+const CATEGORY_OPTIONS = ['동아리', '학과', '스터디', '연구실', '학회', '기타'];
+
+/** 회장 트랙 1: 동아리 만들기 (TeamCreateView 재현 — 이름은 실제 타이핑) */
+export default function SceneCreateClub({ engine }: { engine: TutorialEngine }) {
+  const { state, dispatch } = engine;
+  return (
+    <SceneFrame title="동아리 만들기">
+      <div className="mb-6">
+        <label className="mb-2 block text-sm font-bold text-gray-700">동아리 이름</label>
+        <TutorialTarget id="cc-name" engine={engine}>
+          <div className="relative">
+            <input
+              type="text"
+              value={state.clubName}
+              onChange={(e) => dispatch({ type: 'SET_CLUB_NAME', value: e.target.value })}
+              placeholder="예: 코딩 동아리, 졸업 프로젝트"
+              maxLength={50}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-800 placeholder-gray-400 outline-none transition-colors focus:border-gray-900"
+            />
+            {state.clubName.length > 0 && (
+              <button
+                type="button"
+                onClick={() => dispatch({ type: 'SET_CLUB_NAME', value: '' })}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 transition-colors hover:text-gray-500"
+              >
+                <FiXCircle size={18} />
+              </button>
+            )}
+          </div>
+        </TutorialTarget>
+        <p className="mt-1 text-right text-[11px] text-gray-400">{state.clubName.length}/50</p>
+      </div>
+
+      <div className="mb-6">
+        <label className="mb-2 block text-sm font-bold text-gray-700">
+          카테고리
+          <span className="ml-1 text-xs font-normal text-gray-400">(선택)</span>
+        </label>
+        <TutorialTarget id="cc-category" engine={engine}>
+          <div className="flex flex-wrap gap-2 p-1">
+            {CATEGORY_OPTIONS.map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                onClick={() => dispatch({ type: 'SET_CATEGORY', value: opt })}
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors active:scale-95 ${
+                  state.category === opt
+                    ? 'border-gray-900 bg-gray-900 text-white'
+                    : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        </TutorialTarget>
+      </div>
+
+      <div className="border-t border-gray-100 pt-3">
+        <TutorialTarget id="cc-create" engine={engine}>
+          <div
+            className={`w-full rounded-xl py-3 text-center text-base font-semibold text-white ${
+              state.clubName.trim() ? 'bg-gray-900' : 'bg-gray-300'
+            }`}
+          >
+            만들기
+          </div>
+        </TutorialTarget>
+      </div>
+    </SceneFrame>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneEventCreate.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneEventCreate.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { FiXCircle } from 'react-icons/fi';
+
+import SceneFrame from '../SceneFrame';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
+// 8월 셋째 주 한 줄만 축약 렌더 (16~22일, 19=오늘, 20·21·22 선택 가능)
+const WEEK_DAYS = [16, 17, 18, 19, 20, 21, 22];
+const SELECTABLE = new Set([20, 21, 22]);
+
+/** 회장 트랙 5(전반): 일정 잡기 — 이름 타이핑 + 달력 날짜 선택 (TeamEventCreate + DateSelector 재현) */
+export default function SceneEventCreate({ engine }: { engine: TutorialEngine }) {
+  const { state, dispatch } = engine;
+  const canCreate = state.eventTitle.trim().length > 0 && state.eventDates.length >= 2;
+
+  return (
+    <SceneFrame title="일정 잡기">
+      <div className="mb-5">
+        <label className="mb-2 block text-sm font-bold text-gray-700">모임 이름</label>
+        <TutorialTarget id="ev-title" engine={engine}>
+          <div className="relative">
+            <input
+              type="text"
+              value={state.eventTitle}
+              onChange={(e) => dispatch({ type: 'SET_EVENT_TITLE', value: e.target.value })}
+              placeholder="예: 조별과제 회의, 동아리 정기모임"
+              maxLength={100}
+              className="w-full rounded-xl border border-gray-200 px-4 py-3 pr-10 text-sm text-gray-800 placeholder-gray-400 outline-none transition-colors focus:border-gray-900"
+            />
+            {state.eventTitle.length > 0 && (
+              <button
+                type="button"
+                onClick={() => dispatch({ type: 'SET_EVENT_TITLE', value: '' })}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 transition-colors hover:text-gray-500"
+              >
+                <FiXCircle size={18} />
+              </button>
+            )}
+          </div>
+        </TutorialTarget>
+      </div>
+
+      <div className="mb-5">
+        <label className="mb-1 block text-sm font-bold text-gray-700">날짜 선택</label>
+        <p className="mb-2 text-xs text-gray-400">후보 날짜를 클릭하거나 드래그하여 선택하세요</p>
+        <TutorialTarget id="ev-dates" engine={engine}>
+          <div className="mx-auto w-full max-w-[26rem] p-1">
+            <div className="mb-2 flex items-center justify-center">
+              <span className="text-sm font-bold text-gray-800">2026년 8월</span>
+            </div>
+            <div className="mb-1 grid grid-cols-7">
+              {DAY_LABELS.map((d) => (
+                <div
+                  key={d}
+                  className="flex h-8 items-center justify-center text-[11px] font-medium text-gray-400"
+                >
+                  {d}
+                </div>
+              ))}
+            </div>
+            <div className="grid grid-cols-7 gap-0.5">
+              {WEEK_DAYS.map((day) => {
+                const selectable = SELECTABLE.has(day);
+                const selected = state.eventDates.includes(day);
+                const isToday = day === 19;
+                return (
+                  <button
+                    key={day}
+                    type="button"
+                    disabled={!selectable}
+                    onClick={() => dispatch({ type: 'TOGGLE_DATE', day })}
+                    className={`flex aspect-square items-center justify-center rounded-lg text-sm font-medium transition-colors ${
+                      selected
+                        ? 'bg-gray-900 text-white'
+                        : isToday
+                          ? 'bg-blue-50 text-blue-700'
+                          : selectable
+                            ? 'text-gray-700 hover:bg-gray-100'
+                            : 'cursor-default text-gray-200'
+                    }`}
+                  >
+                    {day}
+                  </button>
+                );
+              })}
+            </div>
+            {state.eventDates.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {state.eventDates.map((day) => (
+                  <span
+                    key={day}
+                    className="inline-flex items-center gap-0.5 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600"
+                  >
+                    8/{day}({DAY_LABELS[new Date(2026, 7, day).getDay()]})
+                    <span className="ml-0.5 text-gray-400">&times;</span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </TutorialTarget>
+      </div>
+
+      <div className="border-t border-gray-100 pt-3">
+        <TutorialTarget id="ev-create" engine={engine}>
+          <div
+            className={`w-full rounded-xl py-3 text-center text-base font-semibold text-white ${
+              canCreate ? 'bg-gray-900' : 'bg-gray-300'
+            }`}
+          >
+            만들기
+          </div>
+        </TutorialTarget>
+      </div>
+    </SceneFrame>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneEventDetail.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneEventDetail.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  FiCheck,
+  FiCheckCircle,
+  FiClock,
+  FiLink,
+  FiRotateCcw,
+  FiShare2,
+  FiTrash2,
+  FiUpload,
+} from 'react-icons/fi';
+
+import SceneFrame from '../SceneFrame';
+import { TutorialTarget } from '../Spotlight';
+import TutorialConfirmModal from '../TutorialConfirmModal';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+const DATES = ['목 8/20', '금 8/21'];
+const ROWS = ['18시', '', '19시', ''];
+
+// [내 시간표 불러오기]가 자동으로 칠하는 수업 시간(회장 본인)
+const TIMETABLE_CELLS = new Set(['0-0', '1-0']);
+
+// 다른 멤버들의 불가능 시간 — 제출 연출이 진행될수록 히트맵이 채워진다
+const MEMBER_UNAVAIL: Record<string, string[]> = {
+  yh: ['3-1'],
+  cs: ['2-1', '3-1'],
+  pjm: ['1-1', '3-1'],
+  sj: ['2-1', '3-1'],
+};
+
+// 이 스텝들에서는 "내 일정" 탭을, 나머지는 "전체 일정" 탭을 보여준다
+const MY_TAB_STEP_IDS = new Set(['E-import', 'E-paint', 'E-save']);
+
+function heatColor(unavail: number, total: number): string {
+  if (total === 0) return 'bg-gray-50';
+  if (unavail === 0) return 'bg-[#21a278]';
+  const ratio = unavail / total;
+  if (ratio <= 0.25) return 'bg-[#41b47e]';
+  if (ratio <= 0.5) return 'bg-[#62c784]';
+  if (ratio <= 0.75) return 'bg-[#a3ec8f]';
+  if (ratio < 1) return 'bg-[#c4fe95]';
+  return 'bg-red-500';
+}
+
+/** 일정 상세(ChinbaEventDetailBody 재현) — 내 일정 제출 → 링크 공유 → 완료 처리까지 한 화면 */
+export default function SceneEventDetail({ engine }: { engine: TutorialEngine }) {
+  const { state, dispatch, step } = engine;
+  const [showComplete, setShowComplete] = useState(false);
+
+  const isMyTab = !!step && MY_TAB_STEP_IDS.has(step.id);
+  const total = state.submissions.length;
+  const allSubmitted = total === state.members.length && total > 0;
+
+  const myUnavail = (key: string) =>
+    (state.importedTimetable && TIMETABLE_CELLS.has(key)) || state.paintedCells.includes(key);
+  const unavailCount = (key: string) =>
+    state.submissions.filter((id) =>
+      id === 'me' ? myUnavail(key) : (MEMBER_UNAVAIL[id]?.includes(key) ?? false),
+    ).length;
+
+  return (
+    <SceneFrame title={state.eventTitle || '일정'}>
+      {/* 날짜 요약 + 액션 아이콘 */}
+      <div className="border-b border-gray-100 pb-2">
+        <div className="flex items-center justify-between">
+          <p className="truncate text-[11px] text-gray-500">8/20(목) ~ 8/21(금)</p>
+          <TutorialTarget id="ev-icons" engine={engine}>
+            <div className="flex shrink-0 items-center gap-1 p-0.5">
+              <TutorialTarget id="ev-complete" engine={engine}>
+                <button
+                  type="button"
+                  onClick={() => setShowComplete(true)}
+                  className="rounded-full p-2 text-emerald-600 transition-colors hover:bg-emerald-50"
+                  title="완료 처리"
+                >
+                  <FiCheckCircle size={18} />
+                </button>
+              </TutorialTarget>
+              <TutorialTarget id="ev-share" engine={engine}>
+                <span className="block rounded-full p-2 text-gray-600" title="링크 복사">
+                  <FiLink size={17} />
+                </span>
+              </TutorialTarget>
+              <span className="rounded-full p-2 text-gray-600" title="공유">
+                <FiShare2 size={18} />
+              </span>
+              <span className="rounded-full p-2 text-red-500" title="삭제">
+                <FiTrash2 size={16} />
+              </span>
+            </div>
+          </TutorialTarget>
+        </div>
+      </div>
+
+      {/* 상태 배너 */}
+      {state.eventCompleted && (
+        <div className="border-b border-emerald-100 bg-emerald-50 px-4 py-2">
+          <p className="text-center text-xs font-medium text-emerald-700">완료된 일정입니다</p>
+        </div>
+      )}
+
+      {/* 서브탭 (진행중일 때만) */}
+      {!state.eventCompleted && (
+        <div className="flex border-b border-gray-200">
+          {(
+            [
+              { key: 'team', label: '전체 일정' },
+              { key: 'my', label: '내 일정' },
+            ] as const
+          ).map(({ key, label }) => {
+            const isActive = (key === 'my') === isMyTab;
+            return (
+              <div
+                key={key}
+                className={`relative flex-1 py-2.5 text-center text-sm ${
+                  isActive ? 'font-bold text-gray-900' : 'font-medium text-gray-400'
+                }`}
+              >
+                {label}
+                {isActive && (
+                  <span className="absolute bottom-0 left-1/2 h-0.5 w-16 -translate-x-1/2 rounded-full bg-gray-900" />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {isMyTab ? (
+        /* ── 내 일정 탭 ── */
+        <div className="pt-3">
+          <div className="mb-3 flex items-center justify-between gap-2 rounded-xl border border-emerald-200 bg-emerald-100 px-3 py-2.5">
+            <div className="min-w-0">
+              <p className="text-[11px] font-semibold leading-tight text-emerald-900">
+                불가능한 시간을 칠하세요
+              </p>
+              <p className="mt-0.5 text-[10px] text-emerald-700">빨간색이 불가능한 시간입니다</p>
+            </div>
+            <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[10px] font-medium text-gray-600">
+              드래그 | 직접 입력
+            </span>
+          </div>
+
+          <div className="mb-3 flex items-stretch gap-2">
+            <TutorialTarget id="ev-import" engine={engine} className="flex-1">
+              <span className="flex w-full items-center justify-center gap-1.5 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-[11px] font-medium text-gray-600">
+                <FiUpload size={12} />내 시간표 불러오기
+              </span>
+            </TutorialTarget>
+            <span className="flex shrink-0 items-center justify-center gap-1.5 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-[11px] font-medium text-red-500">
+              <FiRotateCcw size={12} />
+              초기화
+            </span>
+          </div>
+
+          <TutorialTarget id="ev-grid" engine={engine}>
+            <div className="rounded-xl border border-gray-200 p-2">
+              <div className="flex">
+                <div className="w-7 shrink-0" />
+                {DATES.map((label) => (
+                  <div key={label} className="flex flex-1 flex-col items-center justify-center py-1">
+                    <span className="text-[10px] text-gray-400">{label.split(' ')[0]}</span>
+                    <span className="text-xs font-medium text-gray-700">{label.split(' ')[1]}</span>
+                  </div>
+                ))}
+              </div>
+              {ROWS.map((label, row) => (
+                <div key={row} className="flex">
+                  <div className="flex w-7 shrink-0 items-center justify-start">
+                    {label && <span className="-mt-2 text-[10px] text-gray-400">{label}</span>}
+                  </div>
+                  {[0, 1].map((col) => {
+                    const key = `${row}-${col}`;
+                    return (
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() => dispatch({ type: 'TOGGLE_CELL', key })}
+                        className={`h-6 flex-1 border-t border-gray-100 transition-colors ${
+                          col === 0 ? 'border-r' : ''
+                        } ${myUnavail(key) ? 'bg-red-400' : 'bg-white hover:bg-red-50'}`}
+                        aria-label={`${DATES[col]} ${row}번째 칸`}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+              <div className="mt-2 flex items-center justify-center gap-3 text-[10px] text-gray-400">
+                <span className="flex items-center gap-1">
+                  <span className="inline-block h-2.5 w-2.5 rounded-sm border border-gray-200 bg-white" />
+                  가능
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="inline-block h-2.5 w-2.5 rounded-sm bg-red-400" />
+                  불가능
+                </span>
+              </div>
+            </div>
+          </TutorialTarget>
+
+          <div className="mt-3 border-t border-gray-100 pt-3">
+            <TutorialTarget id="ev-save" engine={engine}>
+              <div className="w-full rounded-xl bg-gray-900 py-3 text-center text-base font-semibold text-white">
+                저장하기
+              </div>
+            </TutorialTarget>
+          </div>
+        </div>
+      ) : (
+        /* ── 전체 일정 탭 ── */
+        <div className="pt-3">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs font-bold text-gray-500">
+              참여자 ({total}/{state.members.length} 제출)
+            </span>
+            {state.members.map((member) => {
+              const submitted = state.submissions.includes(member.id);
+              return (
+                <span
+                  key={member.id}
+                  className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs transition-colors ${
+                    submitted ? 'bg-emerald-50 text-emerald-700' : 'bg-gray-100 text-gray-400'
+                  }`}
+                >
+                  {submitted && <FiCheck size={10} />}
+                  {member.name}
+                </span>
+              );
+            })}
+          </div>
+
+          <div className="mt-3">
+            {total === 0 ? (
+              <div className="rounded-xl border border-gray-100 bg-gray-50 py-8 text-center">
+                <p className="text-sm text-gray-400">아직 제출한 사람이 없습니다</p>
+                <p className="mt-1 text-xs text-gray-300">링크를 공유해 시간을 모아보세요</p>
+              </div>
+            ) : (
+              <div>
+                <div className="flex">
+                  <div className="w-7 shrink-0" />
+                  {DATES.map((label) => (
+                    <div key={label} className="flex flex-1 flex-col items-center justify-center py-1">
+                      <span className="text-[10px] text-gray-400">{label.split(' ')[0]}</span>
+                      <span className="text-xs font-medium text-gray-700">{label.split(' ')[1]}</span>
+                    </div>
+                  ))}
+                </div>
+                {ROWS.map((label, row) => (
+                  <div key={row} className="flex">
+                    <div className="flex w-7 shrink-0 items-center justify-start">
+                      {label && <span className="-mt-2 text-[10px] text-gray-400">{label}</span>}
+                    </div>
+                    {[0, 1].map((col) => {
+                      const key = `${row}-${col}`;
+                      const unavail = unavailCount(key);
+                      const avail = total - unavail;
+                      return (
+                        <div
+                          key={key}
+                          className={`flex h-[22px] flex-1 items-center justify-center border-t border-gray-100 transition-colors ${
+                            col === 0 ? 'border-r' : ''
+                          } ${heatColor(unavail, total)}`}
+                        >
+                          {avail > 0 && (
+                            <span className="text-[9px] font-bold text-gray-800">{avail}</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+                <div className="mt-2 flex items-center justify-center gap-2 px-2">
+                  <span className="text-[10px] text-gray-400">가능</span>
+                  <div className="h-3 w-4 rounded-sm bg-[#21a278]" />
+                  <div className="h-3 w-4 rounded-sm bg-[#41b47e]" />
+                  <div className="h-3 w-4 rounded-sm bg-[#62c784]" />
+                  <div className="h-3 w-4 rounded-sm bg-[#a3ec8f]" />
+                  <div className="h-3 w-4 rounded-sm bg-[#c4fe95]" />
+                  <div className="h-3 w-4 rounded-sm bg-red-500" />
+                  <span className="text-[10px] text-gray-400">불가</span>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {allSubmitted && !state.eventCompleted && (
+            <div className="mt-4 animate-fadeIn">
+              <h4 className="mb-2 text-xs font-bold text-gray-500">추천 시간</h4>
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3">
+                <div className="flex items-center gap-1.5">
+                  <FiClock size={14} className="text-emerald-600" />
+                  <span className="text-sm font-bold text-emerald-700">8/20(목) 18:00~19:00</span>
+                </div>
+                <p className="mt-1 text-xs text-emerald-600">{total}명 전원 가능</p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <TutorialConfirmModal
+        isOpen={showComplete}
+        title="일정 완료"
+        confirmLabel="완료 처리"
+        onConfirm={() => {
+          setShowComplete(false);
+          dispatch({ type: 'COMPLETE_EVENT' });
+        }}
+        onCancel={() => setShowComplete(false)}
+      >
+        이 일정을 완료 처리하시겠습니까?
+      </TutorialConfirmModal>
+    </SceneFrame>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneGroups.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneGroups.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { FiPlus } from 'react-icons/fi';
+
+import SceneFrame from '../SceneFrame';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+/**
+ * 조 편성(GroupManageView + GroupSettingsSection 재현) — 세 화면을 스텝에 따라 전환:
+ * ① 그룹세트 이름 입력(G-setname) → ② 조 편성(G-add1~G-save) → ③ 그룹세트 목록(G-set2)
+ */
+export default function SceneGroups({ engine }: { engine: TutorialEngine }) {
+  const { state, dispatch, step } = engine;
+  const stepId = step?.id ?? '';
+
+  const nameOf = (id: string) => state.members.find((m) => m.id === id)?.name ?? id;
+  const unassigned = state.members.filter(
+    (m) => !state.group1Ids.includes(m.id) && !state.group2Ids.includes(m.id),
+  );
+  const setName = state.groupSetName.trim() || '그룹세트';
+
+  /* ── ① 그룹세트 이름 입력 ── */
+  if (stepId === 'G-setname') {
+    return (
+      <SceneFrame title="조 편성">
+        <label className="mb-2 block text-sm font-bold text-gray-700">새 그룹세트</label>
+        <p className="mb-3 text-xs text-gray-400">
+          조 편성 한 벌의 이름이에요. 활동 이름으로 지으면 알아보기 쉬워요.
+        </p>
+        <TutorialTarget id="grp-set-name" engine={engine}>
+          <input
+            type="text"
+            value={state.groupSetName}
+            onChange={(e) => dispatch({ type: 'SET_GROUP_SET_NAME', value: e.target.value })}
+            placeholder="예: 친바, 스터디, 프로젝트"
+            maxLength={30}
+            className="w-full rounded-xl border border-gray-200 px-4 py-3 text-sm text-gray-800 placeholder-gray-400 outline-none transition-colors focus:border-gray-900"
+          />
+        </TutorialTarget>
+        <div className="mt-6 border-t border-gray-100 pt-3">
+          <div
+            className={`w-full rounded-xl py-3 text-center text-base font-semibold text-white ${
+              state.groupSetName.trim() ? 'bg-gray-900' : 'bg-gray-300'
+            }`}
+          >
+            다음
+          </div>
+        </div>
+      </SceneFrame>
+    );
+  }
+
+  /* ── ③ 그룹세트 목록 ── */
+  if (stepId === 'G-set2') {
+    return (
+      <SceneFrame title="조 / 그룹 관리">
+        <div className="space-y-3">
+          <div className="rounded-xl border border-gray-200 p-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-bold text-gray-800">{setName}</span>
+              <span className="text-[11px] text-gray-400">2개 조</span>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-600">
+                1조({state.group1Ids.length})
+              </span>
+              <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-600">
+                2조({state.group2Ids.length})
+              </span>
+            </div>
+            <div className="mt-3 flex gap-1.5 text-[11px] text-gray-400">
+              <span>이름변경</span>·<span>조 수정</span>·<span>재편성</span>·<span>삭제</span>
+            </div>
+          </div>
+
+          {state.studySetCreated && (
+            <div className="animate-fadeIn rounded-xl border border-gray-200 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-bold text-gray-800">스터디</span>
+                <span className="text-[11px] text-gray-400">2개 조</span>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-600">
+                  월요일반(3)
+                </span>
+                <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs text-gray-600">
+                  수요일반(2)
+                </span>
+              </div>
+            </div>
+          )}
+
+          <TutorialTarget id="grp-newset" engine={engine}>
+            <div className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-3 text-sm font-medium text-gray-500">
+              <FiPlus size={16} />새 그룹 생성
+            </div>
+          </TutorialTarget>
+        </div>
+      </SceneFrame>
+    );
+  }
+
+  /* ── ② 조 편성 ── */
+  const groupCards: { name: string; ids: string[] }[] = [];
+  if (state.groupsCreated >= 1) groupCards.push({ name: '1조', ids: state.group1Ids });
+  if (state.groupsCreated >= 2) groupCards.push({ name: '2조', ids: state.group2Ids });
+
+  return (
+    <SceneFrame title={`조 편성 — ${setName}`}>
+      <div className="space-y-3">
+        {groupCards.map((group, idx) => (
+          <div key={group.name} className="animate-fadeIn rounded-xl border border-gray-200 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm font-bold text-gray-800">{group.name}</span>
+              {group.ids.length === 0 && <span className="text-[11px] text-red-400">멤버 필요</span>}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {group.ids.map((id, memberIdx) => (
+                <span
+                  key={id}
+                  className={`inline-flex animate-fadeIn items-center rounded-full px-2.5 py-1 text-xs font-medium ${
+                    memberIdx === 0 ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  {nameOf(id)}
+                  {memberIdx === 0 && ' ★'}
+                </span>
+              ))}
+            </div>
+            {idx === 0 && (
+              <TutorialTarget id="grp-fill" engine={engine} className="mt-2 inline-block">
+                <span className="px-1 text-xs font-medium text-gray-400">
+                  <FiPlus className="mr-0.5 inline" size={12} />
+                  멤버 추가
+                </span>
+              </TutorialTarget>
+            )}
+          </div>
+        ))}
+
+        {state.groupsCreated < 2 && (
+          <TutorialTarget id="grp-add" engine={engine}>
+            <div className="w-full rounded-xl border-2 border-dashed border-gray-200 py-3 text-center text-sm font-medium text-gray-400">
+              <FiPlus className="mr-1 inline" size={14} />새 조 추가
+            </div>
+          </TutorialTarget>
+        )}
+
+        {unassigned.length > 0 && (
+          <div className="rounded-xl border border-dashed border-gray-300 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-xs font-medium text-gray-500">미배정 멤버</span>
+              <span className="text-[11px] text-gray-400">눌러서 조에 배정</span>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {unassigned.map((m) => (
+                <span key={m.id} className="rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-500">
+                  {m.name}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 border-t border-gray-100 pt-3">
+        <div className="flex gap-2">
+          <div className="flex-1 rounded-lg border border-gray-200 py-3 text-center text-base font-semibold text-gray-700">
+            돌아가기
+          </div>
+          <TutorialTarget id="grp-save" engine={engine} className="flex-1">
+            <div
+              className={`w-full rounded-lg py-3 text-center text-base font-semibold text-white ${
+                unassigned.length === 0 && state.groupsCreated === 2 ? 'bg-gray-900' : 'bg-gray-300'
+              }`}
+            >
+              저장하기
+            </div>
+          </TutorialTarget>
+        </div>
+      </div>
+    </SceneFrame>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneMembersModal.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneMembersModal.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { FiSearch, FiUser, FiUsers, FiX } from 'react-icons/fi';
+
+import { TutorialTarget } from '../Spotlight';
+import type { MemberRole } from '../types';
+import type { TutorialEngine } from '../useTutorialEngine';
+import SceneClubHome from './SceneClubHome';
+
+const ROLE_BADGE: Record<MemberRole, string> = {
+  회장: 'bg-red-100 text-red-700',
+  부회장: 'bg-orange-100 text-orange-700',
+  운영진: 'bg-blue-100 text-blue-700',
+  회원: 'bg-gray-100 text-gray-500',
+};
+
+/**
+ * 동아리 상세 위에 뜨는 멤버 관리 모달(TeamMembersModal 재현).
+ * 모달을 z-[85]로 스포트라이트 오버레이(z-80)보다 위에 두고,
+ * 이 장면의 스텝들은 overlay:false — 모달 자체 백드롭이 클릭 게이팅을 담당한다.
+ */
+export default function SceneMembersModal({ engine }: { engine: TutorialEngine }) {
+  const { state, dispatch } = engine;
+
+  return (
+    <>
+      <SceneClubHome engine={engine} />
+
+      <div className="fixed inset-0 z-[85] flex items-center justify-center bg-black/40 p-4">
+        <div className="flex max-h-[80vh] w-full max-w-md flex-col overflow-visible rounded-2xl bg-white shadow-xl">
+          {/* 헤더 */}
+          <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+            <h2 className="flex items-center gap-2 text-base font-bold text-gray-900">
+              <FiUsers size={18} className="text-gray-500" />
+              멤버 관리
+              <span className="text-xs font-normal text-gray-400">{state.members.length}명</span>
+            </h2>
+            <TutorialTarget id="mem-close" engine={engine}>
+              <span className="block cursor-pointer rounded-full p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700">
+                <FiX size={18} />
+              </span>
+            </TutorialTarget>
+          </div>
+
+          {/* 본문 */}
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <div className="relative mb-3">
+              <FiSearch
+                size={15}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-300"
+              />
+              <div className="w-full rounded-xl border border-gray-200 py-2.5 pl-9 pr-3 text-sm text-gray-400">
+                이름 검색
+              </div>
+            </div>
+            <div className="space-y-1">
+              {state.members.map((member) => {
+                const isMe = member.id === 'me';
+                const row = (
+                  <div className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-gray-50">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-100 bg-gray-50 text-gray-400">
+                      <FiUser size={16} />
+                    </div>
+                    <p className="min-w-0 flex-1 truncate text-sm font-medium text-gray-800">
+                      {member.name}
+                      {isMe && <span className="ml-1 text-[11px] text-gray-400">(나)</span>}
+                    </p>
+                    {isMe ? (
+                      <span
+                        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${ROLE_BADGE[member.role]}`}
+                      >
+                        {member.role}
+                      </span>
+                    ) : (
+                      <>
+                        <select
+                          value={member.role}
+                          onChange={(e) =>
+                            dispatch({
+                              type: 'SET_ROLE',
+                              id: member.id,
+                              role: e.target.value as MemberRole,
+                            })
+                          }
+                          className="rounded-lg border border-gray-200 px-2 py-1 text-xs font-medium text-gray-700 outline-none transition-colors focus:border-gray-900"
+                          aria-label={`${member.name} 역할`}
+                        >
+                          <option value="회원">회원</option>
+                          <option value="운영진">운영진</option>
+                          <option value="부회장">부회장</option>
+                        </select>
+                        <span className="shrink-0 rounded-lg px-2 py-1 text-xs font-medium text-red-400">
+                          내보내기
+                        </span>
+                      </>
+                    )}
+                  </div>
+                );
+                return member.id === 'yh' ? (
+                  <TutorialTarget key={member.id} id="mem-role" engine={engine}>
+                    {row}
+                  </TutorialTarget>
+                ) : (
+                  <div key={member.id}>{row}</div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneRecordForm.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneRecordForm.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { LuPencil } from 'react-icons/lu';
+
+import ClubShell from '../ClubShell';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+/**
+ * 기록 탭 위에 자동으로 열린 활동 기록 폼(ActivityTab 기록 모달 재현).
+ * 모달 z-[85] + 이 장면의 스텝은 overlay:false — 모달 백드롭이 게이팅 담당.
+ */
+export default function SceneRecordForm({ engine }: { engine: TutorialEngine }) {
+  const { state, dispatch } = engine;
+  const canSave = state.record.title.trim().length > 0 && state.record.desc.trim().length > 0;
+
+  return (
+    <>
+      <ClubShell engine={engine} tab="mwoheni">
+        <div className="py-10 text-center">
+          <p className="text-sm text-gray-400">일정을 완료하면 기록 폼이 자동으로 열려요</p>
+        </div>
+      </ClubShell>
+
+      <div className="fixed inset-0 z-[85] flex items-center justify-center bg-black/40 p-4">
+        {/* 본문에 overflow를 걸지 않는다 — 말풍선(absolute)이 잘리면 [다음] 버튼이 클릭 불가가 된다 */}
+        <div className="flex w-full max-w-md flex-col rounded-2xl bg-white shadow-xl">
+          <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4">
+            <h2 className="flex items-center gap-2 text-base font-bold text-gray-900">
+              <LuPencil size={16} className="text-gray-500" />
+              활동 기록하기
+            </h2>
+          </div>
+
+          <div className="px-5 py-4">
+            <TutorialTarget id="rec-form" engine={engine}>
+              <div className="space-y-3 p-1">
+                <input
+                  type="text"
+                  value={state.record.title}
+                  onChange={(e) => dispatch({ type: 'SET_RECORD', patch: { title: e.target.value } })}
+                  placeholder="활동 제목"
+                  maxLength={100}
+                  className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-gray-400"
+                />
+                <div className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+                  2026-08-20
+                </div>
+                <div className="flex gap-2">
+                  <div className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+                    18:00
+                  </div>
+                  <div className="flex-1 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800">
+                    19:00
+                  </div>
+                </div>
+                <div>
+                  <p className="mb-1 text-xs font-medium text-gray-500">활동 설명</p>
+                  <textarea
+                    value={state.record.desc}
+                    onChange={(e) => dispatch({ type: 'SET_RECORD', patch: { desc: e.target.value } })}
+                    placeholder="무엇을 했는지 적어주세요"
+                    rows={2}
+                    className="w-full resize-none rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-gray-400"
+                  />
+                </div>
+                <div>
+                  <p className="mb-1 text-xs font-medium text-gray-500">사용 금액 (선택)</p>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={state.record.amount}
+                    onChange={(e) =>
+                      dispatch({
+                        type: 'SET_RECORD',
+                        patch: { amount: e.target.value.replace(/[^0-9,]/g, '') },
+                      })
+                    }
+                    placeholder="예: 24,000"
+                    className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm outline-none focus:border-gray-400"
+                  />
+                </div>
+              </div>
+            </TutorialTarget>
+
+            <div className="mt-4 flex gap-2">
+              <div className="flex-1 rounded-lg bg-gray-200 py-2 text-center text-sm font-medium text-gray-600">
+                기록하지 않기
+              </div>
+              <TutorialTarget id="rec-save" engine={engine} className="flex-1">
+                <div
+                  className={`w-full rounded-lg py-2 text-center text-sm font-medium text-white ${
+                    canSave ? 'bg-gray-900' : 'bg-gray-300'
+                  }`}
+                >
+                  기록하기
+                </div>
+              </TutorialTarget>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneRecords.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneRecords.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { LuCalendar, LuClock } from 'react-icons/lu';
+
+import ClubShell from '../ClubShell';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+/** 동아리 상세 기록 탭 — 방금 작성한 기록이 카드로 쌓인 모습 (ActivityCard 재현) */
+export default function SceneRecords({ engine }: { engine: TutorialEngine }) {
+  const { state } = engine;
+  const amount = state.record.amount.replace(/,/g, '');
+
+  return (
+    <ClubShell engine={engine} tab="mwoheni">
+      <TutorialTarget id="rec-card" engine={engine}>
+        <div className="rounded-xl border border-gray-100 bg-white p-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <p className="text-sm font-bold text-gray-800">{state.record.title || '활동 기록'}</p>
+              <div className="mt-1 flex items-center gap-2 text-[11px] text-gray-400">
+                <span className="inline-flex items-center gap-0.5">
+                  <LuCalendar size={11} /> 2026-08-20
+                </span>
+                <span className="inline-flex items-center gap-0.5">
+                  <LuClock size={11} /> 18:00~19:00
+                </span>
+              </div>
+            </div>
+            <span className="shrink-0 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              1조
+            </span>
+          </div>
+          {state.record.desc && <p className="mt-2 text-xs text-gray-600">{state.record.desc}</p>}
+          <div className="mt-2 flex items-center gap-2">
+            {amount && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-gray-50 px-2.5 py-1 text-xs text-gray-600">
+                💸 {Number(amount).toLocaleString()}원
+              </span>
+            )}
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500">
+              기록: 홍길동
+            </span>
+          </div>
+        </div>
+      </TutorialTarget>
+    </ClubShell>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/scenes/SceneTimetable.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/scenes/SceneTimetable.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { Fragment } from 'react';
+
+import { FiUpload } from 'react-icons/fi';
+
+import SceneFrame from '../SceneFrame';
+import { TutorialTarget } from '../Spotlight';
+import type { TutorialEngine } from '../useTutorialEngine';
+
+const HOURS = ['9시', '10시', '11시'];
+// 업로드 후 채워지는 가짜 수업 배치: [row][col]
+const CLASSES: Record<string, string> = {
+  '0-1': '자료구조',
+  '1-1': '자료구조',
+  '1-3': '운영체제',
+  '2-0': '선형대수',
+};
+
+/** 부원 트랙 2: 내 시간표 (TimetableTab 재현 — 에브리타임 업로드 → AI 분석 연출) */
+export default function SceneTimetable({ engine }: { engine: TutorialEngine }) {
+  const loaded = engine.state.timetableLoaded;
+  return (
+    <SceneFrame title="내 시간표">
+      <div className="flex items-center justify-between pb-2">
+        <span className="rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs font-medium text-gray-700">
+          2학기 ▾
+        </span>
+        <TutorialTarget id="tt-upload" engine={engine}>
+          <span className="flex items-center gap-1 rounded-lg bg-gray-100 px-2.5 py-1.5 text-xs font-medium text-gray-600">
+            <FiUpload size={12} />
+            에브리타임 시간표 업로드
+          </span>
+        </TutorialTarget>
+      </div>
+      <div className="rounded-xl border border-gray-200 bg-white p-2">
+        <div className="grid grid-cols-6 gap-px text-center">
+          <div />
+          {['월', '화', '수', '목', '금'].map((d) => (
+            <div key={d} className="py-1 text-[10px] font-medium text-gray-400">
+              {d}
+            </div>
+          ))}
+          {HOURS.map((hour, row) => (
+            <Fragment key={hour}>
+              <div className="py-2 pr-1 text-right text-[10px] text-gray-400">{hour}</div>
+              {[0, 1, 2, 3, 4].map((col) => {
+                const label = loaded ? CLASSES[`${row}-${col}`] : undefined;
+                return (
+                  <div
+                    key={`${hour}-${col}`}
+                    className={`flex h-9 items-center justify-center rounded-sm border border-gray-100 ${
+                      label ? 'animate-fadeIn bg-blue-100' : 'bg-white'
+                    }`}
+                  >
+                    {label && <span className="text-[8px] font-medium text-blue-700">{label}</span>}
+                  </div>
+                );
+              })}
+            </Fragment>
+          ))}
+        </div>
+        <p className="mt-2 text-center text-[10px] text-gray-300">
+          {loaded ? '수업이 자동으로 채워졌어요' : '드래그하여 내 고정 일정 추가/수정'}
+        </p>
+      </div>
+    </SceneFrame>
+  );
+}

--- a/app/(main)/chinba/guide/tutorial/_components/state.ts
+++ b/app/(main)/chinba/guide/tutorial/_components/state.ts
@@ -1,0 +1,88 @@
+import type { TutorialAction, TutorialState } from './types';
+
+export const ME_ID = 'me';
+
+export const initialTutorialState: TutorialState = {
+  clubName: '',
+  category: null,
+  members: [],
+  groupSetName: '',
+  groupsCreated: 0,
+  group1Ids: [],
+  group2Ids: [],
+  groupSaved: false,
+  studySetCreated: false,
+  eventTitle: '',
+  eventDates: [],
+  submissions: [],
+  eventCompleted: false,
+  record: { title: '', desc: '', amount: '' },
+  savedRecord: false,
+  timetableLoaded: false,
+  importedTimetable: false,
+  paintedCells: [],
+};
+
+export function tutorialReducer(state: TutorialState, action: TutorialAction): TutorialState {
+  switch (action.type) {
+    case 'SET_CLUB_NAME':
+      return { ...state, clubName: action.value };
+    case 'SET_CATEGORY':
+      return { ...state, category: action.value };
+    case 'ADD_MEMBER':
+      if (state.members.some((m) => m.id === action.member.id)) return state;
+      return { ...state, members: [...state.members, action.member] };
+    case 'SET_ROLE':
+      return {
+        ...state,
+        members: state.members.map((m) => (m.id === action.id ? { ...m, role: action.role } : m)),
+      };
+    case 'SET_GROUP_SET_NAME':
+      return { ...state, groupSetName: action.value };
+    case 'CREATE_GROUP':
+      return { ...state, groupsCreated: Math.min(state.groupsCreated + 1, 2) };
+    case 'ASSIGN_MEMBER': {
+      if (state.group1Ids.includes(action.id) || state.group2Ids.includes(action.id)) return state;
+      return action.group === 1
+        ? { ...state, group1Ids: [...state.group1Ids, action.id] }
+        : { ...state, group2Ids: [...state.group2Ids, action.id] };
+    }
+    case 'SAVE_GROUPS':
+      return { ...state, groupSaved: true };
+    case 'CREATE_STUDY_SET':
+      return { ...state, studySetCreated: true };
+    case 'SET_EVENT_TITLE':
+      return { ...state, eventTitle: action.value };
+    case 'TOGGLE_DATE':
+      return {
+        ...state,
+        eventDates: state.eventDates.includes(action.day)
+          ? state.eventDates.filter((d) => d !== action.day)
+          : [...state.eventDates, action.day].sort((a, b) => a - b),
+      };
+    case 'ADD_SUBMISSION':
+      if (state.submissions.includes(action.id)) return state;
+      return { ...state, submissions: [...state.submissions, action.id] };
+    case 'COMPLETE_EVENT':
+      return { ...state, eventCompleted: true };
+    case 'SET_RECORD':
+      return { ...state, record: { ...state.record, ...action.patch } };
+    case 'SAVE_RECORD':
+      return { ...state, savedRecord: true };
+    case 'LOAD_TIMETABLE':
+      return { ...state, timetableLoaded: true };
+    case 'IMPORT_TIMETABLE':
+      return { ...state, importedTimetable: true };
+    case 'TOGGLE_CELL':
+      return {
+        ...state,
+        paintedCells: state.paintedCells.includes(action.key)
+          ? state.paintedCells.filter((k) => k !== action.key)
+          : [...state.paintedCells, action.key],
+      };
+    case 'RESET':
+      return initialTutorialState;
+    default:
+      return state;
+  }
+}

--- a/app/(main)/chinba/guide/tutorial/_components/tracks.tsx
+++ b/app/(main)/chinba/guide/tutorial/_components/tracks.tsx
@@ -1,0 +1,343 @@
+import { ME_ID } from './state';
+import type { TutorialStep } from './types';
+
+/**
+ * 통합 튜토리얼 대본 — 회장 플로우를 기본으로, 일정 생성과 기록 사이에
+ * 참가자(부원) 플로우(시간표 등록 → 내 시간 제출)를 끼워 넣었다.
+ */
+export const TUTORIAL_STEPS: TutorialStep[] = [
+  // ── 1. 동아리 만들기 ──
+  {
+    id: 'C-name',
+    scene: 'createClub',
+    target: 'cc-name',
+    bubble: { content: <>동아리 이름을 지어주세요. 아무 이름이나 좋아요!</>, placement: 'bottom' },
+    advance: { kind: 'next', enabledWhen: (s) => s.clubName.trim().length > 0 },
+  },
+  {
+    id: 'C-category',
+    scene: 'createClub',
+    target: 'cc-category',
+    bubble: { content: <>카테고리를 하나 골라보세요.</>, placement: 'bottom' },
+    advance: { kind: 'state', when: (s) => s.category !== null },
+  },
+  {
+    id: 'C-create',
+    scene: 'createClub',
+    target: 'cc-create',
+    bubble: { content: <>[만들기]를 누르면 동아리가 생겨요.</>, placement: 'top' },
+    advance: { kind: 'click', enabledWhen: (s) => s.clubName.trim().length > 0 },
+    onComplete: [{ type: 'ADD_MEMBER', member: { id: ME_ID, name: '홍길동', role: '회장' } }],
+    script: [{ delayMs: 0, toast: { message: '동아리가 생성되었습니다', type: 'success' } }],
+  },
+  // ── 2. 초대링크로 부원 초대 ──
+  {
+    id: 'I-copy',
+    scene: 'clubHome',
+    target: 'ops-invite',
+    bubble: {
+      content: <>여기가 동아리 홈이에요. 오른쪽 운영 패널에서 <strong>[초대링크 복사]</strong>를 눌러 단톡방에 붙여넣어 보세요.</>,
+      placement: 'bottom',
+    },
+    advance: { kind: 'click' },
+    script: [{ delayMs: 0, toast: { message: '초대 링크가 복사되었습니다', type: 'success' } }],
+  },
+  {
+    id: 'I-join',
+    scene: 'clubHome',
+    target: 'ops-members',
+    bubble: { content: <>링크를 받은 부원들이 들어오고 있어요!</>, placement: 'bottom' },
+    advance: { kind: 'auto' },
+    script: [
+      { delayMs: 600, action: { type: 'ADD_MEMBER', member: { id: 'yh', name: '이영희', role: '회원' } }, toast: { message: '이영희님이 가입했어요 🎉', type: 'info' } },
+      { delayMs: 1500, action: { type: 'ADD_MEMBER', member: { id: 'cs', name: '김철수', role: '회원' } }, toast: { message: '김철수님이 가입했어요 🎉', type: 'info' } },
+      { delayMs: 2400, action: { type: 'ADD_MEMBER', member: { id: 'pjm', name: '박지민', role: '회원' } }, toast: { message: '박지민님이 가입했어요 🎉', type: 'info' } },
+      { delayMs: 3300, action: { type: 'ADD_MEMBER', member: { id: 'sj', name: '최수진', role: '회원' } }, toast: { message: '최수진님이 가입했어요 🎉', type: 'info' } },
+    ],
+  },
+  // ── 3. 멤버 관리 — 임원진 부여 ──
+  {
+    id: 'M-open',
+    scene: 'clubHome',
+    target: 'ops-members',
+    bubble: { content: <>다 모였네요. <strong>[멤버 관리]</strong>를 눌러볼까요?</>, placement: 'bottom' },
+    advance: { kind: 'click' },
+  },
+  {
+    id: 'M-role',
+    scene: 'membersModal',
+    target: 'mem-role',
+    overlay: false,
+    bubble: {
+      content: <>이영희님의 역할 메뉴를 눌러 <strong>부회장</strong>으로 바꿔보세요.</>,
+      placement: 'bottom',
+    },
+    advance: { kind: 'state', when: (s) => s.members.some((m) => m.id === 'yh' && m.role === '부회장') },
+    script: [{ delayMs: 0, toast: { message: '역할이 변경되었습니다', type: 'success' } }],
+  },
+  {
+    id: 'M-close',
+    scene: 'membersModal',
+    target: 'mem-close',
+    overlay: false,
+    bubble: { content: <>뱃지가 주황색(부회장)으로 바뀌었죠? 닫고 다음으로!</>, placement: 'bottom', align: 'right' },
+    advance: { kind: 'click' },
+  },
+  // ── 4. 그룹 만들고 조 짜기 ──
+  {
+    id: 'G-nav',
+    scene: 'clubHome',
+    target: 'ops-groups',
+    bubble: { content: <>이번엔 조 편성이에요. <strong>[조 / 그룹 관리]</strong>로 들어가요.</>, placement: 'bottom' },
+    advance: { kind: 'click' },
+  },
+  {
+    id: 'G-setname',
+    scene: 'groups',
+    target: 'grp-set-name',
+    bubble: {
+      content: <>조 편성은 <strong>그룹세트</strong> 단위로 묶여요. 먼저 세트 이름을 지어요 — 정기모임용이라면 &lsquo;친바&rsquo;라고 적어볼까요?</>,
+      placement: 'bottom',
+    },
+    advance: { kind: 'next', enabledWhen: (s) => s.groupSetName.trim().length > 0 },
+  },
+  {
+    id: 'G-add1',
+    scene: 'groups',
+    target: 'grp-add',
+    bubble: { content: <>[새 조 추가]를 눌러 <strong>1조</strong>를 만들어보세요.</>, placement: 'bottom' },
+    advance: { kind: 'click' },
+    onComplete: [{ type: 'CREATE_GROUP' }, { type: 'ASSIGN_MEMBER', id: ME_ID, group: 1 }],
+  },
+  {
+    id: 'G-add2',
+    scene: 'groups',
+    target: 'grp-add',
+    bubble: { content: <>한 번 더! <strong>2조</strong>도 만들어요. 조장은 이영희님에게 맡길게요.</>, placement: 'bottom' },
+    advance: { kind: 'click' },
+    onComplete: [{ type: 'CREATE_GROUP' }, { type: 'ASSIGN_MEMBER', id: 'yh', group: 2 }],
+  },
+  {
+    id: 'G-fill',
+    scene: 'groups',
+    target: 'grp-fill',
+    bubble: { content: <>[멤버 추가]를 눌러 나머지 부원들을 두 조에 나눠 담아요.</>, placement: 'bottom' },
+    advance: { kind: 'click' },
+    script: [
+      { delayMs: 300, action: { type: 'ASSIGN_MEMBER', id: 'cs', group: 1 } },
+      { delayMs: 800, action: { type: 'ASSIGN_MEMBER', id: 'pjm', group: 2 } },
+      { delayMs: 1300, action: { type: 'ASSIGN_MEMBER', id: 'sj', group: 2 }, toast: { message: '모든 멤버가 배정되었어요', type: 'success' } },
+    ],
+  },
+  {
+    id: 'G-save',
+    scene: 'groups',
+    target: 'grp-save',
+    bubble: { content: <>[저장하기]를 누르면 조 편성 완료!</>, placement: 'top' },
+    advance: { kind: 'click' },
+    onComplete: [{ type: 'SAVE_GROUPS' }],
+    script: [{ delayMs: 0, toast: { message: '조 편성이 저장되었습니다', type: 'success' } }],
+  },
+  {
+    id: 'G-set2',
+    scene: 'groups',
+    target: 'grp-newset',
+    bubble: {
+      content: <>그룹세트는 여러 개 둘 수 있어요. 같은 멤버로 <strong>&lsquo;스터디&rsquo;용 조</strong>를 따로 짜는 거죠. [새 그룹 생성]을 눌러보세요.</>,
+      placement: 'bottom',
+    },
+    advance: { kind: 'click' },
+    script: [
+      { delayMs: 400, action: { type: 'CREATE_STUDY_SET' }, toast: { message: "'스터디' 그룹세트가 만들어졌어요", type: 'success' } },
+      { delayMs: 1800, toast: { message: '이렇게 목적별로 조 편성을 따로 가질 수 있어요', type: 'info' } },
+    ],
+  },
+  // ── 5. 일정 만들기 ──
+  {
+    id: 'E-nav',
+    scene: 'clubHome',
+    target: 'home-create-event',
+    bubble: { content: <>준비 끝! 이제 <strong>[일정 잡기]</strong>로 모임을 만들어봐요.</>, placement: 'bottom' },
+    advance: { kind: 'click' },
+  },
+  {
+    id: 'E-title',
+    scene: 'eventCreate',
+    target: 'ev-title',
+    bubble: { content: <>모임 이름을 적어주세요.</>, placement: 'bottom' },
+    advance: { kind: 'next', enabledWhen: (s) => s.eventTitle.trim().length > 0 },
+  },
+  {
+    id: 'E-dates',
+    scene: 'eventCreate',
+    target: 'ev-dates',
+    bubble: {
+      content: <>되는 후보 날짜를 <strong>두 개</strong> 골라보세요 (20·21·22일 중).</>,
+      placement: 'top',
+    },
+    advance: { kind: 'state', when: (s) => s.eventDates.length >= 2 },
+  },
+  {
+    id: 'E-create',
+    scene: 'eventCreate',
+    target: 'ev-create',
+    bubble: { content: <>[만들기]로 일정을 만들어요.</>, placement: 'top' },
+    advance: {
+      kind: 'click',
+      enabledWhen: (s) => s.eventTitle.trim().length > 0 && s.eventDates.length >= 2,
+    },
+    script: [{ delayMs: 0, toast: { message: '일정이 만들어졌습니다', type: 'success' } }],
+  },
+  // ── 6. 참가자 입장 — 내 시간 제출 (회장도 참가자!) ──
+  {
+    id: 'T-upload',
+    scene: 'timetable',
+    target: 'tt-upload',
+    bubble: {
+      content: <>회장도 참가자예요. 먼저 MY 탭의 내 시간표에서 <strong>에브리타임 캡처</strong>를 올려두면 AI가 알아서 읽어줘요.</>,
+      placement: 'bottom',
+      align: 'right',
+    },
+    advance: { kind: 'click' },
+    script: [
+      { delayMs: 0, toast: { message: '시간표를 분석하고 있어요...', type: 'info' } },
+      { delayMs: 1500, action: { type: 'LOAD_TIMETABLE' }, toast: { message: '수업 4개를 등록했어요', type: 'success' } },
+    ],
+  },
+  {
+    id: 'E-import',
+    scene: 'eventDetail',
+    target: 'ev-import',
+    bubble: {
+      content: <>일정의 <strong>내 일정</strong> 탭이에요. [내 시간표 불러오기]를 누르면 수업 시간이 자동으로 불가능 처리돼요.</>,
+      placement: 'bottom',
+    },
+    advance: { kind: 'click' },
+    onComplete: [{ type: 'IMPORT_TIMETABLE' }],
+    script: [{ delayMs: 0, toast: { message: '시간표에서 2개 슬롯을 불러왔습니다', type: 'success' } }],
+  },
+  {
+    id: 'E-paint',
+    scene: 'eventDetail',
+    target: 'ev-grid',
+    bubble: {
+      content: <>알바나 약속이 있는 시간은 칸을 눌러 직접 칠해보세요. 빨간색이 안 되는 시간이에요.</>,
+      placement: 'top',
+    },
+    advance: { kind: 'state', when: (s) => s.paintedCells.length >= 1 },
+  },
+  {
+    id: 'E-save',
+    scene: 'eventDetail',
+    target: 'ev-save',
+    bubble: { content: <>[저장하기]를 눌러야 제출됩니다!</>, placement: 'top' },
+    advance: { kind: 'click' },
+    onComplete: [{ type: 'ADD_SUBMISSION', id: ME_ID }],
+    script: [{ delayMs: 0, toast: { message: '저장되었습니다', type: 'success' } }],
+  },
+  // ── 7. 링크 공유로 제출 모으기 ──
+  {
+    id: 'E-share',
+    scene: 'eventDetail',
+    target: 'ev-share',
+    bubble: {
+      content: <>이제 부원들 차례. 링크 아이콘으로 <strong>일정 링크</strong>를 복사해 보내보세요.</>,
+      placement: 'bottom',
+      align: 'right',
+    },
+    advance: { kind: 'click' },
+    script: [
+      { delayMs: 0, toast: { message: '일정 링크가 복사되었습니다', type: 'success' } },
+      { delayMs: 1200, action: { type: 'ADD_SUBMISSION', id: 'yh' }, toast: { message: '이영희님이 시간을 제출했어요', type: 'info' } },
+      { delayMs: 2100, action: { type: 'ADD_SUBMISSION', id: 'cs' }, toast: { message: '김철수님이 시간을 제출했어요', type: 'info' } },
+      { delayMs: 3000, action: { type: 'ADD_SUBMISSION', id: 'pjm' }, toast: { message: '박지민님이 시간을 제출했어요', type: 'info' } },
+      { delayMs: 3900, action: { type: 'ADD_SUBMISSION', id: 'sj' }, toast: { message: '전원 제출 완료! 추천 시간이 나왔어요 ✨', type: 'success' } },
+    ],
+  },
+  // ── 8. 완료 처리 ──
+  {
+    id: 'E-check',
+    scene: 'eventDetail',
+    target: 'ev-complete',
+    bubble: {
+      content: <>모임을 마쳤다면 초록 체크를 눌러 <strong>완료 처리</strong>해보세요.</>,
+      placement: 'bottom',
+      align: 'right',
+    },
+    advance: { kind: 'state', when: (s) => s.eventCompleted },
+  },
+  // ── 9. 기록 작성 ──
+  {
+    id: 'R-form',
+    scene: 'recordForm',
+    target: 'rec-form',
+    overlay: false,
+    bubble: {
+      content: <>완료하면 기록 폼이 열려요. 활동 제목과 설명을 적어보세요.</>,
+      placement: 'top',
+    },
+    advance: {
+      kind: 'next',
+      enabledWhen: (s) => s.record.title.trim().length > 0 && s.record.desc.trim().length > 0,
+    },
+  },
+  {
+    id: 'R-save',
+    scene: 'recordForm',
+    target: 'rec-save',
+    overlay: false,
+    bubble: { content: <>[기록하기]를 누르면 일정 완료가 확정돼요.</>, placement: 'top' },
+    advance: {
+      kind: 'click',
+      enabledWhen: (s) => s.record.title.trim().length > 0 && s.record.desc.trim().length > 0,
+    },
+    onComplete: [{ type: 'SAVE_RECORD' }],
+    script: [{ delayMs: 0, toast: { message: '활동이 기록되었습니다', type: 'success' } }],
+  },
+  {
+    id: 'R-card',
+    scene: 'records',
+    target: 'rec-card',
+    bubble: {
+      content: <>방금 쓴 기록이 기록 탭에 카드로 남았어요. 동아리의 활동 역사이자 회계 메모가 됩니다.</>,
+      placement: 'bottom',
+    },
+    advance: { kind: 'next' },
+  },
+  // ── 10. 기능 투어 (실제 화면 그대로, 오버레이 없음) ──
+  {
+    id: 'X-icons',
+    scene: 'eventDetail',
+    target: 'ev-icons',
+    overlay: false,
+    bubble: {
+      content: <>일정 화면 오른쪽 위 아이콘들이에요. 완료·링크·공유, 그리고 빨간 휴지통은 일정 삭제(만든 사람만).</>,
+      placement: 'bottom',
+      align: 'right',
+    },
+    advance: { kind: 'next' },
+  },
+  {
+    id: 'X-panel',
+    scene: 'clubHome',
+    target: 'ops-response',
+    overlay: false,
+    bubble: {
+      content: <>운영 패널의 <strong>응답 현황</strong> — 누가 아직 시간을 제출 안 했는지 보이고, 이름을 복사해 독촉할 수 있어요. 임원진에게만 보입니다.</>,
+      placement: 'top',
+    },
+    advance: { kind: 'next' },
+  },
+  {
+    id: 'X-gear',
+    scene: 'clubHome',
+    target: 'club-gear',
+    overlay: false,
+    bubble: {
+      content: <>마지막! 톱니(설정)에는 동아리 이름 변경·초대 코드 재생성·회장 위임·동아리 삭제가 모여 있어요. 이제 진짜 동아리를 만들러 가볼까요?</>,
+      placement: 'bottom',
+      align: 'right',
+    },
+    advance: { kind: 'next' },
+  },
+];

--- a/app/(main)/chinba/guide/tutorial/_components/types.ts
+++ b/app/(main)/chinba/guide/tutorial/_components/types.ts
@@ -1,0 +1,97 @@
+import type { ReactNode } from 'react';
+
+export type SceneId =
+  | 'createClub' // 동아리 만들기 풀페이지
+  | 'clubHome' // 동아리 상세(탭+운영 패널)
+  | 'membersModal' // 동아리 상세 위 멤버 관리 모달
+  | 'groups' // 조 편성 풀페이지
+  | 'eventCreate' // 일정 잡기 풀페이지
+  | 'timetable' // MY 탭 내 시간표
+  | 'eventDetail' // 일정 상세(전체/내 일정 탭)
+  | 'recordForm' // 동아리 상세(기록 탭) 위 기록 폼 모달
+  | 'records'; // 동아리 상세 기록 탭
+
+export type MemberRole = '회장' | '부회장' | '운영진' | '회원';
+
+export interface TutorialMember {
+  id: string;
+  name: string;
+  role: MemberRole;
+}
+
+/** 튜토리얼 전체 가짜 데이터 — API 없이 useReducer로만 굴린다 */
+export interface TutorialState {
+  clubName: string;
+  category: string | null;
+  members: TutorialMember[];
+  groupSetName: string; // 그룹세트 이름 (예: 친바)
+  groupsCreated: number; // 만든 조 수 (0~2)
+  group1Ids: string[]; // 1조 멤버 (첫 번째 = 조장)
+  group2Ids: string[]; // 2조 멤버 (첫 번째 = 조장)
+  groupSaved: boolean;
+  studySetCreated: boolean; // 두 번째 그룹세트(스터디) 생성 연출 완료
+  eventTitle: string;
+  eventDates: number[]; // 달력 day 숫자
+  submissions: string[]; // 시간을 제출한 memberId
+  eventCompleted: boolean;
+  record: { title: string; desc: string; amount: string };
+  savedRecord: boolean;
+  timetableLoaded: boolean; // 부원: AI 분석 완료
+  importedTimetable: boolean; // 부원: 내 시간표 불러오기 완료
+  paintedCells: string[]; // 부원: 직접 칠한 셀 key ("row-col")
+}
+
+export type TutorialAction =
+  | { type: 'SET_CLUB_NAME'; value: string }
+  | { type: 'SET_CATEGORY'; value: string }
+  | { type: 'ADD_MEMBER'; member: TutorialMember }
+  | { type: 'SET_ROLE'; id: string; role: MemberRole }
+  | { type: 'SET_GROUP_SET_NAME'; value: string }
+  | { type: 'CREATE_GROUP' }
+  | { type: 'ASSIGN_MEMBER'; id: string; group: 1 | 2 }
+  | { type: 'SAVE_GROUPS' }
+  | { type: 'CREATE_STUDY_SET' }
+  | { type: 'SET_EVENT_TITLE'; value: string }
+  | { type: 'TOGGLE_DATE'; day: number }
+  | { type: 'ADD_SUBMISSION'; id: string }
+  | { type: 'COMPLETE_EVENT' }
+  | { type: 'SET_RECORD'; patch: Partial<TutorialState['record']> }
+  | { type: 'SAVE_RECORD' }
+  | { type: 'LOAD_TIMETABLE' }
+  | { type: 'IMPORT_TIMETABLE' }
+  | { type: 'TOGGLE_CELL'; key: string }
+  | { type: 'RESET' };
+
+/** 스텝 진행 방식 */
+export type Advance =
+  | { kind: 'click'; enabledWhen?: (s: TutorialState) => boolean } // 대상 클릭으로 완료
+  | { kind: 'next'; enabledWhen?: (s: TutorialState) => boolean } // 말풍선 [다음] 버튼으로 완료
+  | { kind: 'auto' } // onEnter script가 끝나면 자동 완료
+  | { kind: 'state'; when: (s: TutorialState) => boolean }; // 상태 조건 충족 시 자동 완료
+
+/** 연출 항목 — 스텝 진입(또는 완료) 후 delayMs 시점에 실행 */
+export interface ScriptItem {
+  delayMs: number; // 스크립트 시작 기준 절대 지연
+  action?: TutorialAction;
+  toast?: { message: string; type: 'success' | 'info' };
+}
+
+export interface TutorialStep {
+  id: string;
+  scene: SceneId;
+  /** TutorialTarget id — null이면 스포트라이트 대상 없음(모달 스텝 등) */
+  target: string | null;
+  /** align: 'right'는 화면 오른쪽 끝 대상용 — 말풍선 오른쪽 모서리를 대상에 맞춘다 */
+  bubble: {
+    content: ReactNode;
+    placement: 'top' | 'bottom' | 'left' | 'right';
+    align?: 'center' | 'right';
+  } | null;
+  advance: Advance;
+  /** false면 어두운 스포트라이트 오버레이를 끈다 (기능 설명 투어처럼 실제 화면을 그대로 보여줄 때) */
+  overlay?: boolean;
+  /** 완료 즉시 디스패치할 액션들 */
+  onComplete?: TutorialAction[];
+  /** 연출 스크립트. advance='auto'면 진입 시, 그 외엔 완료 직후 실행 후 다음 스텝으로 */
+  script?: ScriptItem[];
+}

--- a/app/(main)/chinba/guide/tutorial/_components/useTutorialEngine.ts
+++ b/app/(main)/chinba/guide/tutorial/_components/useTutorialEngine.ts
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
+
+import { initialTutorialState, tutorialReducer } from './state';
+import type { TutorialAction, TutorialState, TutorialStep } from './types';
+
+export interface TutorialToastItem {
+  id: number;
+  message: string;
+  type: 'success' | 'info';
+}
+
+export interface TutorialEngine {
+  state: TutorialState;
+  dispatch: React.Dispatch<TutorialAction>;
+  step: TutorialStep | null;
+  stepIndex: number;
+  totalSteps: number;
+  /** 장면 전환 애니메이션 중 — 스포트라이트·말풍선 표시 지연용 */
+  transitioning: boolean;
+  /** 오버레이(대상 외) 클릭 시 증가 — 말풍선 pulse 재생 트리거 */
+  nudgeKey: number;
+  toasts: TutorialToastItem[];
+  isDone: boolean;
+  completeStep: () => void;
+  nudge: () => void;
+  pushToast: (message: string, type?: 'success' | 'info') => void;
+}
+
+const SCENE_TRANSITION_MS = 350;
+const SCRIPT_TAIL_MS = 700; // 마지막 연출 후 다음 스텝까지 여유
+const STATE_ADVANCE_DELAY_MS = 500; // 조건 충족을 눈으로 확인할 시간
+
+/**
+ * 튜토리얼 스텝 엔진.
+ * - click/next: completeStep() 호출 → onComplete 디스패치 → (script 있으면 연출 후) 다음 스텝
+ * - auto: 스텝 진입 시 script 실행 → 끝나면 자동 진행
+ * - state: 상태 조건 충족을 감지해 자동 진행
+ * 모든 setTimeout은 ref에 모아 스텝 전환·언마운트 시 일괄 해제한다.
+ */
+export function useTutorialEngine(steps: TutorialStep[]): TutorialEngine {
+  const [state, dispatch] = useReducer(tutorialReducer, initialTutorialState);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [transitioning, setTransitioning] = useState(false);
+  const [nudgeKey, setNudgeKey] = useState(0);
+  const [toasts, setToasts] = useState<TutorialToastItem[]>([]);
+
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  // 토스트 제거 타이머는 스텝 전환과 무관하게 살아 있어야 한다 — timersRef와 분리
+  const toastTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const toastIdRef = useRef(0);
+  const completedRef = useRef(false); // 현재 스텝의 완료 처리 중복 방지
+  const prevSceneRef = useRef<string | null>(null);
+
+  const isDone = stepIndex >= steps.length;
+  const step = isDone ? null : steps[stepIndex];
+
+  const schedule = useCallback((fn: () => void, delay: number) => {
+    timersRef.current.push(setTimeout(fn, delay));
+  }, []);
+
+  const clearStepTimers = useCallback(() => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+  }, []);
+
+  // 언마운트 시 모든 타이머 해제
+  useEffect(
+    () => () => {
+      clearStepTimers();
+      toastTimersRef.current.forEach(clearTimeout);
+      toastTimersRef.current = [];
+    },
+    [clearStepTimers],
+  );
+
+  const pushToast = useCallback((message: string, type: 'success' | 'info' = 'info') => {
+    const id = ++toastIdRef.current;
+    setToasts((prev) => [...prev.slice(-3), { id, message, type }]);
+    toastTimersRef.current.push(
+      setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3000),
+    );
+  }, []);
+
+  const advance = useCallback(() => {
+    setStepIndex((i) => i + 1);
+  }, []);
+
+  const runScript = useCallback(
+    (script: NonNullable<TutorialStep['script']>, onEnd?: () => void) => {
+      let maxDelay = 0;
+      for (const item of script) {
+        maxDelay = Math.max(maxDelay, item.delayMs);
+        schedule(() => {
+          if (item.action) dispatch(item.action);
+          if (item.toast) pushToast(item.toast.message, item.toast.type);
+        }, item.delayMs);
+      }
+      if (onEnd) schedule(onEnd, maxDelay + SCRIPT_TAIL_MS);
+    },
+    [schedule, pushToast],
+  );
+
+  const completeStep = useCallback(() => {
+    if (!step || completedRef.current) return;
+    if (step.advance.kind === 'click' || step.advance.kind === 'next') {
+      if (step.advance.enabledWhen && !step.advance.enabledWhen(state)) {
+        setNudgeKey((k) => k + 1);
+        return;
+      }
+    }
+    completedRef.current = true;
+    step.onComplete?.forEach(dispatch);
+    if (step.script && step.advance.kind !== 'auto') {
+      runScript(step.script, advance);
+    } else {
+      advance();
+    }
+  }, [step, state, runScript, advance]);
+
+  const nudge = useCallback(() => setNudgeKey((k) => k + 1), []);
+
+  // 스텝 진입: 타이머 정리, 장면 전환 감지, auto script 시작, 대상 스크롤
+  useEffect(() => {
+    if (!step) return;
+    completedRef.current = false;
+    clearStepTimers();
+
+    const sceneChanged = prevSceneRef.current !== null && prevSceneRef.current !== step.scene;
+    prevSceneRef.current = step.scene;
+    if (sceneChanged) {
+      setTransitioning(true);
+      schedule(() => setTransitioning(false), SCENE_TRANSITION_MS);
+    }
+
+    if (step.target) {
+      const targetId = step.target;
+      schedule(
+        () => {
+          document
+            .getElementById(`tut-${targetId}`)
+            ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        },
+        sceneChanged ? SCENE_TRANSITION_MS + 50 : 80,
+      );
+    }
+
+    if (step.advance.kind === 'auto' && step.script) {
+      // 장면 전환이 끝난 뒤 연출 시작
+      const startDelay = sceneChanged ? SCENE_TRANSITION_MS + 200 : 200;
+      schedule(() => {
+        completedRef.current = true;
+        runScript(step.script!, advance);
+      }, startDelay);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stepIndex]);
+
+  // state 조건 스텝: 조건 충족 감지 → 잠시 후 자동 진행
+  useEffect(() => {
+    if (!step || completedRef.current) return;
+    if (step.advance.kind !== 'state') return;
+    if (!step.advance.when(state)) return;
+    completedRef.current = true;
+    const timer = setTimeout(() => {
+      step.onComplete?.forEach(dispatch);
+      if (step.script) {
+        runScript(step.script, advance);
+      } else {
+        advance();
+      }
+    }, STATE_ADVANCE_DELAY_MS);
+    timersRef.current.push(timer);
+  }, [step, state, runScript, advance]);
+
+  return {
+    state,
+    dispatch,
+    step,
+    stepIndex,
+    totalSteps: steps.length,
+    transitioning,
+    nudgeKey,
+    toasts,
+    isDone,
+    completeStep,
+    nudge,
+    pushToast,
+  };
+}

--- a/app/(main)/chinba/guide/tutorial/page.tsx
+++ b/app/(main)/chinba/guide/tutorial/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+import TutorialApp from './_components/TutorialApp';
+
+export const metadata: Metadata = {
+  title: '타임라인 튜토리얼 | 제로타임',
+  description:
+    '실제 화면과 똑같은 연습 공간에서 클릭하며 배우는 타임라인 튜토리얼. 회장 트랙과 부원 트랙을 제공합니다.',
+};
+
+export default function ChinbaTutorialPage() {
+  return <TutorialApp />;
+}

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -9,7 +9,7 @@ import MobileSidebar from '@/_components/layout/MobileSidebar';
 import SharedHeader from '@/_components/layout/SharedHeader';
 
 const MAIN_PAGES = new Set(['/', '/profile', '/chinba', '/flow']);
-const CHINBA_HEADER_PATHS = new Set(['/chinba', '/chinba/team', '/chinba/my']);
+const CHINBA_HEADER_PATHS = new Set(['/chinba', '/chinba/team', '/chinba/my', '/chinba/guide']);
 const FLOW_HEADER_PATHS = new Set(['/flow', '/flow/career', '/flow/companies', '/flow/profile']);
 
 /**

--- a/app/_components/layout/SidebarContent.test.tsx
+++ b/app/_components/layout/SidebarContent.test.tsx
@@ -6,9 +6,11 @@ import { useUser } from '@/_lib/hooks/useUser';
 
 import SidebarContent from './SidebarContent';
 
+let mockPathname = '/';
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
-  usePathname: () => '/',
+  usePathname: () => mockPathname,
 }));
 
 vi.mock('@/_lib/hooks/useUser', () => ({ useUser: vi.fn() }));
@@ -29,6 +31,7 @@ const renderSidebar = () =>
 describe('SidebarContent 알리미 라벨 (F008)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPathname = '/';
     mockedUseGuestSchool.mockReturnValue(
       asUserHook({ guestSchool: '전북대', setGuestSchool: vi.fn(), isLoading: false }),
     );
@@ -73,5 +76,50 @@ describe('SidebarContent 알리미 라벨 (F008)', () => {
     renderSidebar();
 
     expect(screen.getByText('전북대학교 알리미')).toBeInTheDocument();
+  });
+});
+
+describe('SidebarContent 타임라인 설명서 메뉴', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = '/';
+    mockedUseGuestSchool.mockReturnValue(
+      asUserHook({ guestSchool: '전북대', setGuestSchool: vi.fn(), isLoading: false }),
+    );
+    mockedUseUser.mockReturnValue(
+      asUserHook({ user: null, isLoggedIn: false, isAuthLoaded: true, isLoading: false }),
+    );
+  });
+
+  it('알리미(/)에서는 보이지 않는다', () => {
+    mockPathname = '/';
+    renderSidebar();
+    expect(screen.queryByText('타임라인 설명서')).not.toBeInTheDocument();
+  });
+
+  it('프로필(/profile/)에서는 보이지 않는다', () => {
+    mockPathname = '/profile/';
+    renderSidebar();
+    expect(screen.queryByText('타임라인 설명서')).not.toBeInTheDocument();
+  });
+
+  it('타임라인(/chinba/ — 후행 슬래시)에서는 보인다', () => {
+    mockPathname = '/chinba/';
+    renderSidebar();
+    expect(screen.getByText('타임라인 설명서')).toBeInTheDocument();
+  });
+
+  it('타임라인 하위 경로(/chinba/team/detail/)에서도 보인다', () => {
+    mockPathname = '/chinba/team/detail/';
+    renderSidebar();
+    expect(screen.getByText('타임라인 설명서')).toBeInTheDocument();
+  });
+
+  it('설명서 페이지(/chinba/guide/)에서는 active로 표시된다', () => {
+    mockPathname = '/chinba/guide/';
+    renderSidebar();
+    expect(screen.getByText('타임라인 설명서')).toBeInTheDocument();
+    // '타임라인' 서비스 항목도 startsWith('/chinba')로 active라 "현재" 뱃지는 2개다
+    expect(screen.getAllByText('현재').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/app/_components/layout/SidebarContent.tsx
+++ b/app/_components/layout/SidebarContent.tsx
@@ -13,6 +13,7 @@ import {
   FiMail,
   FiExternalLink,
   FiChevronsLeft,
+  FiBookOpen,
 } from 'react-icons/fi';
 import { SiNaver } from 'react-icons/si';
 
@@ -109,6 +110,13 @@ export default function SidebarContent({
     if (item.matchPath === '/') return pathname === '/';
     return pathname.startsWith(item.matchPath);
   };
+
+  // 타임라인 설명서 — 타임라인(/chinba/*) 안에 있을 때만 노출하는 컨텍스트 메뉴
+  // trailingSlash: true라 pathname에 후행 슬래시가 붙을 수 있어 정규화 후 비교한다
+  const normalizedPath = pathname.replace(/\/$/, '') || '/';
+  const isChinbaSection =
+    normalizedPath === '/chinba' || normalizedPath.startsWith('/chinba/');
+  const isGuideActive = normalizedPath === '/chinba/guide';
 
   const handleServiceClick = (item: ServiceItem) => {
     if (item.isDisabled) {
@@ -297,6 +305,26 @@ export default function SidebarContent({
             <FiExternalLink size={13} className="ml-auto text-gray-300" />
           </a>
         </div>
+
+        {/* 타임라인 설명서 — 타임라인 경로에서만 노출 */}
+        {isChinbaSection && (
+          <button
+            onClick={() => onNavigate('/chinba/guide')}
+            className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
+              isGuideActive
+                ? 'bg-blue-50 text-blue-700'
+                : 'text-gray-500 hover:bg-gray-50 active:bg-gray-100'
+            }`}
+          >
+            <FiBookOpen size={16} />
+            <span className="text-sm font-medium">타임라인 설명서</span>
+            {isGuideActive && (
+              <span className="ml-auto rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-500">
+                현재
+              </span>
+            )}
+          </button>
+        )}
       </div>
 
       {/* Spacer */}


### PR DESCRIPTION
  ## 개요

  타임라인(친바)을 처음 접하는 사용자를 위한 **앱 내 설명서**와 **게임식 인터랙티브 튜토리얼**을 추가합니다.
  기존에는 사이드바의 네이버 블로그 외부 링크("제로타임 앱 사용하기")뿐이라 앱 안에서 기능을 익힐 방법이 없었습니다.

  ## 변경 사항

  ### 1. 타임라인 설명서 페이지 (`/chinba/guide`)
  - 가상의 '전북대 코딩 동아리' 세 인물(홍길동 회장·이영희 부회장·김철수 신입 부원)을 따라가는 줄글 설명서
  - 챕터 7개: ① 임원진 플로우(동아리 개설→조 편성→일정→확정) ② 일반 사용자 플로우(가입→시간표→시간 제출) ③ 운영 도구 ④ 링크와 초대 ⑤ 기록과 랭킹(구현 완료·비노출 안내) ⑥ 알아두면 좋은 기능 ⑦ FAQ
  - 각 버튼·화면은 스크린샷 대신 **실제 컴포넌트의 Tailwind 마크업을 복제한 코드 목업**으로 재현 (화질 열화 없음, 히트맵 hex 색상까지 원본 동일)
  - 목업은 실제 컴포넌트를 import하지 않고 클래스 문자열만 복제 (훅·API 바인딩 배제, 전부 서버 컴포넌트)

  ### 2. 사이드바 메뉴
  - "제로타임 앱 사용하기" 바로 아래에 "타임라인 설명서" 항목 추가
  - **`/chinba/*` 경로에서만 노출** (알리미·프로필에서는 숨김, trailing slash 정규화 처리)
  - `CHINBA_HEADER_PATHS`에 `/chinba/guide` 추가 — 모바일에서 햄버거로 사이드바 접근 확보
  - `SidebarContent.test.tsx`에 경로별 노출/숨김/active 케이스 5개 추가 (usePathname 목을 가변으로 전환)

  ### 3. 인터랙티브 튜토리얼 (`/chinba/guide/tutorial`)
  - 설명서 상단 [타임라인 튜토리얼 들어가기] 버튼으로 진입
  - **실제 앱 창 전체를 복제한 연습 공간**: 왼쪽 사이드바 + 중앙 풀페이지 화면 + 오른쪽 운영 패널
  - **스포트라이트 방식**: 화면을 어둡게(black/40) 덮고 눌러야 할 버튼만 파란 링으로 승격 — 대상 외 클릭 차단, 엉뚱한 곳 클릭 시 말풍선 재생으로 시선 유도
  - 앱의 기존 힌트 말풍선(ClubSwitcher) 스타일 그대로 4방향 배치 지원
  - **통합 트랙 31스텝**: 동아리 만들기(실제 타이핑) → 초대링크 복사 → 가짜 부원 입장 연출 → 멤버 관리 모달에서 부회장 부여 → 그룹세트("친바") 생성 → 1조·2조 편성 → "스터디" 세트로 다중 세트 개념 안내 → 일정 생성 → 시간표 업로드·내 시간 제출(참가자 파트) → 링크 공유로 제출
  모으기(히트맵 실시간 연출) → 완료 처리 → 기록 작성·확인 → 기능 투어(오버레이 해제, 실제 화면 그대로)
  - 모든 데이터는 클라이언트 로컬 가짜 상태(useReducer) — API 호출·로그인 불필요
  - 스텝 엔진: click/next/auto/state 4종 진행 방식 + setTimeout 연출 스크립트(스텝 전환 시 일괄 정리)

  ## 검증

  - [x] `npm run lint` — 변경 파일 오류 0건
  - [x] `npm run test:run` — 358개 전부 통과 (사이드바 신규 케이스 5개 포함)
  - [x] `npm run build` — 정적 export에 `/chinba/guide`, `/chinba/guide/tutorial` 프리렌더 확인
  - [x] Playwright로 튜토리얼 31스텝 전체 실제 클릭 완주 (빈 입력 시 진행 차단, 연출 토스트, 투어 구간 오버레이 해제까지 확인)
  - [x] 데스크톱(1280px)·모바일 뷰포트 렌더 확인
  - [ ] 비주얼 회귀: 사이드바 항목 추가로 `e2e/visual/` chinba 스냅샷 갱신 필요할 수 있음 (`npx playwright test e2e/visual/ --update-snapshots`)